### PR TITLE
Add token id to TokenLogprob

### DIFF
--- a/mlx_engine/utils/top_logprobs.py
+++ b/mlx_engine/utils/top_logprobs.py
@@ -4,6 +4,7 @@ import mlx.core as mx
 
 
 class TokenLogprob(NamedTuple):
+    id: int
     text: str
     logprob: float
 
@@ -11,7 +12,7 @@ class TokenLogprob(NamedTuple):
 def summarize_top_logprobs(
     tokenizer, logprobs: mx.array, top_logprobs: int
 ) -> list[TokenLogprob]:
-    # find the sorted indicies (in descending order) of the logprobs
+    # find the sorted indices (in descending order) of the logprobs
     sorted_indices = mx.argsort(-logprobs)
 
     # sort the logprobs in descending order
@@ -23,4 +24,9 @@ def summarize_top_logprobs(
 
     # decode the top indices
     text_list = [tokenizer.decode(index) for index in top_indices.tolist()]
-    return [TokenLogprob(x, y) for x, y in list(zip(text_list, top_logprobs.tolist()))]
+    
+    # return list of TokenLogprob with id (int), text (str), and logprob (float)
+    return [
+        TokenLogprob(int(idx), txt, float(prob)) 
+        for idx, txt, prob in zip(top_indices.tolist(), text_list, top_logprobs.tolist())
+    ]


### PR DESCRIPTION
Convenience addition so that clients don't have to re-tokenize later if they want the id of the token string