### PR TITLE
Gemma 3 Vision: fix self.model_path ref

### DIFF
--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -81,7 +81,7 @@ class Gemma3VisionAddOn(BaseVisionAddOn, nn.Module):
         self.eval()
         log_info(
             prefix=self.GEMMA3_LOG_PREFIX,
-            message=f"Gemma3 vision model loaded successfully from {self.model_path}",
+            message=f"Gemma3 vision model loaded successfully from {model_path}",
         )
 
     def compute_embeddings(


### PR DESCRIPTION
`model_path` isn't stored in `self` after https://github.com/lmstudio-ai/mlx-engine/pull/159 (no need for it to be)

Fix this hanging self ref