### PR TITLE
Yield on EOS token, with or without text

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -304,8 +304,8 @@ def create_generator(
             ):
                 continue
 
-        # Standard yield - only yield when a non-empty text segment is available
-        if text:
+        # Standard yield - yield when a non-empty text segment is available or eos token is hit
+        if text or token == tokenizer.eos_token_id:
             # populate stop_condition if we hit an eos token
             stop_condition = None
             if token == tokenizer.eos_token_id:


### PR DESCRIPTION
Properly provides a stop condition to the client even if the only token is the EOS token. In this case, there will be no text, since the eos token is not added to the detokenizer by `stream_generate`. This was behavior prior to update to `stream_generate`