### PR TITLE
Return token logprobs for each token in generation result, instead of just token id

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -81,7 +81,7 @@ def create_generator(
     Yields:
         GenerationResult: Named tuple containing:
             - text: Generated text segment
-            - tokens: List of generated tokens, each with ID, text, and logprob
+            - tokens: List of generated tokens, as TokenLogprob named tuples
             - top_logprobs: Token probability information if requested
             - stop_condition: Information about why generation stopped, if applicable
 

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -115,7 +115,7 @@ def create_generator(
     detokenizer = model_kit.detokenizer
     detokenizer.reset()
     # keep track of tokens buffered by detokenizer to yield accurate generation results
-    token_buffer: List[int, str, float] = []
+    token_buffer: List[TokenLogprob] = []
     top_logprobs_buffer: List[List[TokenLogprob]] = []
 
     stop_sequences = [

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterator, List, NamedTuple, Optional
+from typing import Callable, Iterator, List, NamedTuple, Optional, Tuple
 import json
 from pathlib import Path
 
@@ -17,7 +17,7 @@ MAX_TOP_LOGPROBS = 10
 
 class GenerationResult(NamedTuple):
     text: str
-    tokens: List[int]
+    tokens: List[Tuple[int, str]]  # Each tuple contains (token_id, string token_piece)
     top_logprobs: List[List[TokenLogprob]]
     stop_condition: Optional[GenerationStopCondition]
 
@@ -81,7 +81,7 @@ def create_generator(
     Yields:
         GenerationResult: Named tuple containing:
             - text: Generated text segment
-            - tokens: List of generated token IDs
+            - tokens: List of generated token IDs and their corresponding string token pieces
             - top_logprobs: Token probability information if requested
             - stop_condition: Information about why generation stopped, if applicable
 
@@ -115,7 +115,7 @@ def create_generator(
     detokenizer = model_kit.detokenizer
     detokenizer.reset()
     # keep track of tokens buffered by detokenizer to yield accurate generation results
-    token_buffer: List[int] = []
+    token_buffer: List[int, str] = []
     top_logprobs_buffer: List[List[TokenLogprob]] = []
 
     stop_sequences = [
@@ -132,7 +132,7 @@ def create_generator(
     ):
         model_kit.record_generated_token(token)
         detokenizer.add_token(token)
-        token_buffer.append(token)
+        token_buffer.append([token, tokenizer.decode(token)])
         if top_logprobs:
             top_logprobs_buffer.append(
                 summarize_top_logprobs(tokenizer, logprobs, top_logprobs)

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -81,7 +81,7 @@ def create_generator(
     Yields:
         GenerationResult: Named tuple containing:
             - text: Generated text segment
-            - tokens: List of generated token IDs and their corresponding string token pieces
+            - tokens: List of generated tokens, each with ID, text, and logprob
             - top_logprobs: Token probability information if requested
             - stop_condition: Information about why generation stopped, if applicable
 


### PR DESCRIPTION
This allows clients to glean string piece information about what each token is, which is useful for interpreting logprobs (especially when the token id is not in top_logprobs) without having to decode each token themselves (which they don't have direct access to doing atm)

For example, instead of just seeing:
```
GenerationResult(
    text='The',
    tokens=[
        791,
    ],
    top_logprobs=[
        [
            TokenLogprob(id=791, text='The', logprob=-0.171875),
            TokenLogprob(id=89342, text='Chess', logprob=-2.28125),
            TokenLogprob(id=644, text='In', logprob=-3.0625),
            TokenLogprob(id=25242, text='Players', logprob=-4.703125),
            TokenLogprob(id=11874, text='Two', logprob=-5.03125)
        ]
    ],
    stop_condition=None
)
```
Where tokens is simply id's, clients will get:
```
GenerationResult(
    text='The',
    tokens=[
        TokenLogprob(id=791, text='The', logprob=-0.171875),
    ],
    top_logprobs=[
        [
            TokenLogprob(id=791, text='The', logprob=-0.171875),
            TokenLogprob(id=89342, text='Chess', logprob=-2.28125),
            TokenLogprob(id=644, text='In', logprob=-3.0625),
            TokenLogprob(id=25242, text='Players', logprob=-4.703125),
            TokenLogprob(id=11874, text='Two', logprob=-5.03125)
        ]
    ],
    stop_condition=None
)
```
This means they don't have to consult top logprobs get the logprobs of the tokens generated, and they get intuitive understanding of the string piece for the token