### PR TITLE
Set multiple eos tokens for VLM

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -267,11 +267,7 @@ def create_generator(
     tokenizer = model_kit.tokenizer
 
     # Set up stop string processor if non-empty stop_strings are provided
-    eos_token_ids = (
-        tokenizer.eos_token_ids
-        if isinstance(tokenizer.eos_token_ids, Iterable)
-        else [tokenizer.eos_token_ids]
-    )
+    eos_token_ids = model_kit.eos_token_ids
     stop_string_processor = None
     if stop_strings is not None and len(stop_strings) > 0:
         stop_string_processor = StopStringProcessor(stop_strings, tokenizer)

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -267,7 +267,7 @@ def create_generator(
     tokenizer = model_kit.tokenizer
 
     # Set up stop string processor if non-empty stop_strings are provided
-    eos_token_ids = model_kit.eos_token_ids
+    eos_token_ids = tokenizer.eos_token_ids
     stop_string_processor = None
     if stop_strings is not None and len(stop_strings) > 0:
         stop_string_processor = StopStringProcessor(stop_strings, tokenizer)

--- a/mlx_engine/model_kit.py
+++ b/mlx_engine/model_kit.py
@@ -243,3 +243,7 @@ class ModelKit:
     @property
     def language_model(self):
         return self.model
+
+    @property
+    def eos_token_ids(self):
+        return self.tokenizer.eos_token_ids

--- a/mlx_engine/model_kit.py
+++ b/mlx_engine/model_kit.py
@@ -243,7 +243,3 @@ class ModelKit:
     @property
     def language_model(self):
         return self.model
-
-    @property
-    def eos_token_ids(self):
-        return self.tokenizer.eos_token_ids

--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -21,6 +21,7 @@ class VisionModelKit(ModelKit):
     model_path: Path = None
     vocab_only: bool = False
     model_weights = None
+    eos_token_ids = set()
 
     processor: Union[PreTrainedTokenizer, PreTrainedTokenizerFast] = None
     has_processed_prompt: bool = False
@@ -102,6 +103,14 @@ class VisionModelKit(ModelKit):
         self.model = VisionModelWrapper(self.model)
         self.tokenizer = mlx_vlm.tokenizer_utils.load_tokenizer(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer
+
+        # Set the eos_token_ids
+        if (eos_tokens := self.config.get("eos_token_ids", None)) is not None:
+            self.eos_token_ids = set(eos_tokens)
+            log_info(f"Setting eos token ids: {self.eos_token_ids}")
+        elif (eos_tokens := self.config.get("eos_token_id", None)) is not None:
+            self.eos_token_ids = {eos_tokens}
+
         self.cache_wrapper = None
         mx.metal.clear_cache()
 

--- a/mlx_engine/vision/vision_model_kit.py
+++ b/mlx_engine/vision/vision_model_kit.py
@@ -6,6 +6,7 @@ from mlx_engine.logging import log_info, log_warn
 from .vision_model_wrapper import VisionModelWrapper
 
 import mlx_vlm
+import mlx_lm
 from pathlib import Path
 import mlx.core as mx
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
@@ -21,7 +22,6 @@ class VisionModelKit(ModelKit):
     model_path: Path = None
     vocab_only: bool = False
     model_weights = None
-    eos_token_ids = set()
 
     processor: Union[PreTrainedTokenizer, PreTrainedTokenizerFast] = None
     has_processed_prompt: bool = False
@@ -101,15 +101,20 @@ class VisionModelKit(ModelKit):
         else:
             self.model, self.processor, self.model_weights = return_tuple
         self.model = VisionModelWrapper(self.model)
-        self.tokenizer = mlx_vlm.tokenizer_utils.load_tokenizer(self.model_path)
-        self.detokenizer = self.tokenizer.detokenizer
 
         # Set the eos_token_ids
+        eos_token_ids = []
         if (eos_tokens := self.config.get("eos_token_ids", None)) is not None:
-            self.eos_token_ids = set(eos_tokens)
-            log_info(f"Setting eos token ids: {self.eos_token_ids}")
+            eos_token_ids = list(set(eos_tokens))
+            log_info(f"Setting eos token ids: {eos_token_ids}")
         elif (eos_tokens := self.config.get("eos_token_id", None)) is not None:
-            self.eos_token_ids = {eos_tokens}
+            eos_token_ids = [eos_tokens]
+
+        # Use the mlx_lm tokenizer since it's more robust
+        self.tokenizer = mlx_lm.tokenizer_utils.load_tokenizer(
+            self.model_path, eos_token_ids=list(eos_token_ids)
+        )
+        self.detokenizer = self.tokenizer.detokenizer
 
         self.cache_wrapper = None
         mx.metal.clear_cache()

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -227,6 +227,7 @@ class TestVisionModels(unittest.TestCase):
         prompt = f"{self.text_only_prompt}"
         self.model_helper("mlx-community/gemma-3-4b-it-4bit", prompt, text_only=True)
 
+
 """
 To find the correct prompt format for new models, run this command for your model in the terminal and check the prompt dump:
 python -m mlx_vlm.generate --model ~/.cache/lm-studio/models/mlx-community/MODEL-NAME --max-tokens 100 --temp 0.0 --image http://images.cocodataset.org/val2017/000000039769.jpg --prompt "What do you see?"


### PR DESCRIPTION
Use mlx_lm tokenizer instead of mlx_vlm tokenizer. For example, mlx_vlm tokenizer doesn't support eos_token_ids as an argument in its __init__. This fixes gemma models which have multiple EOS tokens.

Also closes #99 