### PR TITLE
Upgrade mlx and outlines dependencies, and add support for llama 3.2 vision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.venv/

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ cd mlx-engine
 ```
 2. Create a virtual environment (optional)
 ```
- python -m venv myenv
- source myenv/bin/activate
+ python -m venv .venv
+ source .venv/bin/activate
 ```
 3. Install the required dependency packages
 ```
-pip install -r requirements.txt
+pip install -U -r requirements.txt
 ```
 
 ### Text Model Demo
@@ -64,10 +64,12 @@ Run the `demo.py` script with an MLX vision model:
 python demo.py --model ~/.cache/lm-studio/models/mlx-community/pixtral-12b-4bit --prompt "<s>[INST]Compare these images[IMG][IMG][/INST]" --images demo-data/chameleon.webp demo-data/toucan.jpeg
 ```
 Currently supported vision models and download links:
+ - Llama-3.2-Vision
+   - [mlx-community/Llama-3.2-11B-Vision-Instruct-4bit](https://model.lmstudio.ai/download/mlx-community/Llama-3.2-11B-Vision-Instruct-4bit)
  - Pixtral
    - [mlx-community/pixtral-12b-4bit](https://model.lmstudio.ai/download/mlx-community/pixtral-12b-4bit) - 7.15 GB
  - Qwen2-VL
    - [mlx-community/Qwen2-VL-2B-4bit](https://model.lmstudio.ai/download/mlx-community/Qwen2-VL-2B-4bit) - 1.26 GB
-   - [mlx-community/Qwen2-VL-7B-4bit](https://model.lmstudio.ai/download/mlx-community/Qwen2-VL-7B-Instruct-4bit) - 4.68 GB
+   - [mlx-community/Qwen2-VL-7B-Instruct-4bit](https://model.lmstudio.ai/download/mlx-community/Qwen2-VL-7B-Instruct-4bit) - 4.68 GB
  - Llava-v1.6
    - [mlx-community/llava-v1.6-mistral-7b-4bit](https://model.lmstudio.ai/download/mlx-community/llava-v1.6-mistral-7b-4bit) - 4.26 GB

--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -1,14 +1,20 @@
-import time
-from typing import Callable, List, Optional, Tuple
+from typing import List, Optional, Any
 
-from mlx_lm.utils import make_kv_caches, RotatingKVCache
+from mlx_lm.models.cache import (
+    RotatingKVCache,
+    make_prompt_cache,
+    trim_prompt_cache,
+    can_trim_prompt_cache,
+)
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
+import sys
 
 
 class CacheWrapper:
     """
-    Wrapper class for the MLX cache to maintain an in-memory cache
+    Wrapper class for the MLX LM cache to maintain an in-memory cache
     """
 
     def __init__(self, model: nn.Module, max_kv_size: int, verbose: bool = False):
@@ -21,177 +27,143 @@ class CacheWrapper:
         """
         # utilize a simple ordered list of tokens processed so far for cache invalidation checking
         self.tokens: Optional[mx.array] = None
-        # will always be a list of RotatingKVCache objects since we pass max_kv_size
-        self.cache: List[RotatingKVCache] = make_kv_caches(model, max_kv_size)
+        self.cache: List[Any] = make_prompt_cache(model, max_kv_size)
         self.model = model
         self.max_kv_size = max_kv_size
         self.verbose = verbose
 
-    def _reset_cache_if_necessary(self, tokens: List[int]) -> bool:
+    @staticmethod
+    def _find_common_prefix(
+        current_tokens: mx.array, prompt_tokens: mx.array, num_tokens_to_exclude: int
+    ) -> int:
         """
-        Resets the cache if the incoming tokens do not match the start of the existing cache.
-        Returns True if the cache was reset, False otherwise.
-
-        This is the most naive implementation of cache invalidation.
-        """
-        # loop through reasons to short-circuit detailed reset checking
-        if self.tokens is None:
-            if self.verbose:
-                print("No cached tokens, no need to reset", flush=True)
-            return False
-
-        # loop through all potential reset reasons
-        y = mx.array(tokens)
-        reset = False
-        if len(y) == 0:
-            reset = True
-            reason = "Passed token list is empty"
-        elif len(self.tokens) > len(y):
-            reset = True
-            reason = "Passed token list is shorter than cached tokens"
-        elif not mx.all(y[: len(self.tokens)] == self.tokens):
-            reset = True
-            reason = (
-                "Beginning sequence of passed token list does not match cached tokens"
-            )
-
-        if reset:
-            if self.verbose:
-                print(f"Resetting cache with reason: {reason}", flush=True)
-            self.cache = make_kv_caches(self.model, self.max_kv_size)
-            self.tokens = None
-        else:
-            if self.verbose:
-                print("Cache is valid with passed tokens", flush=True)
-
-        return reset
-
-    def _determine_tokens_to_process(self, tokens: mx.array) -> mx.array:
-        """
-        Returns an mx.array of the tokens that should be processed given the state of the cache and
-        an array of tokens.
-
-        Throws if there isn't a contiugous sequence of tokens that can be naively processed in order
-        """
-        # no tokens yet, so should process all
-        if self.tokens is None:
-            return tokens
-        # if y is shorter than self.tokens, throw an error
-        elif len(tokens) < len(self.tokens):
-            raise RuntimeError(
-                "Passed tokens list cannot be shorter than cached tokens"
-            )
-        # if start of y is not the same as self.tokens, throw an error
-        elif not mx.all(tokens[: len(self.tokens)] == self.tokens):
-            raise RuntimeError(
-                "Passed tokens list does not start with previously cached tokens, cannot safely "
-                "process new tokens continguously into cache"
-            )
-        # figure out which tokens are new
-        else:
-            new_tokens = tokens[len(self.tokens) :]
-            return new_tokens
-
-    # adapted from https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/cache_prompt.py#L121-L137
-    def _process_tokens_into_cache(
-        self,
-        tokens_to_process: mx.array,
-        progress_callback: Optional[Callable[[float], None]],
-        step_size: int,
-    ) -> None:
-        """
-        Process tokens and update the cache.
+        Determine the common prefix length between the current tokens and the prompt tokens.
 
         Args:
-            tokens_to_process (mx.array): Tokens to be processed and added to the cache.
-            progress_callback (function): Callback function to report progress.
-            step_size (int): Number of tokens to process in each step.
-        """
-        # signal that processing has started
-        if progress_callback:
-            progress_callback(0)
+            current_tokens (mx.array): The cached tokens (self.tokens).
+            prompt_tokens (mx.array): The prompt tokens.
+            num_tokens_to_exclude (int): The minimum length of the remaining prompt tokens array.
 
-        processed: int = 0
-        start = time.time()
-        while processed < len(tokens_to_process):
-            chunk: mx.array = tokens_to_process[processed : processed + step_size]
-            self.model(chunk[None], cache=self.cache)
-            mx.eval([c.state for c in self.cache])
-            self.tokens: mx.array = (
-                mx.concatenate([self.tokens, chunk])
-                if self.tokens is not None
-                else chunk
-            )
-            processed += chunk.size
-            speed = processed / (time.time() - start)
-            percentage: float = (processed / len(tokens_to_process)) * 100
-            if self.verbose:
-                print(
-                    f"\rProcessed {processed:d} tokens ({speed:.2f} tok/s) - {percentage:.2f}% complete",
-                    flush=True,
-                )
-            if progress_callback:
-                progress_callback(percentage)
+        Returns:
+            int: The length of the common prefix.
+        """
+        prompt_tokens_np = np.array(prompt_tokens)
+        current_tokens_np = np.array(current_tokens)
+        # Find the minimum length between the two arrays
+        min_length = min(len(current_tokens_np), len(prompt_tokens_np))
+
+        # Compare elements up to the minimum length
+        mask = prompt_tokens_np[:min_length] == current_tokens_np[:min_length]
+
+        # Find the index where the first mismatch occurs
+        if np.any(mask == False):
+            common_length = int(np.argmax(mask == False))
+        else:
+            common_length = int(min_length)
+
+        # Ensure that the prompt is at least num_tokens_to_exclude long
+        uncached_prompt_tokens_length = len(prompt_tokens_np[common_length:])
+        length_adjustment = max(
+            0, num_tokens_to_exclude - uncached_prompt_tokens_length
+        )
+        common_length = max(common_length - length_adjustment, 0)
+        return common_length
+
+    def _get_unprocessed_tokens(
+        self, prompt_tokens: mx.array, num_tokens_to_exclude: int
+    ):
+        """
+        Get the unprocessed tokens from the prompt.
+
+        Args:
+            prompt_tokens (mx.array): The prompt tokens.
+            num_tokens_to_exclude (int): The number of tokens that should not be added to the cache.
+
+        Returns:
+            mx.array: The unprocessed tokens.
+        """
+        if self.tokens is None:
+            self.tokens = prompt_tokens
+            return self.tokens
+
+        if not can_trim_prompt_cache(self.cache):
+            self.cache = make_prompt_cache(self.model, self.max_kv_size)
+            self.tokens = prompt_tokens
+            return self.tokens
+
+        # Find common KV between the last generation and the current prompt
+        common_prefix = self._find_common_prefix(
+            self.tokens, prompt_tokens, num_tokens_to_exclude
+        )
+
+        # Trim the cache history from its end so that it forgets tokens that are not in this prompt
+        num_tokens_to_trim = self.cache[0].offset - common_prefix
+        tokens_trimmed = trim_prompt_cache(self.cache, num_tokens_to_trim)
+        if tokens_trimmed != num_tokens_to_trim:
+            # If we trimmed fewer tokens than expected, the cache is invalid
+            self.cache = make_prompt_cache(self.model, self.max_kv_size)
+            self.tokens = prompt_tokens
+            return self.tokens
+
+        # Keep track of the prompt tokens
+        self.tokens = prompt_tokens
+
+        if self.verbose:
+            print(f"Common prefix length: {common_prefix}", file=sys.stderr)
+            print(f"Trimmed tokens: {num_tokens_to_trim}", file=sys.stderr)
+
+        # All of the common tokens are now in the cache, so we can return the remaining tokens that still need to be processed
+        return prompt_tokens[common_prefix:]
 
     def update_cache(
         self,
         prompt_tokens: mx.array,
-        num_tokens_to_exclude,
-        progress_callback=None,
-        step_size: int = 512,
-    ) -> Tuple[List[Tuple[mx.array, mx.array]], mx.array]:
+        prompt_progress_callback,
+        num_tokens_to_exclude: int = 1,
+    ) -> mx.array:
         """
-        Update the cache by filling it with the prompt tokens in a way that:
-         1. Ensures it is valid for the prompt tokens
-         2. Can be told to exclude a certain number of tokens from the end of the prompt, so that those tokens can
-            be processed outside of the cache route (e.g. for repetition penalty)
+        Set up the KV cache for the next generation.
+        Re-use as much of the KV cache from the previous generation as possible.
 
         Args:
-            prompt_tokens (mx.array): Tokens to sync the cache with.
-            num_tokens_to_exclude (int): Number of tokens to exclude from caching.
-            progress_callback (function, optional): Function to report progress.
-            step_size (int, optional): Batch size for processing. Defaults to 512.
+            prompt_tokens (mx.array): The prompt tokens.
+            num_tokens_to_exclude (int): The number of tokens that should not be added to the cache.
 
         Returns:
-            tuple: Cache history object and uncached tokens.
+            mx.array: The prompt tokens to be used for the next generation.
         """
-        if len(prompt_tokens) == 0:
-            return prompt_tokens
+        if prompt_progress_callback is None:
+            prompt_progress_callback = lambda x: None
 
-        # first, reset the cache if the full prompt tokens do not match the start of the cache
-        # we need to see the whole prompt so that if the cache is not valid for it, we can reset it
-        self._reset_cache_if_necessary(prompt_tokens)
+        num_tokens_to_exclude = max(num_tokens_to_exclude, 1)
+        prompt_tokens = self._get_unprocessed_tokens(
+            prompt_tokens, num_tokens_to_exclude
+        )
 
-        tokens_to_cache = mx.array(prompt_tokens[:-num_tokens_to_exclude])
-        uncached_tokens = mx.array(prompt_tokens[-num_tokens_to_exclude:])
+        # Prefill the cache with the non-excluded prompt tokens
+        prompt_progress_callback(0)
+        prefill_tokens = prompt_tokens[:-num_tokens_to_exclude]
+        num_total_prefill_tokens = len(prefill_tokens)
+        processed: int = 0
+        chunk_default_size: int = 512
+        while prefill_tokens.size > 0:
+            chunk_size = min(chunk_default_size, prefill_tokens.size)
+            chunk = prefill_tokens[:chunk_size]
 
-        # second, reset the cache if the tokens to cache do not match the start of the cache
-        # we need to do this so that we can safely process the uncached tokens
-        self._reset_cache_if_necessary(tokens_to_cache)
+            self.model(chunk[None], cache=self.cache)
+            mx.eval([c.state for c in self.cache])
 
-        # figure out which tokens are not already in cache, and add them
-        tokens_to_process = self._determine_tokens_to_process(tokens_to_cache)
-        self._process_tokens_into_cache(tokens_to_process, progress_callback, step_size)
+            prefill_tokens = prefill_tokens[chunk_size:]
+            processed += chunk_size
+            prompt_progress_callback((processed / num_total_prefill_tokens) * 100)
+            mx.metal.clear_cache()
 
-        return self._to_cache_history(), uncached_tokens
+        # Return the tokens that must still be proccessed outside of the cache
+        non_prefill_tokens = prompt_tokens[-num_tokens_to_exclude:]
+        return non_prefill_tokens
 
-    # adapted from https://github.com/ml-explore/mlx-examples/blob/6c2369e4b97f49fb5906ec46033497b39931b25d/llms/mlx_lm/cache_prompt.py#L140-L143
-    # and https://github.com/ml-explore/mlx-examples/blob/6c2369e4b97f49fb5906ec46033497b39931b25d/llms/mlx_lm/generate.py#L139-L149
-    def _to_cache_history(self) -> List[Tuple[mx.array, mx.array]]:
+    def record_generated_token(self, token):
         """
-        Convert the current cache to a cache history format.
-
-        Returns:
-            List[Tuple[mx.array, mx.array]]: A list of tuples containing keys and values from the cache.
-            Returns None if there are no tokens in the cache.
+        Add the generated token to the token list, so that we can map the token to the KV cache.
         """
-        if self.tokens is None:
-            return None
-
-        cache_history = []
-        for c in self.cache:
-            keys = c.state[0][..., : c.offset, :]
-            values = c.state[1][..., : c.offset, :]
-            cache_history.append((keys, values))
-
-        return cache_history
+        self.tokens = mx.concat([self.tokens, mx.array([token])])

--- a/mlx_engine/outlines_logits_processor.py
+++ b/mlx_engine/outlines_logits_processor.py
@@ -15,7 +15,6 @@ class OutlinesLogitsProcessor:
         self.logits_processor = JSONLogitsProcessor(
             json_schema,
             TransformerTokenizer(model_kit.tokenizer._tokenizer),
-            whitespace_pattern="",
         )
 
     def __call__(self, tokens: mx.array, logits: mx.array):

--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -39,6 +39,7 @@ class VisionModelKit(ModelKit):
         self.tokenizer = mlx_vlm.tokenizer_utils.load_tokenizer(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer
         self.cache_wrapper = None
+        mx.metal.clear_cache()
 
     def _reset(self):
         # it's a shortcoming that the only way to reset the model is to reload it
@@ -72,6 +73,9 @@ class VisionModelKit(ModelKit):
 
         generate_step_input = self.model.input_ids[0]
         return generate_step_input
+
+    def record_generated_token(self, token: int) -> None:
+        pass
 
     @property
     def language_model(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-mlx==0.18.0
-mlx-lm==0.19.0
-mlx-vlm @ https://github.com/Blaizzy/mlx-vlm/archive/51b0e7c84e8925dc690bb6da8517288be2acc5c0.zip
+mlx==0.19.1
+mlx-lm==0.19.2
+mlx-vlm @ https://github.com/Blaizzy/mlx-vlm/archive/f0812b5c7d6ec2b83512bfda176d9ddee59ed26a.zip
 sentencepiece==0.2.0
-outlines==0.0.46
-torch==2.4.0
+outlines==0.1.1
+torch==2.5.0
+transformers==4.46.0


### PR DESCRIPTION
## Summary of changes

### MLX VLM upgrade
`mlx_vlm` was upgraded to its latest commit. This brings in support for llama 3.2 vision (aka `mllama`). `vision_model_kit` and `vision_model_wrapper` was updated to bring in the latest changes needed to use `mllama` with `mlx_vlm`. Note that the current `mlx_vlm`'s implementation of mllama does not support text generation without accompanying images.

Also, the ballooning memory usage upon continued use of a vision model without unloading should now be fixed, because we are now calling `mx.metal.clear_cache()`

### MLX LM upgrade
`mlx_lm` refactored the cache history API, so `cache_wrapper` was refactored accordingly.
This upgrade also bring in support for more model architectures.

This upgrade also brought in a refactor of the BPE detokenizer, which fixes a bug where our structured output generator did not conform to a valid json.

### Outlines upgrade
The requirements.txt has been upgraded to start using the outlines rust backend. This rust backend was already being shipped as part of the LM Studio app, but users of `demo.py` here should now see massive improvements when compiling the outlines finite-state-machine for the provided json schema.

### Transformers upgrade
Update transformers to the latest. Users should have fewer issues quantizing their own models now.

### README edits
The recommended `venv` dir was changed to `.venv`, and that dir is now part of the `.gitignore`
Add a lmstudio deeplink to llama 3.2 vision