### PR TITLE
Add tests for VLM inferencing without images attached

### DIFF
--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -14,12 +14,13 @@ class TestVisionModels(unittest.TestCase):
         cls.toucan_path = Path("demo-data/toucan.jpeg")
         cls.model_path_prefix = Path("~/.cache/lm-studio/models").expanduser().resolve()
         cls.description_prompt = "Describe what you see in great detail"
+        cls.text_only_prompt = "What is a toucan?"
 
         # Read and encode the test image
         with open(cls.toucan_path, "rb") as image_file:
             cls.image_b64 = base64.b64encode(image_file.read()).decode("utf-8")
 
-    def model_helper(self, model_name: str, prompt: str):
+    def model_helper(self, model_name: str, prompt: str, text_only=False):
         """Helper method to test a single vision model"""
         print(f"Testing model {model_name}")
 
@@ -55,7 +56,7 @@ class TestVisionModels(unittest.TestCase):
         for result in create_generator(
             model_kit=model_kit,
             prompt_tokens=prompt_tokens,
-            images_b64=[self.image_b64],
+            images_b64=([self.image_b64] if not text_only else None),
             seed=0,
             max_tokens=20,
             temp=0.0,
@@ -86,41 +87,104 @@ class TestVisionModels(unittest.TestCase):
         prompt = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{self.description_prompt}<|image|><|eot_id|><|start_header_id|>assistant<|end_header_id|>"
         self.model_helper("mlx-community/Llama-3.2-11B-Vision-Instruct-4bit", prompt)
 
+    def test_llama_vision_instruct_text_only(self):
+        """Test Llama 3.2 11B Vision Instruct model with only text"""
+        prompt = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{self.text_only_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
+        try:
+            self.model_helper(
+                "mlx-community/Llama-3.2-11B-Vision-Instruct-4bit",
+                prompt,
+                text_only=True,
+            )
+        except ValueError as e:
+            self.assertIn(
+                "Using this model without any images attached is not supported yet.",
+                str(e),
+            )
+
     def test_pixtral(self):
         """Test Pixtral 12B model"""
         prompt = f"<s>[INST]{self.description_prompt}[IMG][/INST]"
         self.model_helper("mlx-community/pixtral-12b-4bit", prompt)
+
+    def test_pixtral_text_only(self):
+        """Test Pixtral 12B model with only text"""
+        prompt = f"<s>[INST]{self.text_only_prompt}[/INST]"
+        self.model_helper("mlx-community/pixtral-12b-4bit", prompt, text_only=True)
 
     def test_qwen2(self):
         """Test Qwen2 VL 7B Instruct model"""
         prompt = f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n<image> {self.description_prompt}<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>assistant\n"
         self.model_helper("mlx-community/Qwen2-VL-7B-Instruct-4bit", prompt)
 
+    def test_qwen2_text_only(self):
+        """Test Qwen2 VL 7B Instruct model with only text"""
+        prompt = f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n{self.text_only_prompt}<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>assistant\n"
+        self.model_helper(
+            "mlx-community/Qwen2-VL-7B-Instruct-4bit", prompt, text_only=True
+        )
+
     def test_florence(self):
         """Test Florence 2 Large model"""
         prompt = self.description_prompt
         self.model_helper("mlx-community/Florence-2-base-ft-4bit", prompt)
+
+    def test_florence_text_only(self):
+        """Test Florence 2 Large model with only text"""
+        prompt = self.text_only_prompt
+        try:
+            self.model_helper(
+                "mlx-community/Florence-2-base-ft-4bit", prompt, text_only=True
+            )
+        except ValueError as e:
+            self.assertIn(
+                "Using this model without any images attached is not supported yet.",
+                str(e),
+            )
 
     def test_molmo(self):
         """Test Molmo 7B model"""
         prompt = self.description_prompt
         self.model_helper("mlx-community/Molmo-7B-D-0924-4bit", prompt)
 
+    def test_molmo_text_only(self):
+        """Test Molmo 7B model with only text"""
+        prompt = self.text_only_prompt
+        self.model_helper("mlx-community/Molmo-7B-D-0924-4bit", prompt, text_only=True)
+
     def test_llava(self):
         """Test LLaVA v1.6 Mistral 7B model"""
         prompt = f"[INST] <image>\n{self.description_prompt} [/INST]"
         self.model_helper("mlx-community/llava-v1.6-mistral-7b-4bit", prompt)
 
+    def test_llava_text_only(self):
+        """Test LLaVA v1.6 Mistral 7B model with only text"""
+        prompt = f"[INST] {self.text_only_prompt} [/INST]"
+        self.model_helper(
+            "mlx-community/llava-v1.6-mistral-7b-4bit", prompt, text_only=True
+        )
+
     def test_bunny_llama(self):
         """Test Bunny Llama 3 8B V model"""
-        prompt = f"<image> {self.description_prompt}"
         prompt = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n<image>\n{self.description_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
         self.model_helper("mlx-community/Bunny-Llama-3-8B-V-4bit", prompt)
+
+    def test_bunny_llama_text_only(self):
+        """Test Bunny Llama 3 8B V model with only text"""
+        prompt = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{self.text_only_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
+        self.model_helper(
+            "mlx-community/Bunny-Llama-3-8B-V-4bit", prompt, text_only=True
+        )
 
     def test_nano_llava(self):
         """Test Nano LLaVA 1.5 4B model"""
         prompt = f"<|im_start|>system\nAnswer the prompt.<|im_end|><|im_start|>user\n<image>\n{self.description_prompt}<|im_end|><|im_start|>assistant\n\n"
         self.model_helper("mlx-community/nanoLLaVA-1.5-4bit", prompt)
+
+    def test_nano_llava_text_only(self):
+        """Test Nano LLaVA 1.5 4B model with only text"""
+        prompt = f"<|im_start|>system\nAnswer the prompt.<|im_end|><|im_start|>user\n{self.text_only_prompt}<|im_end|><|im_start|>assistant\n\n"
+        self.model_helper("mlx-community/nanoLLaVA-1.5-4bit", prompt, text_only=True)
 
 
 """
@@ -148,13 +212,21 @@ if __name__ == "__main__":
     # List of all test methods
     test_methods = [
         "test_llama_vision_instruct",
+        "test_llama_vision_instruct_text_only",
         "test_pixtral",
+        "test_pixtral_text_only",
         "test_qwen2",
+        "test_qwen2_text_only",
         "test_florence",
+        "test_florence_text_only",
         "test_molmo",
+        "test_molmo_text_only",
         "test_llava",
+        "test_llava_text_only",
         "test_bunny_llama",
+        "test_bunny_llama_text_only",
         "test_nano_llava",
+        "test_nano_llava_text_only",
     ]
 
     # Get the current script path


### PR DESCRIPTION
There are two models which do not support inferencing without images attached: Florence 2 and Llama 3.2 Vision. For those models, create a nice exception message so that users know it's not a supported mode.

This PR also fixes a few bugs that prevented text-only generation with some VLMs.