### PR TITLE
Fix bug where EOS during some tool calls were unhandled

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -305,10 +305,10 @@ def create_generator(
                 continue
 
         # Standard yield - yield when a non-empty text segment is available or eos token is hit
-        if text or token == tokenizer.eos_token_id:
+        if text or token in tokenizer.eos_token_ids:
             # populate stop_condition if we hit an eos token
             stop_condition = None
-            if token == tokenizer.eos_token_id:
+            if token in tokenizer.eos_token_ids:
                 stop_condition = GenerationStopCondition(
                     stop_reason="eos_token",
                     stop_string=tokenizer.decode(token),


### PR DESCRIPTION
A bug was reported where `mlx_engine.generate.create_generator.__next__()` was returning a `StopIteration` exception. That generator was designed to never emit `StopIteration`; the caller needs to use the yielded object to determine when to stop iterating.

The `StopIteration` exception was being raised by an unhandled EOS token, in this case `<|eom_id|>` from llama 3.1. `<|eom_id|>` acts as an additional stop-string for tool calls ([source](https://github.com/meta-llama/llama-models/issues/44)). Our generator in mlx-engine was not set up to handle multiple stop tokens, even though the upstream mlx-lm registers multiple stop tokens. Handling multiple stop tokens was a recent change in mlx-lm https://github.com/ml-explore/mlx-examples/pull/1141 .

This PR fixes the bug by using the same logic as mlx-lm when determining EOS. This change is confirmed to fix the llama tool-calling bug which printed a `StopIteration` error in the LM Studio logs.