### PR TITLE
Wrap huggingface_hub snapshot download to only use local files

### DIFF
--- a/mlx_engine/__init__.py
+++ b/mlx_engine/__init__.py
@@ -5,6 +5,9 @@
 from pathlib import Path
 import os
 
+from .utils.disable_hf_download import patch_huggingface_hub
+patch_huggingface_hub()
+
 
 def _set_outlines_cache_dir(cache_dir: Path | str):
     """

--- a/mlx_engine/utils/disable_hf_download.py
+++ b/mlx_engine/utils/disable_hf_download.py
@@ -1,0 +1,23 @@
+from functools import wraps
+import sys
+import huggingface_hub
+
+# Store the original function before we patch anything
+_original_snapshot_download = huggingface_hub.snapshot_download
+
+@wraps(_original_snapshot_download)
+def snapshot_download(*args, **kwargs):
+    """
+    Wrapper around huggingface_hub.snapshot_download that disables it
+    """
+    raise RuntimeError("Internal error: Cannot proceed without downloading from huggingface. Please report this error to the LM Studio team.")
+
+def patch_huggingface_hub():
+    """
+    Patch the huggingface_hub module to use our local-only snapshot_download.
+    This ensures that any import of snapshot_download from huggingface_hub
+    will use our wrapped version.
+    """
+    huggingface_hub.snapshot_download = snapshot_download
+    # Also patch the module in sys.modules to ensure any other imports get our version
+    sys.modules['huggingface_hub'].snapshot_download = snapshot_download


### PR DESCRIPTION
mlx-vlm version 0.1.6 was attempting to download dependencies from huggingface for certain models. This PR prevents this from happening in the future by overwriting the `snapshot_download` method to raise an Exception instead. Note that upgrading to mlx-vlm version 0.1.10 fixes the issue encountered in 0.1.6, but adding this function wrapper will prevent this issue from recurring in the future.