### PR TITLE
Wire in KV cache quantization

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -45,6 +45,27 @@ def setup_arg_parser():
         default=0,
         help="Number of top logprobs to return",
     )
+    parser.add_argument(
+        "--max-kv-size",
+        type=int,
+        help="Max context size of the model",
+    )
+    parser.add_argument(
+        "--kv-bits",
+        type=int,
+        choices=range(3, 9),
+        help="Number of bits for KV cache quantization. Must be between 3 and 8 (inclusive)",
+    )
+    parser.add_argument(
+        "--kv-group-size",
+        type=int,
+        help="Group size for KV cache quantization",
+    )
+    parser.add_argument(
+        "--quantized-kv-start",
+        type=int,
+        help="When --kv-bits is set, start quantizing the KV cache from this step onwards",
+    )
     return parser
 
 
@@ -62,7 +83,14 @@ if __name__ == "__main__":
 
     # Load the model
     model_path = args.model
-    model_kit = load_model(str(model_path), max_kv_size=4096, trust_remote_code=False)
+    model_kit = load_model(
+        str(model_path),
+        max_kv_size=args.max_kv_size,
+        trust_remote_code=False,
+        kv_bits=args.kv_bits,
+        kv_group_size=args.kv_group_size,
+        quantized_kv_start=args.quantized_kv_start,
+    )
 
     # Tokenize the prompt
     prompt = args.prompt

--- a/mlx_engine/__init__.py
+++ b/mlx_engine/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import os
 
 from .utils.disable_hf_download import patch_huggingface_hub
+
 patch_huggingface_hub()
 
 

--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -16,7 +16,9 @@ class CacheWrapper:
     Wrapper class for the MLX LM cache to maintain an in-memory cache
     """
 
-    def __init__(self, model: nn.Module, max_kv_size: Optional[int], verbose: bool = False):
+    def __init__(
+        self, model: nn.Module, max_kv_size: Optional[int], verbose: bool = False
+    ):
         """
         Initialize the CacheWrapper.
 

--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -16,13 +16,13 @@ class CacheWrapper:
     Wrapper class for the MLX LM cache to maintain an in-memory cache
     """
 
-    def __init__(self, model: nn.Module, max_kv_size: int, verbose: bool = False):
+    def __init__(self, model: nn.Module, max_kv_size: Optional[int], verbose: bool = False):
         """
         Initialize the CacheWrapper.
 
         Args:
             model (nn.Module): The model to be cached.
-            max_kv_size (int): Maximum size of the key-value cache.
+            max_kv_size (Optional[int]): Maximum size of the key-value cache.
         """
         # utilize a simple ordered list of tokens processed so far for cache invalidation checking
         self.tokens: Optional[mx.array] = None

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -74,9 +74,7 @@ def load_model(
 
     if "vision_config" in config_json:
         if any([kv_bits, kv_group_size, quantized_kv_start]):
-            raise ValueError(
-                "MLX vision models do not support KV cache quantization"
-            )
+            raise ValueError("MLX vision models do not support KV cache quantization")
         return VisionModelKit(model_path, trust_remote_code)
     else:
         return ModelKit(
@@ -226,7 +224,11 @@ def create_generator(
     tokenizer = model_kit.tokenizer
 
     # Set up stop string processor if non-empty stop_strings are provided
-    eos_token_ids = tokenizer.eos_token_ids if isinstance(tokenizer.eos_token_ids, Iterable) else [tokenizer.eos_token_ids]
+    eos_token_ids = (
+        tokenizer.eos_token_ids
+        if isinstance(tokenizer.eos_token_ids, Iterable)
+        else [tokenizer.eos_token_ids]
+    )
     stop_string_processor = None
     if stop_strings is not None and len(stop_strings) > 0:
         stop_string_processor = StopStringProcessor(stop_strings, tokenizer)

--- a/mlx_engine/model_kit.py
+++ b/mlx_engine/model_kit.py
@@ -10,7 +10,14 @@ import mlx.nn as nn
 
 class ModelKit:
     """
-    Collection of objects and methods that are needed for operating a text model
+    Collection of objects and methods that are needed for operating a text model.
+
+    Args:
+        model_path (Path): Path to the model directory containing model files.
+        max_kv_size (int): Maximum size of the key-value cache used during model inference.
+        kv_bits (Optional[int]): Number of bits for KV cache quantization. None disables quantization.
+        kv_group_size (int): Group size for KV cache quantization. Defaults to 64.
+        quantized_kv_start (int): Step to begin KV cache quantization when enabled. Defaults to 0.
     """
 
     # model state tracking
@@ -18,14 +25,36 @@ class ModelKit:
     tokenizer: TokenizerWrapper = None
     detokenizer: StreamingDetokenizer = None
     cache_wrapper: Optional[CacheWrapper] = None
-    max_kv_size: int = None
+    max_kv_size: Optional[int] = None
+    kv_bits: Optional[int] = None
+    kv_group_size: Optional[int] = None
+    quantized_kv_start: Optional[int] = None
 
-    def __init__(self, model_path: Path, max_kv_size: int):
+    def __init__(
+        self,
+        model_path: Path,
+        max_kv_size: Optional[int],
+        kv_bits: Optional[int] = None,
+        kv_group_size: Optional[int] = None,
+        quantized_kv_start: Optional[int] = None,
+    ):
+        if any([kv_group_size, quantized_kv_start]) and kv_bits is None:
+            raise ValueError(
+                "Enabling KV Cache Quantization requires kv_bits to be set"
+            )
+        if not any([kv_bits, kv_group_size, quantized_kv_start]) and max_kv_size is None:
+            raise ValueError(
+                "Context length setting is required"
+            )
+
         self.model_path = model_path
         self.model, self.tokenizer = mlx_lm.utils.load(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer
         self.cache_wrapper = CacheWrapper(self.model, max_kv_size)
         self.max_kv_size = max_kv_size
+        self.kv_bits = kv_bits
+        self.kv_group_size = kv_group_size
+        self.quantized_kv_start = quantized_kv_start
 
     def tokenize(self, prompt: str) -> List[int]:
         ids = self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(prompt))

--- a/mlx_engine/model_kit.py
+++ b/mlx_engine/model_kit.py
@@ -16,8 +16,8 @@ class ModelKit:
         model_path (Path): Path to the model directory containing model files.
         max_kv_size (int): Maximum size of the key-value cache used during model inference.
         kv_bits (Optional[int]): Number of bits for KV cache quantization. None disables quantization.
-        kv_group_size (int): Group size for KV cache quantization. Defaults to 64.
-        quantized_kv_start (int): Step to begin KV cache quantization when enabled. Defaults to 0.
+        kv_group_size (Optional[int]): Group size for KV cache quantization. Defaults to 64.
+        quantized_kv_start (Optional[int]): Step to begin KV cache quantization when enabled. Defaults to 0.
     """
 
     # model state tracking

--- a/mlx_engine/model_kit.py
+++ b/mlx_engine/model_kit.py
@@ -42,10 +42,11 @@ class ModelKit:
             raise ValueError(
                 "Enabling KV Cache Quantization requires kv_bits to be set"
             )
-        if not any([kv_bits, kv_group_size, quantized_kv_start]) and max_kv_size is None:
-            raise ValueError(
-                "Context length setting is required"
-            )
+        if (
+            not any([kv_bits, kv_group_size, quantized_kv_start])
+            and max_kv_size is None
+        ):
+            raise ValueError("Context length setting is required")
 
         self.model_path = model_path
         self.model, self.tokenizer = mlx_lm.utils.load(self.model_path)

--- a/mlx_engine/utils/disable_hf_download.py
+++ b/mlx_engine/utils/disable_hf_download.py
@@ -5,12 +5,16 @@ import huggingface_hub
 # Store the original function before we patch anything
 _original_snapshot_download = huggingface_hub.snapshot_download
 
+
 @wraps(_original_snapshot_download)
 def snapshot_download(*args, **kwargs):
     """
     Wrapper around huggingface_hub.snapshot_download that disables it
     """
-    raise RuntimeError("Internal error: Cannot proceed without downloading from huggingface. Please report this error to the LM Studio team.")
+    raise RuntimeError(
+        "Internal error: Cannot proceed without downloading from huggingface. Please report this error to the LM Studio team."
+    )
+
 
 def patch_huggingface_hub():
     """
@@ -20,4 +24,4 @@ def patch_huggingface_hub():
     """
     huggingface_hub.snapshot_download = snapshot_download
     # Also patch the module in sys.modules to ensure any other imports get our version
-    sys.modules['huggingface_hub'].snapshot_download = snapshot_download
+    sys.modules["huggingface_hub"].snapshot_download = snapshot_download

--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -17,16 +17,15 @@ class VisionModelKit(ModelKit):
     config: dict = None
     trust_remote_code: bool = False
     model_path: Path = None
-    max_kv_size: int = None
 
     processor: Union[PreTrainedTokenizer, PreTrainedTokenizerFast] = None
     has_processed_prompt: bool = False
 
-    def __init__(self, model_path: Path, max_kv_size: int, trust_remote_code: bool):
+    def __init__(self, model_path: Path, trust_remote_code: bool):
+
         self.config = mlx_vlm.utils.load_config(model_path, trust_remote_code=trust_remote_code)
         self.trust_remote_code = trust_remote_code
         self.model_path = model_path
-        self.max_kv_size = max_kv_size
         self._initializer()
 
     def _initializer(self):

--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -22,8 +22,9 @@ class VisionModelKit(ModelKit):
     has_processed_prompt: bool = False
 
     def __init__(self, model_path: Path, trust_remote_code: bool):
-
-        self.config = mlx_vlm.utils.load_config(model_path, trust_remote_code=trust_remote_code)
+        self.config = mlx_vlm.utils.load_config(
+            model_path, trust_remote_code=trust_remote_code
+        )
         self.trust_remote_code = trust_remote_code
         self.model_path = model_path
         self._initializer()

--- a/mlx_engine/vision/vision_model_wrapper.py
+++ b/mlx_engine/vision/vision_model_wrapper.py
@@ -31,7 +31,6 @@ class VisionModelWrapper:
             "first_call": False,
             "decoder_input_ids": None,
             "language_model_kwargs": {},
-
             # vision model kwargs
             "model_inputs": {},
         }
@@ -186,7 +185,9 @@ class VisionModelWrapper:
             try:
                 if hasattr(processor, "process"):
                     # Needed for Molmo
-                    self.input_ids = mx.array(processor.process(text=prompt)["input_ids"])
+                    self.input_ids = mx.array(
+                        processor.process(text=prompt)["input_ids"]
+                    )
                 else:
                     self.input_ids = mx.array(processor(text=prompt).input_ids)
             except ValueError as e:
@@ -201,7 +202,7 @@ class VisionModelWrapper:
                 images=images,
                 prompts=prompt,
                 image_token_index=image_token_index,
-                resize_shape=None
+                resize_shape=None,
             )
             self.input_ids = inputs["input_ids"]
             self.pixel_values = inputs["pixel_values"]
@@ -247,7 +248,7 @@ class VisionModelWrapper:
             aspect_ratio = img.width / img.height
 
             sys.stderr.write(
-                f"[mlx-engine] Image {i+1}: Original size {original_size}\n"
+                f"[mlx-engine] Image {i + 1}: Original size {original_size}\n"
             )
 
             if img.width > max_size[0] or img.height > max_size[1]:
@@ -259,10 +260,10 @@ class VisionModelWrapper:
                     new_width = int(new_height * aspect_ratio)
                 img = img.resize((new_width, new_height), PIL.Image.LANCZOS)
                 sys.stderr.write(
-                    f"[mlx-engine] Image {i+1}: Resized to {img.width}x{img.height}\n"
+                    f"[mlx-engine] Image {i + 1}: Resized to {img.width}x{img.height}\n"
                 )
             else:
-                sys.stderr.write(f"[mlx-engine] Image {i+1}: No resize needed\n")
+                sys.stderr.write(f"[mlx-engine] Image {i + 1}: No resize needed\n")
 
             max_width = max(max_width, img.width)
             max_height = max(max_height, img.height)


### PR DESCRIPTION
See this PR for the mlx-lm implementation https://github.com/ml-explore/mlx-examples/pull/1075

Summary of changes:
- Wire `kv_bits`, `kv_group_size`, and `quantized_kv_start` into `model_kit`, `load_model`, and `create_generator`. These values are optional, so that way we rely on `mlx-lm` to set defaults for us. `kv_bits` is required to set the other two parameters
- Disable kv cache quantization for VLMs
- Note that `max_kv_size` is not respected when quantizing the KV cache
- Apply a formatting pass