### PR TITLE
Wire 'from_draft' member of Token

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -104,11 +104,15 @@ class GenerationStatsCollector:
         self.start_time = time.time()
         self.first_token_time = None
         self.total_tokens = 0
+        self.num_accepted_draft_tokens = 0
 
     def add_tokens(self, tokens):
         """Record new tokens and their timing."""
         if self.first_token_time is None:
             self.first_token_time = time.time()
+        for token in tokens:
+            if token.from_draft:
+                self.num_accepted_draft_tokens += 1
         self.total_tokens += len(tokens)
 
     def print_stats(self):
@@ -123,6 +127,7 @@ class GenerationStatsCollector:
         print(f" - Total tokens generated: {self.total_tokens}")
         print(f" - Total time: {total_time:.2f}s")
         print(f" - Tokens per second: {tokens_per_second:.2f}")
+        print(f" - Number of accepted draft tokens: {self.num_accepted_draft_tokens}")
 
 
 

--- a/demo.py
+++ b/demo.py
@@ -3,7 +3,8 @@ import base64
 import time
 from typing import List
 
-from mlx_engine.generate import load_model, load_draft_model, create_generator, tokenize, Token
+from mlx_engine.generate import load_model, load_draft_model, create_generator, tokenize
+from mlx_engine.utils.token import Token
 from mlx_engine.model_kit import VALID_KV_BITS, VALID_KV_GROUP_SIZE
 
 

--- a/demo.py
+++ b/demo.py
@@ -112,11 +112,12 @@ class GenerationStatsCollector:
         """Record new tokens and their timing."""
         if self.first_token_time is None:
             self.first_token_time = time.time()
-        for token in tokens:
-            if token.from_draft:
-                if self.num_accepted_draft_tokens is None:
-                    self.num_accepted_draft_tokens = 0
-                self.num_accepted_draft_tokens += 1
+            
+        draft_tokens = sum(1 for token in tokens if token.from_draft)
+        if draft_tokens and self.num_accepted_draft_tokens is None:
+            self.num_accepted_draft_tokens = 0
+        self.num_accepted_draft_tokens += draft_tokens
+            
         self.total_tokens += len(tokens)
 
     def print_stats(self):

--- a/mlx_engine/__init__.py
+++ b/mlx_engine/__init__.py
@@ -33,4 +33,5 @@ from .generate import (
     unload_draft_model,
     create_generator,
     tokenize,
+    Token,
 )

--- a/mlx_engine/__init__.py
+++ b/mlx_engine/__init__.py
@@ -33,5 +33,4 @@ from .generate import (
     unload_draft_model,
     create_generator,
     tokenize,
-    Token,
 )

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -10,7 +10,8 @@ import mlx.nn as nn
 from mlx_engine.model_kit import ModelKit
 from mlx_engine.vision.vision_model_kit import VisionModelKit
 from mlx_engine.processors.outlines_logits_processor import OutlinesLogitsProcessor
-from mlx_engine.utils.top_logprobs import summarize_top_logprobs, TokenLogprob
+from mlx_engine.utils.token import Token
+from mlx_engine.utils.top_logprobs import summarize_top_logprobs
 from mlx_engine.stop_string_processor import (
     StopStringProcessor,
     StopStringProcessorResult,
@@ -20,7 +21,6 @@ from mlx_engine.utils.speculative_decoding import (
     determine_draft_model_for_generation,
     configure_num_draft_tokens_in_generate_args,
 )
-from mlx_engine.logging import log_info
 
 
 MAX_TOP_LOGPROBS = 10
@@ -37,8 +37,8 @@ class GenerationStopCondition(NamedTuple):
 
 class GenerationResult(NamedTuple):
     text: str
-    tokens: List[TokenLogprob]
-    top_logprobs: List[List[TokenLogprob]]
+    tokens: List[Token]
+    top_logprobs: List[List[Token]]
     stop_condition: Optional[GenerationStopCondition]
 
 
@@ -262,8 +262,8 @@ def create_generator(
         )
 
     # Keep track of tokens buffered by detokenizer to yield accurate generation results
-    token_buffer: List[TokenLogprob] = []
-    top_logprobs_buffer: List[List[TokenLogprob]] = []
+    token_buffer: List[Token] = []
+    top_logprobs_buffer: List[List[Token]] = []
 
     tokenizer = model_kit.tokenizer
 
@@ -282,8 +282,8 @@ def create_generator(
         tokenizer,
         stop_string_processor_result: StopStringProcessorResult,
         text: str,
-        token_buffer: List[TokenLogprob],
-        top_logprobs_buffer: List[List[TokenLogprob]],
+        token_buffer: List[Token],
+        top_logprobs_buffer: List[List[Token]],
     ) -> GenerationResult:
         """
         Helper method to Handle completion of text generation when a stop string is
@@ -345,7 +345,7 @@ def create_generator(
 
         logprobs = generation_result.logprobs
         token_buffer.append(
-            TokenLogprob(
+            Token(
                 token,
                 tokenizer.decode(token),
                 float(logprobs[token]),

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -345,7 +345,12 @@ def create_generator(
 
         logprobs = generation_result.logprobs
         token_buffer.append(
-            TokenLogprob(token, tokenizer.decode(token), float(logprobs[token]))
+            TokenLogprob(
+                token,
+                tokenizer.decode(token),
+                float(logprobs[token]),
+                from_draft=generation_result.from_draft,
+            )
         )
         if top_logprobs:
             top_logprobs_buffer.append(

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import sys
 
 import mlx_lm
-import mlx.nn as nn
 
 from mlx_engine.model_kit import ModelKit
 from mlx_engine.vision.vision_model_kit import VisionModelKit

--- a/mlx_engine/utils/token.py
+++ b/mlx_engine/utils/token.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Token:
+    """
+    Base dataclass for a single generated token.
+    """
+    id: int
+    text: str
+    logprob: float
+    from_draft: Optional[bool] = None

--- a/mlx_engine/utils/token.py
+++ b/mlx_engine/utils/token.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 from typing import Optional
 
+
 @dataclass
 class Token:
     """
     Base dataclass for a single generated token.
     """
+
     id: int
     text: str
     logprob: float

--- a/mlx_engine/utils/top_logprobs.py
+++ b/mlx_engine/utils/top_logprobs.py
@@ -1,18 +1,11 @@
-from typing import NamedTuple
+from mlx_engine.utils.token import Token
 
 import mlx.core as mx
 
 
-class TokenLogprob(NamedTuple):
-    id: int
-    text: str
-    logprob: float
-    from_draft: bool
-
-
 def summarize_top_logprobs(
     tokenizer, logprobs: mx.array, top_logprobs: int
-) -> list[TokenLogprob]:
+) -> list[Token]:
     # find the sorted indices (in descending order) of the logprobs
     sorted_indices = mx.argsort(-logprobs)
 
@@ -28,7 +21,7 @@ def summarize_top_logprobs(
 
     # return list of TokenLogprob with id (int), text (str), and logprob (float)
     return [
-        TokenLogprob(int(idx), txt, float(prob))
+        Token(id=int(idx), text=txt, logprob=float(prob))
         for idx, txt, prob in zip(
             top_indices.tolist(), text_list, top_logprobs.tolist()
         )

--- a/mlx_engine/utils/top_logprobs.py
+++ b/mlx_engine/utils/top_logprobs.py
@@ -7,6 +7,7 @@ class TokenLogprob(NamedTuple):
     id: int
     text: str
     logprob: float
+    from_draft: bool
 
 
 def summarize_top_logprobs(

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ lark==1.2.2
 markdown-it-py==3.0.0
 markupsafe==2.1.5
 mdurl==0.1.2
-mlx-lm==0.21.1
+mlx-lm @ git+https://github.com/mattjcly/mlx-examples@9e28bed#subdirectory=llms
 mlx-vlm==0.1.12
 mlx==0.22.0
 mpmath==1.3.0


### PR DESCRIPTION
Enables the statistic of whether or not a token was generated from a draft model during speculative decoding.

For now, point to https://github.com/mattjcly/mlx-examples/tree/from_draft in requirements to get this functionality in, but the plan is to move back to main of `mlx-lm` once this pr: https://github.com/ml-explore/mlx-examples/pull/1272 or something like it gets in.