### PR TITLE
Fix indexing bug in stop_string_processor.py

### DIFF
--- a/mlx_engine/stop_string_processor.py
+++ b/mlx_engine/stop_string_processor.py
@@ -126,7 +126,7 @@ class StopStringProcessor:
         return result
 
     def _check_incomplete_utf8(self, string: str) -> Optional[_StoppingCriteriaResult]:
-        if len(string) and string[-1] == REPLACEMENT_CHAR:
+        if len(string) == 0 or string[-1] == REPLACEMENT_CHAR:
             return self._StoppingCriteriaResult(status="multi_byte", stop_string=None)
         return None
 

--- a/mlx_engine/stop_string_processor.py
+++ b/mlx_engine/stop_string_processor.py
@@ -126,7 +126,7 @@ class StopStringProcessor:
         return result
 
     def _check_incomplete_utf8(self, string: str) -> Optional[_StoppingCriteriaResult]:
-        if string[-1] == REPLACEMENT_CHAR:
+        if len(string) and string[-1] == REPLACEMENT_CHAR:
             return self._StoppingCriteriaResult(status="multi_byte", stop_string=None)
         return None
 


### PR DESCRIPTION
Fixes the error described in the following traceback:
```
  File "/.../generate.py", line 355, in create_generator
    stop_string_processor_result = stop_string_processor.process_token(token)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../stop_string_processor.py", line 63, in process_token
    result = self._stopping_criteria(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../stop_string_processor.py", line 120, in _stopping_criteria
    self._check_incomplete_utf8(string)
  File "/.../stop_string_processor.py", line 129, in _check_incomplete_utf8
    if string[-1] == REPLACEMENT_CHAR:
       ~~~~~~^^^^
IndexError: string index out of range
```

I checked the rest of the code here to ensure there's no bad indexing happening elsewhere with this detokenized text.