### PR TITLE
Make num_draft_tokens setting never fatal, fix chunk_size overwrite

### DIFF
--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -142,7 +142,6 @@ class CacheWrapper:
             start_progress: Starting progress percentage
             end_progress: Ending progress percentage
         """
-        chunk_size = 512  # Default chunk size
         remaining_tokens = tokens
         num_processed = 0
         total_tokens = len(tokens)
@@ -168,7 +167,10 @@ class CacheWrapper:
         if self.model is None:
             raise ValueError("Cannot add a draft model to cache without a main model")
         if self.max_kv_size is not None:
-            log_warn(prefix="CacheWrapper", message="Disabling max_kv_size when adding a draft model")
+            log_warn(
+                prefix="CacheWrapper",
+                message="Disabling max_kv_size when adding a draft model",
+            )
             self.max_kv_size = None
 
         # clear the current cache, append draft model cache to the end of the main model cache as per

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -192,17 +192,15 @@ def create_generator(
 
     # Set up speculative decoding
     if num_draft_tokens is not None:
-        can_use_draft = (
-            isinstance(model_kit, ModelKit) and model_kit.draft_model is not None
-        )
-        if not can_use_draft:
-            reason = (
-                "No draft model loaded"
-                if isinstance(model_kit, ModelKit)
-                else "model_kit must be of type ModelKit"
-            )
+        if type(model_kit) is not ModelKit:
             log_info(
-                message=f"num_draft_tokens setting '{num_draft_tokens}' ignored. Reason: {reason}",
+                message=f"num_draft_tokens setting '{num_draft_tokens}' ignored, "
+                f"model_kit (type {type(model_kit).__name__}) must be a text ModelKit instance"
+            )
+        elif model_kit.draft_model is None:
+            log_info(
+                message=f"num_draft_tokens setting '{num_draft_tokens}' ignored, "
+                "no draft model loaded"
             )
         else:
             generate_args["num_draft_tokens"] = num_draft_tokens

--- a/mlx_engine/model_kit.py
+++ b/mlx_engine/model_kit.py
@@ -53,7 +53,10 @@ class ModelKit:
         )
         if kv_bits and max_kv_size is not None:
             # Quantized KV cache is only supported for non-rotating KV cache
-            log_warn("max_kv_size is ignored when using KV cache quantization")
+            log_warn(
+                prefix="ModelKit",
+                message="max_kv_size is ignored when using KV cache quantization",
+            )
             max_kv_size = None
 
         self.model_path = model_path


### PR DESCRIPTION
Fix for https://github.com/lmstudio-ai/mlx-engine/pull/83#discussion_r1928048085 + just log and ignore if `num_draft_tokens` with incompatible ModelKit instance