### PR TITLE
Fix Gemma 3 Vision add on when loading QAT models

### DIFF
--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -71,6 +71,7 @@ class Gemma3VisionAddOn(BaseVisionAddOn, nn.Module):
                 class_predicate=class_predicate,
             )
 
+        # load weights using nn.Module method
         self.load_weights(list(weights.items()))
         # hardcode lazy loading to false for now, always load weights to memory here
         lazy = False


### PR DESCRIPTION
Gemma 3 QAT vision components depend on this code: 

https://github.com/Blaizzy/mlx-vlm/blob/d2391123cabac313729f9a2a8d57d396e2592f20/mlx_vlm/utils.py#L220-L228

to load properly. I didn't initially include this because it was marked as "`# Handle legacy models which may not have everything quantized`", but that appears to not be true.

In the future, it'd be nice to get upsteam changes in to not have to duplicate so much from the `load_model` function in mlx_vlm utils, but I think this is okay for now and can refactor when we need that code for more than just Gemma 3.

Gemma 3 QAT works with this fix:
![Screenshot 2025-05-15 at 2 52 17 PM](https://github.com/user-attachments/assets/5b14d4d8-2526-42c5-ad7e-8e06a34eedf2)
