### PR TITLE
Fix gemma-3-text behavior with VisionAddOn

### DIFF
--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -96,7 +96,10 @@ class ModelKit:
         config_json = json.loads((model_path / "config.json").read_text())
         model_type = config_json.get("model_type", None)
         vision_add_on_class = self.VISION_ADD_ON_MAP.get(model_type)
-        if vision_add_on_class:
+        should_load_vision_add_on = (
+            vision_add_on_class is not None and "vision_config" in config_json
+        )
+        if should_load_vision_add_on:
             self.vision_add_on = vision_add_on_class(model_path)
         log_info(prefix=LOG_PREFIX, message="Model loaded successfully")
 


### PR DESCRIPTION
Need to check more than just `model_type` to decide whether to try and load the vision add on for Gemma 3, since some models exist of `model_type` `gemma3`, but don't have vision components (see https://huggingface.co/mlx-community/gemma-3-text-4b-it-4bit/blob/main/config.json)

#### Before
![Screenshot 2025-05-16 at 11 08 29 AM](https://github.com/user-attachments/assets/6922a417-96a6-43ef-92d4-f2e149aa4979)

#### After
![Screenshot 2025-05-16 at 11 06 15 AM](https://github.com/user-attachments/assets/6ef13809-998e-4de6-9438-36887787533a)
