### PR TITLE
Bump mlx version to >= 0.19.3, < 0.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mlx>=0.19.3
+mlx>=0.19.3,<0.20.0
 mlx-lm==0.19.2
 mlx-vlm @ https://github.com/Blaizzy/mlx-vlm/archive/f0812b5c7d6ec2b83512bfda176d9ddee59ed26a.zip
 sentencepiece==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mlx==0.19.2
+mlx>=0.19.3
 mlx-lm==0.19.2
 mlx-vlm @ https://github.com/Blaizzy/mlx-vlm/archive/f0812b5c7d6ec2b83512bfda176d9ddee59ed26a.zip
 sentencepiece==0.2.0


### PR DESCRIPTION
Fixes `pip install` following https://github.com/lmstudio-ai/mlx-engine?tab=readme-ov-file#standalone-demo breakage:
```
ERROR: Could not find a version that satisfies the requirement mlx==0.19.2 (from versions: 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.9, 0.0.10, 0.0.11, 0.1.0, 0.2.0, 0.3.0, 0.4.0, 0.5.1, 0.6.0, 0.7.0, 0.8.1, 0.9.1, 0.10.0, 0.11.1, 0.12.2, 0.13.0, 0.13.1, 0.14.0, 0.14.1, 0.15.0, 0.15.1, 0.15.2, 0.16.0, 0.16.1, 0.16.2, 0.16.3, 0.17.1, 0.17.2, 0.17.3, 0.18.0, 0.18.1, 0.19.0, 0.19.3)
```
It appears that `mlx` hotfix versions may be getting removed from `PyPI`, so switching from and explicit `==` version pin to a range to hopefully increase robustness. `<0.20.0` because `0.20.0` could theoretically include breaking changes.