### PR TITLE
Set the random seed for all ML libraries

### DIFF
--- a/mlx_engine/utils/set_seed.py
+++ b/mlx_engine/utils/set_seed.py
@@ -1,0 +1,28 @@
+import numpy as np
+import torch
+import mlx.core as mx
+import time
+from typing import Optional
+import random
+
+
+def set_seed(seed: Optional[int]) -> None:
+    """
+    Set the seed for all random number generators used in mlx-engine.
+
+    Args:
+        seed: The seed to use. If None, the seed will be set to the current nanosecond timestamp.
+    """
+    if seed is None:
+        # Get nanosecond timestamp and use it as seed
+        seed = int(time.time_ns()) & (2**32 - 1)  # Ensure seed fits in 32 bits
+
+    # For MLX and MLX_LM
+    mx.random.seed(seed)
+
+    # MLX_VLM depends on numpy and torch
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+    # Just in case
+    random.seed(seed)


### PR DESCRIPTION
Summary:
- `mlx_vlm` uses `numpy` and `torch`, so start setting the seed for those libraries as well.
- Set the seed before the prompt processing instead of after.
- Create new directory `utils` which contains the `set_seed` method
- Set the default seed with a timestamp, instead of from another PRNG

This improvement came about by investigating https://github.com/lmstudio-ai/mlx-engine/issues/27 , but this seed fix is not the root-cause of the regression observed in #27 