### PR TITLE
Fix image loading

### DIFF
--- a/mlx_engine/vision/vision_model_wrapper.py
+++ b/mlx_engine/vision/vision_model_wrapper.py
@@ -217,7 +217,7 @@ class VisionModelWrapper:
     def _convert_to_pil(self, images_b64: List[str]):
         """Convert a list of base64 strings to PIL Images"""
         return [
-            PIL.Image.open(BytesIO(base64.b64decode(img))) for img in images_b64 or []
+            PIL.Image.open(BytesIO(base64.b64decode(img))).convert("RGB") for img in images_b64 or []
         ]
 
     def _custom_resize(self, pil_images, max_size=(1000, 1000)):


### PR DESCRIPTION
According to this [post](https://stackoverflow.com/questions/75891072/valueerror-unable-to-infer-channel-dimension-format), adding `.convert("RGB")` magically fixes the issue.