### PR TITLE
Add vocab_only load option

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -40,6 +40,7 @@ class GenerationResult(NamedTuple):
 def load_model(
     model_path: str | Path,
     *,
+    vocab_only: bool = False,
     max_kv_size: Optional[int] = 4096,
     trust_remote_code: bool = False,
     kv_bits: Optional[int] = None,
@@ -54,6 +55,7 @@ def load_model(
 
     Args:
         model_path (str | Path): Path to the model directory containing model files and config.json.
+        vocab_only (bool): Only load vocabulary/tokenizer, not the full model.
         max_kv_size (int): Maximum size of the key-value cache used during model inference.
         trust_remote_code (bool): Whether to allow loading of remote code during model initialization.
         kv_bits (Optional[int]): Number of bits for KV cache quantization.
@@ -78,10 +80,11 @@ def load_model(
             raise ValueError(
                 "MLX vision models do not currently support KV cache quantization"
             )
-        return VisionModelKit(model_path, trust_remote_code)
+        return VisionModelKit(model_path, vocab_only, trust_remote_code)
     else:
         return ModelKit(
             model_path,
+            vocab_only,
             max_kv_size,
             kv_bits=kv_bits,
             kv_group_size=kv_group_size,
@@ -152,6 +155,7 @@ def create_generator(
         seed (Optional[int]): Random seed for reproducible generation
         json_schema (Optional[str]): JSON schema for structured output generation
         max_tokens (Optional[int]): Maximum number of tokens to generate. Defaults to 10000000
+        speculative_decoding_enabled (bool): Whether to enable speculative decoding
         num_draft_tokens (Optional[int]): Number of tokens to draft when using speculative decoding
 
     Yields:

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -155,7 +155,6 @@ def create_generator(
         seed (Optional[int]): Random seed for reproducible generation
         json_schema (Optional[str]): JSON schema for structured output generation
         max_tokens (Optional[int]): Maximum number of tokens to generate. Defaults to 10000000
-        speculative_decoding_enabled (bool): Whether to enable speculative decoding
         num_draft_tokens (Optional[int]): Number of tokens to draft when using speculative decoding
 
     Yields:

--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -79,7 +79,7 @@ class VisionModelKit(ModelKit):
         Returns the input for the `generate_step` function
         """
         if self.has_processed_prompt:
-            self._reset()
+            self._reset_for_prediction()
 
         self.model.process_prompt_with_images(
             images_b64, prompt_tokens, self.processor, self.detokenizer

--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -58,10 +58,10 @@ class VisionModelKit(ModelKit):
         else:
             self._full_model_init()
 
-    def _reset(self):
-        # it's a shortcoming that the only way to reset the model is to reload it
-        # worth investigating how to make resetting faster
-        self._initializer()
+    def _reset_for_prediction(self):
+        # It's a shortcoming that the only way to reset the model for prediction 
+        # is to reload it. Worth investigating how to make resetting faster
+        self._full_model_init()
 
     def process_prompt(
         self,

--- a/tests/test_speculative_decoding.py
+++ b/tests/test_speculative_decoding.py
@@ -17,7 +17,17 @@ class TestSpeculativeDecoding(unittest.TestCase):
         """Set up test resources that will be shared across all test methods"""
         cls.model_path_prefix = Path("~/.cache/lm-studio/models").expanduser().resolve()
 
-    def test_is_draft_model_compatible_true(self):
+    def test_is_draft_model_compatible_true_vocab_only_load(self):
+        model_path = model_getter("mlx-community/Qwen2.5-3B-Instruct-4bit")
+        draft_model_path = model_getter(
+            "lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit"
+        )
+        model_kit = load_model(model_path=model_path, vocab_only=True)
+        self.assertTrue(
+            is_draft_model_compatible(model_kit=model_kit, path=draft_model_path)
+        )
+
+    def test_is_draft_model_compatible_true_full_model_load(self):
         model_path = model_getter("mlx-community/Qwen2.5-3B-Instruct-4bit")
         draft_model_path = model_getter(
             "lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit"
@@ -27,7 +37,15 @@ class TestSpeculativeDecoding(unittest.TestCase):
             is_draft_model_compatible(model_kit=model_kit, path=draft_model_path)
         )
 
-    def test_is_draft_model_compatible_false_incompatible(self):
+    def test_is_draft_model_compatible_false_vocab_only_load(self):
+        model_path = model_getter("mlx-community/Qwen2.5-3B-Instruct-4bit")
+        draft_model_path = model_getter("mlx-community/Llama-3.2-1B-Instruct-4bit")
+        model_kit = load_model(model_path=model_path, vocab_only=True)
+        self.assertFalse(
+            is_draft_model_compatible(model_kit=model_kit, path=draft_model_path)
+        )
+
+    def test_is_draft_model_compatible_false_full_model_load(self):
         model_path = model_getter("mlx-community/Qwen2.5-3B-Instruct-4bit")
         draft_model_path = model_getter("mlx-community/Llama-3.2-1B-Instruct-4bit")
         model_kit = load_model(model_path=model_path)


### PR DESCRIPTION
Adds the ability to load a model in vocab_only mode.

This is useful for checking speculative decoding compatibility without needing to load the full model & its weights.