### PR TITLE
Use apply-chat-template in demo.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Download models with the `lms` CLI tool. The `lms` CLI documentation can be foun
 Run the `demo.py` script with an MLX text generation model:
 ```bash
 lms get mlx-community/Meta-Llama-3.1-8B-Instruct-4bit
-python demo.py --model ~/.cache/lm-studio/models/mlx-community/Meta-Llama-3.1-8B-Instruct-4bit 
+python demo.py --model ~/.lmstudio/models/mlx-community/Meta-Llama-3.1-8B-Instruct-4bit 
 ```
 [mlx-community/Meta-Llama-3.1-8B-Instruct-4bit](https://model.lmstudio.ai/download/mlx-community/Meta-Llama-3.1-8B-Instruct-4bit) - 4.53 GB
 
-This command will use a default prompt that is formatted for Llama-3.1. For other models, add a custom `--prompt` argument with the correct prompt formatting:
+This command will use a default prompt. For a different prompt, add a custom `--prompt` argument like:
 ```bash
 lms get mlx-community/Mistral-Small-Instruct-2409-4bit
-python demo.py --model ~/.cache/lm-studio/models/mlx-community/Mistral-Small-Instruct-2409-4bit --prompt "<s> [INST] How long will it take for an apple to fall from a 10m tree? [/INST]"
+python demo.py --model ~/.lmstudio/models/mlx-community/Mistral-Small-Instruct-2409-4bit --prompt "How long will it take for an apple to fall from a 10m tree?"
 ```
 [mlx-community/Mistral-Small-Instruct-2409-4bit](https://model.lmstudio.ai/download/mlx-community/Mistral-Small-Instruct-2409-4bit) - 12.52 GB
 
@@ -72,7 +72,7 @@ python demo.py --model ~/.cache/lm-studio/models/mlx-community/Mistral-Small-Ins
 Run the `demo.py` script with an MLX vision model:
 ```bash
 lms get mlx-community/pixtral-12b-4bit
-python demo.py --model ~/.cache/lm-studio/models/mlx-community/pixtral-12b-4bit --prompt "<s>[INST]Compare these images[IMG][IMG][/INST]" --images demo-data/chameleon.webp demo-data/toucan.jpeg
+python demo.py --model ~/.lmstudio/models/mlx-community/pixtral-12b-4bit --prompt "Compare these images" --images demo-data/chameleon.webp demo-data/toucan.jpeg
 ```
 Currently supported vision models include:
  - [Llama-3.2-Vision](https://model.lmstudio.ai/download/mlx-community/Llama-3.2-11B-Vision-Instruct-4bit)

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Download models with the `lms` CLI tool. The `lms` CLI documentation can be foun
 Run the `demo.py` script with an MLX text generation model:
 ```bash
 lms get mlx-community/Meta-Llama-3.1-8B-Instruct-4bit
-python demo.py --model ~/.lmstudio/models/mlx-community/Meta-Llama-3.1-8B-Instruct-4bit 
+python demo.py --model mlx-community/Meta-Llama-3.1-8B-Instruct-4bit 
 ```
 [mlx-community/Meta-Llama-3.1-8B-Instruct-4bit](https://model.lmstudio.ai/download/mlx-community/Meta-Llama-3.1-8B-Instruct-4bit) - 4.53 GB
 
 This command will use a default prompt. For a different prompt, add a custom `--prompt` argument like:
 ```bash
 lms get mlx-community/Mistral-Small-Instruct-2409-4bit
-python demo.py --model ~/.lmstudio/models/mlx-community/Mistral-Small-Instruct-2409-4bit --prompt "How long will it take for an apple to fall from a 10m tree?"
+python demo.py --model mlx-community/Mistral-Small-Instruct-2409-4bit --prompt "How long will it take for an apple to fall from a 10m tree?"
 ```
 [mlx-community/Mistral-Small-Instruct-2409-4bit](https://model.lmstudio.ai/download/mlx-community/Mistral-Small-Instruct-2409-4bit) - 12.52 GB
 
@@ -72,7 +72,7 @@ python demo.py --model ~/.lmstudio/models/mlx-community/Mistral-Small-Instruct-2
 Run the `demo.py` script with an MLX vision model:
 ```bash
 lms get mlx-community/pixtral-12b-4bit
-python demo.py --model ~/.lmstudio/models/mlx-community/pixtral-12b-4bit --prompt "Compare these images" --images demo-data/chameleon.webp demo-data/toucan.jpeg
+python demo.py --model mlx-community/pixtral-12b-4bit --prompt "Compare these images" --images demo-data/chameleon.webp demo-data/toucan.jpeg
 ```
 Currently supported vision models include:
  - [Llama-3.2-Vision](https://model.lmstudio.ai/download/mlx-community/Llama-3.2-11B-Vision-Instruct-4bit)
@@ -90,8 +90,8 @@ Run the `demo.py` script with an MLX text generation model and a compatible `--d
 lms get mlx-community/Qwen2.5-7B-Instruct-4bit
 lms get lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit
 python demo.py \
-    --model ~/.lmstudio/models/mlx-community/Qwen2.5-7B-Instruct-4bit \
-    --draft-model ~/.lmstudio/models/lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit \
+    --model mlx-community/Qwen2.5-7B-Instruct-4bit \
+    --draft-model lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit \
     --prompt "<|im_start|>system
 You are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>
 <|im_start|>user

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ attrs==25.1.0
 certifi==2025.1.31
 charset-normalizer==3.4.1
 cloudpickle==3.1.1
-dill==0.3.9
+dill==0.3.8
 diskcache==5.6.3
 filelock==3.17.0
 frozenlist==1.5.0
@@ -31,7 +31,7 @@ nest-asyncio==1.6.0
 networkx==3.4.2
 numpy==2.1.3
 outlines-core==0.1.26
-outlines==0.2.2
+outlines==0.2.1
 packaging==24.2
 pillow==11.1.0
 propcache==0.3.0


### PR DESCRIPTION
## Overview
This PR implements the following and addresses #114 : 
- Use`apply_chat_template` in the `demo.py` file to make it easier to use the demo file. 
- Updates `README.md` to reflect this change and have correct LM Studio models path
- Updates `requirements.txt` to handle conflicts in python packages.
 