### PR TITLE
Add speculative_decoding_toggle generation argument

### DIFF
--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Any
 
-from mlx_engine.logging import log_info, log_warn
+from mlx_engine.logging import log_info
 from mlx_lm.models.cache import (
     make_prompt_cache,
     trim_prompt_cache,

--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -164,14 +164,31 @@ class CacheWrapper:
             mx.metal.clear_cache()
 
     def set_draft_model(self, draft_model: nn.Module):
+        """
+        Sets or updates the draft model to use in the cache.
+
+        If the provided draft_model is already set, returns without changes.
+        Otherwise, clears existing cache and rebuilds it by combining caches
+        from the main model and draft model. Requires a main model to be set first.
+
+        Args:
+            draft_model: The draft model to cache. Pass None to remove draft model.
+
+        Raises:
+            ValueError: If main model hasn't been set yet.
+        """
         if self.model is None:
             raise ValueError("Cannot add a draft model to cache without a main model")
         if self.max_kv_size is not None:
             log_warn(
                 prefix="CacheWrapper",
-                message="Disabling max_kv_size when adding a draft model",
+                message="Disabling max_kv_size when setting a draft model for cache",
             )
             self.max_kv_size = None
+
+        if self.draft_model is draft_model:
+            # Skip if the exact same draft model instance is already in cache
+            return
 
         # clear the current cache, append draft model cache to the end of the main model cache as per
         # https://github.com/ml-explore/mlx-examples/blob/514502da22f0dc4c1ac439bdf78c07d5ec41acf7/llms/mlx_lm/utils.py#L381-L382
@@ -181,10 +198,8 @@ class CacheWrapper:
         self.draft_model = draft_model
 
     def unset_draft_model(self):
+        """Removes the draft model from the cache if one exists."""
         if self.draft_model is None:
-            log_info(
-                prefix="CacheWrapper", message="No draft model to remove from cache"
-            )
             return
         self.draft_model = None
         self.cache = self.cache[: len(self.model.layers)]

--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -180,7 +180,7 @@ class CacheWrapper:
         if self.model is None:
             raise ValueError("Cannot add a draft model to cache without a main model")
         if self.max_kv_size is not None:
-            log_warn(
+            log_info(
                 prefix="CacheWrapper",
                 message="Disabling max_kv_size when setting a draft model for cache",
             )

--- a/mlx_engine/model_kit.py
+++ b/mlx_engine/model_kit.py
@@ -130,6 +130,7 @@ class ModelKit:
         prompt_progress_callback,
         repetition_context_size,
         generate_args,
+        speculative_decoding_toggle: Optional[bool] = None,
     ) -> mx.array:
         """
         This method processes the prompt, adding its tokens to the cache history
@@ -141,6 +142,22 @@ class ModelKit:
         """
         if len(prompt_tokens) == 0:
             raise ValueError("Prompt tokens must be non-empty")
+
+        # Make sure cache's draft model setting aligns with speculative decoding toggle
+        should_use_draft_model = (
+            speculative_decoding_toggle
+            if speculative_decoding_toggle is not None
+            else bool(self.draft_model)
+        )
+        if should_use_draft_model:
+            if not self.draft_model:
+                raise ValueError(
+                    "Speculative decoding toggle is enabled for prompt processing but no "
+                    "draft model is loaded"
+                )
+            self.cache_wrapper.set_draft_model(self.draft_model)
+        else:
+            self.cache_wrapper.unset_draft_model()
 
         # Check for common tokens with the previous cache and re-use the cache if possible
         prompt_tokens = self.cache_wrapper.update_cache(

--- a/mlx_engine/model_kit.py
+++ b/mlx_engine/model_kit.py
@@ -147,7 +147,7 @@ class ModelKit:
         should_use_draft_model = (
             speculative_decoding_toggle
             if speculative_decoding_toggle is not None
-            else bool(self.draft_model)
+            else self.draft_model is not None
         )
         if should_use_draft_model:
             if not self.draft_model:

--- a/mlx_engine/utils/speculative_decoding.py
+++ b/mlx_engine/utils/speculative_decoding.py
@@ -35,7 +35,7 @@ def configure_num_draft_tokens_in_generate_args(
     draft_model: Optional[nn.Module],
     num_draft_tokens: Optional[int],
     generate_args: dict,
-) -> dict:
+):
     """
     Modifies generate_args in place to include num_draft_tokens if applicable
     """

--- a/mlx_engine/utils/speculative_decoding.py
+++ b/mlx_engine/utils/speculative_decoding.py
@@ -1,0 +1,54 @@
+from typing import Optional
+
+import mlx.nn as nn
+
+from mlx_engine.logging import log_info
+from mlx_engine.model_kit import ModelKit
+
+
+def determine_draft_model_for_generation(
+    model_kit: ModelKit, speculative_decoding_toggle: Optional[bool]
+) -> Optional[nn.Module]:
+    """
+    Based on ModelKit and speculative_decoding_toggle, determine draft model to use for
+    generation, or None
+    """
+    if speculative_decoding_toggle is None:
+        # toggle not set, use draft model if available
+        return model_kit.draft_model
+    elif speculative_decoding_toggle and model_kit.draft_model is None:
+        raise ValueError(
+            "Speculative decoding toggle is explicitly enabled but no draft model is loaded"
+        )
+    elif not speculative_decoding_toggle and model_kit.draft_model is not None:
+        log_info(
+            "Draft model is loaded but speculative decoding is disabled for this generation"
+        )
+        return None
+    else:
+        # toggle set to true, draft model available
+        return model_kit.draft_model
+
+
+def configure_num_draft_tokens_in_generate_args(
+    model_kit: ModelKit,
+    draft_model: Optional[nn.Module],
+    num_draft_tokens: Optional[int],
+    generate_args: dict,
+) -> dict:
+    """
+    Modifies generate_args in place to include num_draft_tokens if applicable
+    """
+    if num_draft_tokens is not None:
+        if type(model_kit) is not ModelKit:
+            log_info(
+                message=f"num_draft_tokens setting '{num_draft_tokens}' ignored, "
+                f"model_kit (type {type(model_kit).__name__}) must be a text ModelKit instance"
+            )
+        elif draft_model is None:
+            log_info(
+                message=f"num_draft_tokens setting '{num_draft_tokens}' ignored, "
+                "no draft model loaded/activated for this generation"
+            )
+        else:
+            generate_args["num_draft_tokens"] = num_draft_tokens

--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -6,6 +6,7 @@ from .vision_model_wrapper import VisionModelWrapper
 import mlx_vlm
 from pathlib import Path
 import mlx.core as mx
+import mlx.nn as nn
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
@@ -39,7 +40,7 @@ class VisionModelKit(ModelKit):
     def _vocab_only_init(self):
         self.tokenizer = mlx_vlm.tokenizer_utils.load_tokenizer(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer
-    
+
     def _full_model_init(self):
         self.model, self.processor = mlx_vlm.utils.load(
             self.model_path,
@@ -59,7 +60,7 @@ class VisionModelKit(ModelKit):
             self._full_model_init()
 
     def _reset_for_prediction(self):
-        # It's a shortcoming that the only way to reset the model for prediction 
+        # It's a shortcoming that the only way to reset the model for prediction
         # is to reload it. Worth investigating how to make resetting faster
         self._full_model_init()
 
@@ -70,6 +71,7 @@ class VisionModelKit(ModelKit):
         prompt_progress_callback,
         repetition_context_size,
         generate_args,
+        speculative_decoding_toggle: Optional[bool] = None,
     ) -> mx.array:
         """
         Call this before starting evaluation


### PR DESCRIPTION
### Overview
Allows speculative decoding to be disabled for generation, even if a draft model is loaded, through a new optional `speculative_decoding_toggle` argument to `create_generator`

Behavior:
- If NOT set: use speculative decoding if a draft model is loaded (prior behavior)
- If set to true: draft model will be used and must be loaded or else error
- If set to false: speculative decoding is disabled even if a draft model is loaded, log but don't unload

`CacheWrapper` must be aligned on each generation to respect this toggle. Ensure `set_draft_model` and `unset_draft_model` can be called on every generation and that those functions do nothing if setting is already aligned.

### Testing
- [x] Draft model loaded, toggle unset: Uses spec decoding
- [x] Draft model loaded, toggle enabled: Uses spec decoding
- [x] Draft model loaded, toggle disabled: Logs and doesn't use spec decoding
- [x] Draft model not loaded, toggle unset: Doesn't use spec decoding
- [x] Draft model not loaded, spec decoding enabled: Error
- [x] Draft model not loaded, specc decoding disabled: Doesn't use spec decoding