### PR TITLE
Update mlx to 0.25.0 and mlx-lm to 0.23.1 to support GLM-4 models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,9 @@ jsonschema-specifications==2024.10.1
 jsonschema==4.23.0
 lark==1.2.2
 markupsafe==2.1.5
-mlx-lm==0.22.5
+mlx-lm==0.23.1
 mlx-vlm==0.1.23
-mlx==0.24.2
+mlx==0.25.0
 mpmath==1.3.0
 multidict==6.1.0
 nest-asyncio==1.6.0


### PR DESCRIPTION
Only tested with mlx-community/GLM-4-32B-0414-4bit so far.

![image](https://github.com/user-attachments/assets/07c89e14-1892-4603-a468-8ddfadf246c9)

- Pre-commit hooks - passed ✓
- test_text_models.py - passed ✓
- test_cache_wrapper.py - passed ✓
- test_stop_string_processor.py - passed ✓
- test_vision_models.py - pending model downloads ⏳

Resolves: #146 