### PR TITLE
Add common EOT tokens to the tokenizer's eos_token_ids

### DIFF
--- a/mlx_engine/utils/eot_tokens.py
+++ b/mlx_engine/utils/eot_tokens.py
@@ -1,0 +1,33 @@
+# Taken from https://github.com/ggml-org/llama.cpp/blob/master/src/llama-vocab.cpp#L1807-L1814
+EOT_TOKENS = [
+    "<|eot_id|>",
+    "<|im_end|>",
+    "<|end|>",
+    "<end_of_turn>",
+    "<|endoftext|>",
+    "<EOT>",
+    "_<EOT>",
+    "<｜end▁of▁sentence｜>",
+]
+
+
+def get_eot_token_ids(tokenizer) -> set[int]:
+    """
+    Get the token ID of common end-of-text tokens, using the provided tokenizer.
+
+    If the EOT token str cannot be converted into a single token ID, it is discarded as a candidate
+    """
+    # Convert EOT tokens to token IDs
+    eot_token_ids = [
+        tokenizer.encode(eot_str, add_special_tokens=False) for eot_str in EOT_TOKENS
+    ]
+
+    # Find all elements that are either a single integer or a list with a single integer
+    single_int = [token_id for token_id in eot_token_ids if isinstance(token_id, int)]
+    single_element_list = [
+        token_id[0]
+        for token_id in eot_token_ids
+        if isinstance(token_id, list) and len(token_id) == 1
+    ]
+
+    return set(single_int + single_element_list)


### PR DESCRIPTION
Add several common EOT tokens to the tokenizer's eos_token_ids. This is a useful shortcut for ending generation, even if the model conversion does not accurately specify the EOS tokens. [llama.cpp uses this technique](https://github.com/ggml-org/llama.cpp/blob/971f245/src/llama-vocab.cpp#L1807-L1814) this to end generation when the model wants, instead of relying on a correct eos_token_id specification. For example, gemma models such as the recent gemma-3-1b-qat, were missing the `<end_of_turn>` as part of [its EOS list](https://huggingface.co/google/gemma-3-1b-it-qat-q4_0-unquantized/blob/904ac18/config.json#L10), and so the [MLX conversion didn't pick it up either](https://huggingface.co/mlx-community/gemma-3-1b-it-qat-4bit/commit/15fed4eafb456c6fcb2a1165f19ac609670ed14b). This issue wasn't an issue in llama.cpp due to this fallback EOT list

This was tested with `demo.py` text-only with various model archs: deepseek-qwen, gemma-3, phi-3. I made sure that for each model, the result picked the correct EOT token(s) for its arch.