### PR TITLE
Add support for gemma3n

### DIFF
--- a/mlx_engine/vision_model_kit/_transformers_compatibility.py
+++ b/mlx_engine/vision_model_kit/_transformers_compatibility.py
@@ -1,45 +1,37 @@
 import json
 from pathlib import Path
-from mlx_engine.logging import log_info, log_warn
+from mlx_engine.logging import log_warn
 
 
 def fix_qwen2_5_vl_image_processor(model_path: Path):
     """
-    Register Qwen2_5_VLImageProcessor as Qwen2VLImageProcessor in AutoImageProcessor
-    This is needed because Qwen2_5_VLImageProcessor was deleted from transformers, but legacy versions of the model used this
-    Ref https://github.com/Blaizzy/mlx-vlm/issues/209#issuecomment-2678113857
+    Update the `image_processor_type` in the preprocessor_config.json file to Qwen2VLImageProcessor
     Ref https://huggingface.co/mlx-community/Qwen2.5-VL-7B-Instruct-4bit/commit/fdcc572e8b05ba9daeaf71be8c9e4267c826ff9b
     """
     try:
         # We are looking for a specific entry, so if any of this throws, we don't need to do anything
         with open(model_path / "preprocessor_config.json", "r") as f:
             image_processor_type = json.load(f)["image_processor_type"]
+        with open(model_path / "config.json", "r") as f:
+            model_type = json.load(f)["model_type"]
     except:  # noqa: E722
         return
 
-    if image_processor_type != "Qwen2_5_VLImageProcessor":
+    if not (
+        image_processor_type == "Qwen2_5_VLImageProcessor"
+        and model_type == "qwen2_5_vl"
+    ):
         return
 
-    log_info("Registering deprecated Qwen2_5_VLImageProcessor as Qwen2VLImageProcessor")
-    try:
-        from transformers.models.qwen2_vl.image_processing_qwen2_vl import (
-            Qwen2VLImageProcessor,
-        )
-        from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
-            Qwen2_5_VLConfig,
-        )
-        from transformers.models.auto.processing_auto import AutoImageProcessor
-
-        class Qwen2_5_VLImageProcessor(Qwen2VLImageProcessor):
-            pass
-
-        AutoImageProcessor.register(
-            Qwen2_5_VLConfig, Qwen2_5_VLImageProcessor, exist_ok=True
-        )
-    except Exception as e:
-        log_warn(
-            f"Failed to register Qwen2_5_VLImageProcessor to AutoImageProcessor: {e}"
-        )
+    # Replace image_processor_type with Qwen2VLImageProcessor
+    log_warn(
+        "Replacing `image_processor_type` with Qwen2VLImageProcessor in preprocessor_config.json"
+    )
+    with open(model_path / "preprocessor_config.json", "r") as f:
+        preprocessor_config = json.load(f)
+    preprocessor_config["image_processor_type"] = "Qwen2VLImageProcessor"
+    with open(model_path / "preprocessor_config.json", "w") as f:
+        json.dump(preprocessor_config, f)
 
 
 def fix_qwen2_vl_preprocessor(model_path: Path):

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -201,11 +201,13 @@ You are a helpful assistant.<|im_end|>
         self.assertIn("toucan", unified_generated_text.lower())
         self.assertIn("chameleon", unified_generated_text.lower())
 
+    @unittest.skip("Unavailable since this requires trust_remote_code")
     def test_florence(self):
         """Test Florence 2 Large model"""
         prompt = self.description_prompt
         self.toucan_test_runner("mlx-community/Florence-2-base-ft-4bit", prompt)
 
+    @unittest.skip("Unavailable since this requires trust_remote_code")
     def test_florence_text_only(self):
         """Test Florence 2 Large model with only text"""
         prompt = self.text_only_prompt
@@ -416,6 +418,16 @@ Summarize this in one sentence<end_of_turn>
         generated_text, num_prompt_processing_callbacks = generate_text(prompt)
         self.assertEqual(2, num_prompt_processing_callbacks)  # single batch - 0, 100
         self.assertIn("benjamin franklin", generated_text.lower())
+
+    def test_gemma3n(self):
+        """Test gemma 3n model"""
+        prompt = f"<bos><start_of_turn>user\n<image_soft_token>{self.description_prompt}<end_of_turn>\n<start_of_turn>model\n"
+        self.toucan_test_runner("lmstudio-community/gemma-3n-E2B-it-MLX-bf16", prompt)
+
+    def test_gemma3n_text_only(self):
+        """Test gemma 3n model text only"""
+        prompt = f"<bos><start_of_turn>user\n{self.text_only_prompt}<end_of_turn>\n<start_of_turn>model\n"
+        self.toucan_test_runner("lmstudio-community/gemma-3n-E2B-it-MLX-bf16", prompt, text_only=True)
 
     ### NON-MODEL-SPECIFIC TESTS ###
     def test_draft_model_not_compatible_vision(self):

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -427,7 +427,9 @@ Summarize this in one sentence<end_of_turn>
     def test_gemma3n_text_only(self):
         """Test gemma 3n model text only"""
         prompt = f"<bos><start_of_turn>user\n{self.text_only_prompt}<end_of_turn>\n<start_of_turn>model\n"
-        self.toucan_test_runner("lmstudio-community/gemma-3n-E2B-it-MLX-bf16", prompt, text_only=True)
+        self.toucan_test_runner(
+            "lmstudio-community/gemma-3n-E2B-it-MLX-bf16", prompt, text_only=True
+        )
 
     ### NON-MODEL-SPECIFIC TESTS ###
     def test_draft_model_not_compatible_vision(self):


### PR DESCRIPTION
Also, patch any older versions of qwen2_5_vl image_processor_type. Using this engine will break compatibility with MLX engines that were release before March 21.