### PR TITLE
Allow empty prompts for text-only models

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -5,7 +5,7 @@ import os
 
 from mlx_engine.generate import load_model, load_draft_model, create_generator, tokenize
 from mlx_engine.utils.token import Token
-from mlx_engine.model_kit import VALID_KV_BITS, VALID_KV_GROUP_SIZE
+from mlx_engine.utils.kv_cache_quantization import VALID_KV_BITS, VALID_KV_GROUP_SIZE
 from transformers import AutoTokenizer, AutoProcessor
 
 DEFAULT_PROMPT = "Explain the rules of chess in one sentence"

--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -237,6 +237,7 @@ class CacheWrapper:
         self,
         prompt_tokens: mx.array,
         prompt_progress_callback,
+        *,
         num_tokens_to_exclude: int = 1,
     ) -> mx.array:
         """
@@ -262,8 +263,9 @@ class CacheWrapper:
         )
 
         # Prefill the cache with the non-excluded prompt tokens
-        prompt_progress_callback(0)
+        num_tokens_to_exclude = min(num_tokens_to_exclude, len(prompt_tokens))
         prefill_tokens = prompt_tokens[:-num_tokens_to_exclude]
+        prompt_progress_callback(0)
         with mx.stream(generation_stream):
             if self.draft_model is not None:
                 # Fill draft model cache (0% to 50% progress)

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -138,8 +138,15 @@ class ModelKit:
         is_text_only_processing = images_b64 is None or len(images_b64) == 0
         if is_text_only_processing:
             self._cross_prompt_cache_active = True
+            if len(prompt_tokens) == 0:
+                log_warn(
+                    prefix="ModelKit",
+                    message="Received empty prompt. Generation quality will be poor",
+                )
+                # Models expect some sort of input, so add whitespace
+                prompt_tokens = self.tokenize(" ")
             return process_prompt_text_only(
-                prompt_tokens,
+                mx.array(prompt_tokens),
                 self.cache_wrapper,
                 generate_args,
                 self.draft_model,

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -141,7 +141,7 @@ class ModelKit:
             if len(prompt_tokens) == 0:
                 log_warn(
                     prefix="ModelKit",
-                    message="Received empty prompt. Generation quality will be poor",
+                    message="Received empty prompt. Generation quality will likely be poor",
                 )
                 # Models expect some sort of input, so add whitespace
                 prompt_tokens = self.tokenize(" ")

--- a/mlx_engine/utils/prompt_processing.py
+++ b/mlx_engine/utils/prompt_processing.py
@@ -7,15 +7,13 @@ from mlx_engine.cache_wrapper import CacheWrapper
 
 
 def process_prompt_text_only(
-    prompt_tokens: List[int],
+    prompt_tokens: mx.array,
     cache_wrapper: CacheWrapper,
     generate_args: dict = None,
     draft_model: Optional[nn.Module] = None,
     speculative_decoding_toggle: Optional[bool] = None,
     prompt_progress_callback: Optional[Callable[[float], None]] = None,
 ):
-    if len(prompt_tokens) == 0:
-        raise ValueError("Prompt tokens must be non-empty")
     if cache_wrapper is None:
         raise ValueError("Cache wrapper is not initialized, cannot process prompt")
     if generate_args is None:
@@ -38,7 +36,7 @@ def process_prompt_text_only(
 
     # Check for common tokens with the previous cache and re-use the cache if possible
     prompt_tokens = cache_wrapper.update_cache(
-        mx.array(prompt_tokens),
+        prompt_tokens,
         prompt_progress_callback,
     )
     generate_args["prompt_cache"] = cache_wrapper.cache

--- a/mlx_engine/utils/prompt_processing.py
+++ b/mlx_engine/utils/prompt_processing.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Callable
+from typing import Optional, Callable
 
 from mlx import nn
 import mlx.core as mx


### PR DESCRIPTION
We are currently throwing on empty prompts. Instead, allow generation to continue, and note that generation quality will be poor.

Closes #161 