### PR TITLE
Upgrade MLX VLM

### DIFF
--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -23,7 +23,7 @@ class VisionModelKit(ModelKit):
     has_processed_prompt: bool = False
 
     def __init__(self, model_path: Path, max_kv_size: int, trust_remote_code: bool):
-        self.config = mlx_vlm.utils.load_config(model_path)
+        self.config = mlx_vlm.utils.load_config(model_path, trust_remote_code=trust_remote_code)
         self.trust_remote_code = trust_remote_code
         self.model_path = model_path
         self.max_kv_size = max_kv_size
@@ -33,9 +33,9 @@ class VisionModelKit(ModelKit):
         self.model, self.processor = mlx_vlm.utils.load(
             self.model_path,
             processor_config={"trust_remote_code": self.trust_remote_code},
+            trust_remote_code=self.trust_remote_code,
         )
-        image_processor = mlx_vlm.utils.load_image_processor(self.model_path)
-        self.model = VisionModelWrapper(self.model, image_processor)
+        self.model = VisionModelWrapper(self.model)
         self.tokenizer = mlx_vlm.tokenizer_utils.load_tokenizer(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer
         self.cache_wrapper = None

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -164,28 +164,6 @@ class TestVisionModels(unittest.TestCase):
             "mlx-community/llava-v1.6-mistral-7b-4bit", prompt, text_only=True
         )
 
-    def test_bunny_llama(self):
-        """Test Bunny Llama 3 8B V model"""
-        prompt = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n<image>\n{self.description_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        self.model_helper("mlx-community/Bunny-Llama-3-8B-V-4bit", prompt)
-
-    def test_bunny_llama_text_only(self):
-        """Test Bunny Llama 3 8B V model with only text"""
-        prompt = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{self.text_only_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
-        self.model_helper(
-            "mlx-community/Bunny-Llama-3-8B-V-4bit", prompt, text_only=True
-        )
-
-    def test_nano_llava(self):
-        """Test Nano LLaVA 1.5 4B model"""
-        prompt = f"<|im_start|>system\nAnswer the prompt.<|im_end|><|im_start|>user\n<image>\n{self.description_prompt}<|im_end|><|im_start|>assistant\n\n"
-        self.model_helper("mlx-community/nanoLLaVA-1.5-4bit", prompt)
-
-    def test_nano_llava_text_only(self):
-        """Test Nano LLaVA 1.5 4B model with only text"""
-        prompt = f"<|im_start|>system\nAnswer the prompt.<|im_end|><|im_start|>user\n{self.text_only_prompt}<|im_end|><|im_start|>assistant\n\n"
-        self.model_helper("mlx-community/nanoLLaVA-1.5-4bit", prompt, text_only=True)
-
     def test_paligemma2(self):
         """Test Paligemma 2 model"""
         prompt = f"<image>{self.description_prompt}"


### PR DESCRIPTION
Upgrade mlx-vlm to 0.1.9.

Remove tests for bunny_llama (which is different from bunny_llava) and nano_llava, which are not explicitly supported.

Refactor `vision_model_wrapper.py` to matches the changes upstream in mlx-vlm.

Explicit addition of deepseek VL2 coming in a future PR