### PR TITLE
Fix structured generation with speculative decoding

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -249,7 +249,7 @@ def create_generator(
     is_structured_output_request = json_schema is not None
     if is_structured_output_request:
         generate_args["logits_processors"].append(
-            OutlinesLogitsProcessor(model_kit, json_schema)
+            OutlinesLogitsProcessor(model_kit, json_schema, stream_generate_input)
         )
 
     # Validate top_logprobs

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==23.2.1
 aiohappyeyeballs==2.4.6
 aiohttp==3.11.12
 aiosignal==1.3.2
-airportsdata==20241001
+airportsdata==20250224
 annotated-types==0.7.0
 anyio==4.8.0
 attrs==25.1.0
@@ -15,19 +15,19 @@ datasets==3.3.2
 dill==0.3.8
 diskcache==5.6.3
 distlib==0.3.9
-fastapi==0.115.8
+fastapi==0.115.10
 ffmpy==0.5.0
 filelock==3.17.0
 frozenlist==1.5.0
 fsspec==2024.12.0
 genson==1.3.0
-gradio-client==1.7.1
-gradio==5.17.0
+gradio-client==1.7.2
+gradio==5.19.0
 h11==0.14.0
 httpcore==1.0.7
 httpx==0.28.1
 huggingface-hub==0.29.1
-identify==2.6.7
+identify==2.6.8
 idna==3.10
 interegular==0.3.3
 iso3166==2.1.1
@@ -38,7 +38,7 @@ lark==1.2.2
 markdown-it-py==3.0.0
 markupsafe==2.1.5
 mdurl==0.1.2
-mlx-lm @ git+https://github.com/ml-explore/mlx-examples@3d677f0#subdirectory=llms
+mlx-lm==0.21.5
 mlx-vlm==0.1.13
 mlx==0.23.1
 mpmath==1.3.0
@@ -51,7 +51,7 @@ numpy==2.1.3
 opencv-python==4.10.0.84
 orjson==3.10.15
 outlines-core==0.1.26
-outlines==0.2.0
+outlines==0.2.1
 packaging==24.2
 pandas==2.2.3
 pillow==11.1.0
@@ -73,7 +73,7 @@ regex==2024.11.6
 requests==2.32.3
 rich==13.9.4
 rpds-py==0.23.1
-ruff==0.9.7
+ruff==0.9.9
 safehttpx==0.1.6
 safetensors==0.5.2
 scipy==1.13.1
@@ -83,19 +83,19 @@ setuptools==75.8.0
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
-starlette==0.45.3
+starlette==0.46.0
 sympy==1.13.1
 tokenizers==0.21.0
 tomlkit==0.13.2
 torch==2.6.0
 tqdm==4.67.1
 transformers @ git+https://github.com/huggingface/transformers@62db3e6
-typer==0.15.1
+typer==0.15.2
 typing-extensions==4.12.2
 tzdata==2025.1
 urllib3==2.3.0
 uvicorn==0.34.0
 virtualenv==20.29.2
-websockets==14.2
+websockets==15.0
 xxhash==3.5.0
 yarl==1.18.3

--- a/tests/test_structured_gen.py
+++ b/tests/test_structured_gen.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 
@@ -56,7 +57,9 @@ class TestStructuredGen(unittest.TestCase):
         self.assertIn("name", generated_text)
         self.assertIn("hex", generated_text)
 
-    @unittest.skip("Temporarily disabled until logits_processors are fixed for sd")
+        # throw if not valid JSON
+        json.loads(generated_text)
+
     def test_structured_gen_with_json_schema_speculative_decoding(self):
         # Uses same model for main and draft, not a speed test
         model_kit, prompt_tokens = model_load_and_tokenize_prompt(
@@ -82,3 +85,6 @@ class TestStructuredGen(unittest.TestCase):
         self.assertIn("colors", generated_text)
         self.assertIn("name", generated_text)
         self.assertIn("hex", generated_text)
+
+        # throw if not valid JSON
+        json.loads(generated_text)


### PR DESCRIPTION
This PR fixes structured generation with speculative decoding by 1) bringing in the latest mlx-lm, which adds a logit_processor step to the draft generation, and 2) removing the state tracking from `OutlinesLogitsProcessor`.

Remove the state tracking `processed_token_count` from `OutlinesLogitsProcessor`, since the logit processor has to handle both draft-model input and validation-model input, without knowing which it's handling. To track the generated tokens so far, initialize `OutlinesLogitsProcessor` with the prompt tokens and filter them out.