### PR TITLE
Unify mistral3

### DIFF
--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -13,6 +13,7 @@ from mlx_engine.logging import log_info, log_warn
 from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.gemma3 import Gemma3VisionAddOn
 from mlx_engine.model_kit.vision_add_ons.pixtral import PixtralVisionAddOn
+from mlx_engine.model_kit.vision_add_ons.mistral3 import Mistral3VisionAddOn
 from mlx_engine.utils.kv_cache_quantization import get_kv_cache_quantization_params
 from mlx_engine.utils.prompt_processing import process_prompt_text_only
 
@@ -34,6 +35,7 @@ class ModelKit:
 
     VISION_ADD_ON_MAP = {
         "gemma3": Gemma3VisionAddOn,
+        "mistral3": Mistral3VisionAddOn,
         "pixtral": PixtralVisionAddOn,
     }
 

--- a/mlx_engine/model_kit/vision_add_ons/mistral3.py
+++ b/mlx_engine/model_kit/vision_add_ons/mistral3.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+from typing import List
+
+from mlx import nn
+import mlx.core as mx
+
+from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
+from mlx_vlm.models.mistral3 import (
+    VisionModel as Mistral3VisionTower,
+    ModelConfig as Mistral3ModelConfig,
+    VisionConfig as Mistral3VisionConfig,
+    TextConfig as Mistral3TextConfig,
+    Model as Mistral3CombinedModel,
+)
+from mlx_vlm.models.mistral3.mistral3 import Mistral3MultiModalProjector
+from mlx_engine.model_kit.vision_add_ons.process_prompt_with_images import (
+    common_process_prompt_with_images,
+)
+from mlx_engine.model_kit.vision_add_ons.load_utils import load_vision_addon
+
+
+class Mistral3VisionAddOn(BaseVisionAddOn):
+    """
+    Vision add-on for Mistral3 models.
+    """
+
+    LOG_PREFIX = "Mistral3VisionAddOn"
+
+    def __init__(self, model_path: Path):
+        """Initialize Mistral3VisionAddOn with vision components loaded from the given path."""
+        super().__init__()
+
+        self.vision_tower, self.multi_modal_projector, self.config, self.processor = (
+            load_vision_addon(
+                model_path=model_path,
+                model_config_class=Mistral3ModelConfig,
+                vision_config_class=Mistral3VisionConfig,
+                text_config_class=Mistral3TextConfig,
+                vision_tower_class=Mistral3VisionTower,
+                multi_modal_projector_class=Mistral3MultiModalProjector,
+                log_prefix=self.LOG_PREFIX,
+            )
+        )
+
+    def compute_embeddings(
+        self,
+        text_model: nn.Module,
+        prompt_tokens: mx.array,
+        images_b64: List[str],
+    ) -> mx.array:
+        """
+        Compute embeddings for text with images.
+
+        This method is heavily based on the mlx-vlm's mistral3 `get_input_embeddings`
+        https://github.com/Blaizzy/mlx-vlm/blob/2c3014fd40962bd5320ad611502e7e26cae08926/mlx_vlm/models/mistral3/mistral3.py#L240-L279
+        """
+
+        input_ids, pixel_values, attention_mask, other_model_inputs = (
+            common_process_prompt_with_images(
+                prompt_tokens=prompt_tokens,
+                images_b64=images_b64,
+                processor=self.processor,
+                config=self.config,
+            )
+        )
+
+        image_sizes_list = other_model_inputs["image_sizes"]
+        image_sizes = mx.array(image_sizes_list)
+
+        if pixel_values is None:
+            return text_model.language_model.model.embed_tokens(input_ids)
+
+        # Get the input embeddings from the language model
+        inputs_embeds = text_model.language_model.model.embed_tokens(input_ids)
+
+        # Get the output hidden states from the vision model
+        if isinstance(pixel_values, list):
+            pixel_values = mx.concatenate(
+                [mx.array(pv)[None, ...] for pv in pixel_values], axis=0
+            )
+        if pixel_values.ndim == 3:
+            pixel_values = pixel_values[None, ...]
+
+        # Pass pixel_values as list of images, as each image is individually run through conv2d and position encoding
+        # Reference code from transformers: https://github.com/huggingface/transformers/blob/main/src/transformers/models/pixtral/modeling_pixtral.py#L479C9-L479C21
+        # and mistral_inference: https://github.com/mistralai/mistral-inference/blob/main/src/mistral_inference/vision_encoder.py#L85
+        *_, hidden_states = self.vision_tower(
+            pixel_values.transpose(0, 2, 3, 1),
+            output_hidden_states=True,
+        )
+        # Select the hidden states from the desired layer
+        selected_image_feature = hidden_states[self.config.vision_feature_layer]
+
+        # Pass image features through the multi-modal projector
+        image_features = self.multi_modal_projector(selected_image_feature, image_sizes)
+
+        # Insert special image tokens in the input_ids
+        final_inputs_embeds = Mistral3CombinedModel.merge_input_ids_with_image_features(
+            self.config.image_token_index, image_features, inputs_embeds, input_ids
+        )
+        return final_inputs_embeds.squeeze(0)  # remove batch dimension

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -15,9 +15,20 @@ from textwrap import dedent
 
 class TestVisionModels(unittest.TestCase):
     @classmethod
+    def setModelPathPrefix(cls):
+        valid_locations = ["~/.cache/lm-studio/models", "~/.lmstudio/models"]
+        for loc in valid_locations:
+            path = Path(loc).expanduser().resolve()
+            if path.is_dir():
+                cls.model_path_prefix = path
+                break
+        else:
+            raise RuntimeError("No model directory found.")
+
+    @classmethod
     def setUpClass(cls):
         """Set up test resources that will be shared across all test methods"""
-        cls.model_path_prefix = Path("~/.cache/lm-studio/models").expanduser().resolve()
+        cls.setModelPathPrefix()
         cls.description_prompt = "What is this"
         cls.text_only_prompt = "What is a toucan?"
         cls.test_data_dir = Path(__file__).parent / "data"
@@ -131,6 +142,68 @@ class TestVisionModels(unittest.TestCase):
         self.toucan_test_runner(
             "mlx-community/pixtral-12b-4bit", prompt, text_only=True
         )
+
+    def test_mistral3(self):
+        prompt = f"<s>[INST]{self.description_prompt}[IMG][/INST]"
+        self.toucan_test_runner(
+            "lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit", prompt
+        )
+
+    def test_mistral3_text_only(self):
+        prompt = f"<s>[INST]{self.text_only_prompt}[IMG][/INST]"
+        self.toucan_test_runner(
+            "lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit",
+            prompt,
+            text_only=True,
+        )
+
+    def test_mistral3_text_only_generation_caching(self):
+        """Ensure that text only prompts with vlms take full advantage of caching generated tokens"""
+        model_path = model_getter(
+            "lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit"
+        )
+
+        model_kit = load_model(model_path=model_path, max_kv_size=4096)
+
+        def generate_text(prompt):
+            prompt_tokens = tokenize(model_kit, prompt)
+            num_prompt_processing_callbacks = 0
+
+            def progress_callback(progress: float) -> None:
+                nonlocal num_prompt_processing_callbacks
+                num_prompt_processing_callbacks += 1
+                print(f"Prompt processing progress: {progress}")
+
+            generated_text = ""
+            for result in create_generator(
+                model_kit=model_kit,
+                prompt_tokens=prompt_tokens,
+                seed=0,
+                temp=0.0,
+                max_tokens=1000,
+                prompt_progress_callback=progress_callback,
+            ):
+                generated_text += result.text
+                print(result.text, end="", flush=True)
+                if result.stop_condition:
+                    break
+            print("\n", flush=True)
+            return generated_text, num_prompt_processing_callbacks
+
+        # Generation 1 - model creates a long story
+        prompt = "<s>[INST]Tell me a 500 word story[/INST]"
+        generated_text, num_prompt_processing_callbacks = generate_text(prompt)
+        self.assertEqual(num_prompt_processing_callbacks, 2)  # single batch - 0%, 100%
+        self.assertIn("clara", generated_text.lower())
+
+        # Generation 2 - ask for a detail about the story, should not reprocess
+        prompt += generated_text + "[INST]What was the main characters name?[/INST]"
+        num_tokens = len(model_kit.tokenize(prompt))
+        # Without caching, prompts > 512 tokens cause multi-batch processing. Ensure prompt meets that condition
+        self.assertGreater(num_tokens, 512)
+        generated_text, num_prompt_processing_callbacks = generate_text(prompt)
+        self.assertEqual(2, num_prompt_processing_callbacks)  # single batch - 0%, 100%
+        self.assertIn("**clara**", generated_text.lower())
 
     def test_qwen2(self):
         """Test Qwen2 VL 7B Instruct model"""


### PR DESCRIPTION
This PR extends the pattern from PR #164 to unify the mistral3 model type. As described in @mattjcly's [blog post](https://lmstudio.ai/blog/unified-mlx-engine), this allows us to use `mlx-vlm` to generate the image embeddings  and the `mlx-lm` mistral3 implementation for generation.