### PR TITLE
Unify Gemma3n

### DIFF
--- a/mlx_engine/model_kit/__init__.py
+++ b/mlx_engine/model_kit/__init__.py
@@ -5,9 +5,6 @@ This module automatically applies compatibility patches for various model types
 by replacing classes in their respective modules with derived, compatible versions.
 """
 
-from .patches.gemma3n import apply_patches as apply_patches_gemma3n
+from .patches.gemma3n import apply_patches as _apply_patches_gemma3n
 
-apply_patches_gemma3n()
-
-# Keep namespace clean
-del apply_patches_gemma3n
+_apply_patches_gemma3n()

--- a/mlx_engine/model_kit/__init__.py
+++ b/mlx_engine/model_kit/__init__.py
@@ -1,0 +1,13 @@
+"""
+Model Kit module with automatic compatibility patches.
+
+This module automatically applies compatibility patches for various model types
+by replacing classes in their respective modules with derived, compatible versions.
+"""
+
+from .patches.gemma3n import apply_patches as apply_patches_gemma3n
+
+apply_patches_gemma3n()
+
+# Keep namespace clean
+del apply_patches_gemma3n

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -13,6 +13,8 @@ from mlx_engine.logging import log_info, log_warn
 from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.gemma3 import Gemma3VisionAddOn
 from mlx_engine.model_kit.vision_add_ons.pixtral import PixtralVisionAddOn
+from mlx_engine.model_kit.vision_add_ons.gemma3n import Gemma3nVisionAddOn
+from mlx_engine.model_kit.patches.gemma3n import do_patch as do_patch_gemma3n
 from mlx_engine.utils.kv_cache_quantization import get_kv_cache_quantization_params
 from mlx_engine.utils.prompt_processing import process_prompt_text_only
 
@@ -34,7 +36,12 @@ class ModelKit:
 
     VISION_ADD_ON_MAP = {
         "gemma3": Gemma3VisionAddOn,
+        "gemma3n": Gemma3nVisionAddOn,
         "pixtral": PixtralVisionAddOn,
+    }
+
+    PATCHES = {
+        "gemma3n": do_patch_gemma3n,
     }
 
     # model state tracking
@@ -83,6 +90,10 @@ class ModelKit:
             max_kv_size = None
         self.model_path = model_path
         log_info(prefix=LOG_PREFIX, message=f"Loading model from {model_path}...")
+        config_json = json.loads((model_path / "config.json").read_text())
+        model_type = config_json.get("model_type", None)
+
+        self.PATCHES.get(model_type, lambda: None)()
         self.model, self.tokenizer = mlx_lm.utils.load(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer
         self.cache_wrapper = CacheWrapper(
@@ -95,8 +106,6 @@ class ModelKit:
         self.kv_bits = kv_bits
         self.kv_group_size = kv_group_size
         self.quantized_kv_start = quantized_kv_start
-        config_json = json.loads((model_path / "config.json").read_text())
-        model_type = config_json.get("model_type", None)
         vision_add_on_class = self.VISION_ADD_ON_MAP.get(model_type)
         should_load_vision_add_on = (
             vision_add_on_class is not None and "vision_config" in config_json
@@ -164,10 +173,10 @@ class ModelKit:
                 "Vision add-on is not loaded, but images were provided for processing"
             )
         self._cross_prompt_cache_active = False
-        embeddings = self.vision_add_on.compute_embeddings(
+        (input_ids, embeddings) = self.vision_add_on.compute_embeddings(
             self.model, prompt_tokens, images_b64
         )
-        return mx.array([]), embeddings
+        return input_ids, embeddings
 
     def is_cross_prompt_cache_active(self) -> bool:
         """

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -173,7 +173,7 @@ class ModelKit:
                 "Vision add-on is not loaded, but images were provided for processing"
             )
         self._cross_prompt_cache_active = False
-        (input_ids, embeddings) = self.vision_add_on.compute_embeddings(
+        input_ids, embeddings = self.vision_add_on.compute_embeddings(
             self.model, prompt_tokens, images_b64
         )
         return input_ids, embeddings

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -14,7 +14,6 @@ from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.gemma3 import Gemma3VisionAddOn
 from mlx_engine.model_kit.vision_add_ons.pixtral import PixtralVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.gemma3n import Gemma3nVisionAddOn
-from mlx_engine.model_kit.patches.gemma3n import do_patch as do_patch_gemma3n
 from mlx_engine.utils.kv_cache_quantization import get_kv_cache_quantization_params
 from mlx_engine.utils.prompt_processing import process_prompt_text_only
 
@@ -38,10 +37,6 @@ class ModelKit:
         "gemma3": Gemma3VisionAddOn,
         "gemma3n": Gemma3nVisionAddOn,
         "pixtral": PixtralVisionAddOn,
-    }
-
-    PATCHES = {
-        "gemma3n": do_patch_gemma3n,
     }
 
     # model state tracking
@@ -93,7 +88,6 @@ class ModelKit:
         config_json = json.loads((model_path / "config.json").read_text())
         model_type = config_json.get("model_type", None)
 
-        self.PATCHES.get(model_type, lambda: None)()
         self.model, self.tokenizer = mlx_lm.utils.load(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer
         self.cache_wrapper = CacheWrapper(

--- a/mlx_engine/model_kit/patches/gemma3n.py
+++ b/mlx_engine/model_kit/patches/gemma3n.py
@@ -1,39 +1,28 @@
+"""
+Gemma3n compatibility patches using derive and override pattern.
+
+This module provides derived classes that inherit from the original mlx-lm classes
+and override specific methods to handle compatibility issues between mlx-vlm and mlx-lm.
+"""
+
 from mlx_lm.models.gemma3n import Model, TextConfig
 from mlx.utils import tree_flatten, tree_unflatten
 import inspect
 
-APPLIED = False
 
-
-def _patch_weight_ordering():
+class CompatibleTextConfig(TextConfig):
     """
-    mlx-vlm's conversion changes the weight keys from the original huggingface weights.
-    For example, "model.language_model.embed_tokens.weight" becomes "language_model.model.embed_tokens.weight"
-    mlx-lm expects the weight keys to be in the original huggingface order.
-    Here, we use some magic to minimally patch the mlx-lm gemma3n Model class's sanitize to be able to read mlx-vlm converted weights.
-    """
+    TextConfig that handles intermediate_size as list or integer.
 
-    def mlx_vlm_compatible_sanitize(self, weights):
-        weights = tree_unflatten(list(weights.items()))
-        if weights.get("language_model", {}).get("model", None) is not None:
-            weights = {"model": {"language_model": weights["language_model"]["model"]}}
-        weights = dict(tree_flatten(weights))
-        return self.original_sanitize(weights)
-
-    Model.original_sanitize = Model.sanitize
-    Model.sanitize = mlx_vlm_compatible_sanitize
-
-
-def _patch_intermediate_size_value():
-    """
-    mlx-vlm's conversion (transformers under the hood) changes the "text_config" -> "intermediate_size" value
-    from a single integer to a list of integers of length number of layers.
+    mlx-vlm's conversion (transformers under the hood) changes the
+    "text_config" -> "intermediate_size" value from a single integer to
+    a list of integers of length number of layers.
     mlx-lm's model loader expects it to be a single integer.
-    Here, we minimally patch the gemma3n TextConfig's from_dict method to read the list and just use the first value.
+    This class handles both formats by taking the first value if it's a list.
     """
 
     @classmethod
-    def fix_intermediate_size_from_dict(cls, params):
+    def from_dict(cls, params):
         config_dict = {
             k: v for k, v in params.items() if k in inspect.signature(cls).parameters
         }
@@ -43,15 +32,31 @@ def _patch_intermediate_size_value():
             config_dict["intermediate_size"] = config_dict["intermediate_size"][0]
         return cls(**config_dict)
 
-    TextConfig.original_from_dict = TextConfig.from_dict
-    TextConfig.from_dict = fix_intermediate_size_from_dict
+
+class CompatibleModel(Model):
+    """
+    Model that handles mlx-vlm compatible weight ordering.
+
+    mlx-vlm's conversion changes the weight keys from the original huggingface weights.
+    For example, "model.language_model.embed_tokens.weight" becomes
+    "language_model.model.embed_tokens.weight".
+    mlx-lm expects the weight keys to be in the original huggingface order.
+    This class handles both weight formats.
+    """
+
+    def sanitize(self, weights):
+        weights = tree_unflatten(list(weights.items()))
+        if weights.get("language_model", {}).get("model", None) is not None:
+            weights = {"model": {"language_model": weights["language_model"]["model"]}}
+        weights = dict(tree_flatten(weights))
+        return super().sanitize(weights)
 
 
-def do_patch():
-    global APPLIED
-    if APPLIED:
-        return
-    _patch_weight_ordering()
-    _patch_intermediate_size_value()
+def apply_patches():
+    """
+    Apply gemma3n compatibility patches by replacing classes in the mlx_lm module.
+    """
+    import mlx_lm.models.gemma3n
 
-    APPLIED = True
+    mlx_lm.models.gemma3n.Model = CompatibleModel
+    mlx_lm.models.gemma3n.TextConfig = CompatibleTextConfig

--- a/mlx_engine/model_kit/patches/gemma3n.py
+++ b/mlx_engine/model_kit/patches/gemma3n.py
@@ -32,6 +32,7 @@ def _patch_intermediate_size_value():
     Here, we minimally patch the gemma3n TextConfig's from_dict method to read the list and just use the first value.
     """
 
+    @classmethod
     def fix_intermediate_size_from_dict(cls, params):
         config_dict = {
             k: v for k, v in params.items() if k in inspect.signature(cls).parameters

--- a/mlx_engine/model_kit/patches/gemma3n.py
+++ b/mlx_engine/model_kit/patches/gemma3n.py
@@ -6,6 +6,13 @@ APPLIED = False
 
 
 def _patch_weight_ordering():
+    """
+    mlx-vlm's conversion changes the weight keys from the original huggingface weights.
+    For example, "model.language_model.embed_tokens.weight" becomes "language_model.model.embed_tokens.weight"
+    mlx-lm expects the weight keys to be in the original huggingface order.
+    Here, we use some magic to minimally patch the mlx-lm gemma3n Model class's sanitize to be able to read mlx-vlm converted weights.
+    """
+
     def mlx_vlm_compatible_sanitize(self, weights):
         weights = tree_unflatten(list(weights.items()))
         if weights.get("language_model", {}).get("model", None) is not None:
@@ -18,7 +25,13 @@ def _patch_weight_ordering():
 
 
 def _patch_intermediate_size_value():
-    @classmethod
+    """
+    mlx-vlm's conversion (transformers under the hood) changes the "text_config" -> "intermediate_size" value
+    from a single integer to a list of integers of length number of layers.
+    mlx-lm's model loader expects it to be a single integer.
+    Here, we minimally patch the gemma3n TextConfig's from_dict method to read the list and just use the first value.
+    """
+
     def fix_intermediate_size_from_dict(cls, params):
         config_dict = {
             k: v for k, v in params.items() if k in inspect.signature(cls).parameters
@@ -34,12 +47,6 @@ def _patch_intermediate_size_value():
 
 
 def do_patch():
-    """
-    mlx-vlm's conversion changes the weight keys from the original huggingface weights.
-    For example, "model.language_model.embed_tokens.weight" becomes "language_model.model.embed_tokens.weight"
-    mlx-lm expects the weight keys to be in the original huggingface order.
-    Here, we use some magic to minimally patch the mlx-lm gemma3n Model class's sanitize to be able to read mlx-vlm converted weights.
-    """
     global APPLIED
     if APPLIED:
         return

--- a/mlx_engine/model_kit/patches/gemma3n.py
+++ b/mlx_engine/model_kit/patches/gemma3n.py
@@ -1,0 +1,49 @@
+from mlx_lm.models.gemma3n import Model, TextConfig
+from mlx.utils import tree_flatten, tree_unflatten
+import inspect
+
+APPLIED = False
+
+
+def _patch_weight_ordering():
+    def mlx_vlm_compatible_sanitize(self, weights):
+        weights = tree_unflatten(list(weights.items()))
+        if weights.get("language_model", {}).get("model", None) is not None:
+            weights = {"model": {"language_model": weights["language_model"]["model"]}}
+        weights = dict(tree_flatten(weights))
+        return self.original_sanitize(weights)
+
+    Model.original_sanitize = Model.sanitize
+    Model.sanitize = mlx_vlm_compatible_sanitize
+
+
+def _patch_intermediate_size_value():
+    @classmethod
+    def fix_intermediate_size_from_dict(cls, params):
+        config_dict = {
+            k: v for k, v in params.items() if k in inspect.signature(cls).parameters
+        }
+        if "intermediate_size" in config_dict and isinstance(
+            config_dict["intermediate_size"], list
+        ):
+            config_dict["intermediate_size"] = config_dict["intermediate_size"][0]
+        return cls(**config_dict)
+
+    TextConfig.original_from_dict = TextConfig.from_dict
+    TextConfig.from_dict = fix_intermediate_size_from_dict
+
+
+def do_patch():
+    """
+    mlx-vlm's conversion changes the weight keys from the original huggingface weights.
+    For example, "model.language_model.embed_tokens.weight" becomes "language_model.model.embed_tokens.weight"
+    mlx-lm expects the weight keys to be in the original huggingface order.
+    Here, we use some magic to minimally patch the mlx-lm gemma3n Model class's sanitize to be able to read mlx-vlm converted weights.
+    """
+    global APPLIED
+    if APPLIED:
+        return
+    _patch_weight_ordering()
+    _patch_intermediate_size_value()
+
+    APPLIED = True

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import List, Tuple
 
 import mlx.core as mx
 from mlx import nn
@@ -21,8 +20,8 @@ class BaseVisionAddOn:
         self,
         text_model: nn.Module,
         prompt_tokens: mx.array,
-        images_b64: List[str],
-    ) -> Tuple[mx.array, mx.array]:
+        images_b64: list[str],
+    ) -> tuple[mx.array, mx.array]:
         """
         Returns input embeddings for the language model after text/image merging of the prompt
         """

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -23,5 +23,6 @@ class BaseVisionAddOn:
         images_b64: list[str],
     ) -> tuple[mx.array, mx.array]:
         """
-        Returns input embeddings for the language model after text/image merging of the prompt
+        Returns input ids and input embeddings for the language model after text/image merging of the prompt.
+        The former may be empty for models that do not require input_ids during generation.
         """

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -24,5 +24,4 @@ class BaseVisionAddOn:
     ) -> tuple[mx.array, mx.array]:
         """
         Returns input ids and input embeddings for the language model after text/image merging of the prompt.
-        The former may be empty for models that do not require input_ids during generation.
         """

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import List
+from typing import List, Tuple
 
 import mlx.core as mx
 from mlx import nn
@@ -22,7 +22,7 @@ class BaseVisionAddOn:
         text_model: nn.Module,
         prompt_tokens: mx.array,
         images_b64: List[str],
-    ) -> mx.array:
+    ) -> Tuple[mx.array, mx.array]:
         """
         Returns input embeddings for the language model after text/image merging of the prompt
         """

--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 from pathlib import Path
 
 from mlx import nn
@@ -49,7 +49,7 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
         text_model: nn.Module,
         prompt_tokens: mx.array,
         images_b64: List[str],
-    ) -> mx.array:
+    ) -> Tuple[mx.array, mx.array]:
         """Compute embeddings for text with images."""
         input_ids, pixel_values, attention_mask, other_model_inputs = (
             common_process_prompt_with_images(
@@ -81,4 +81,4 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
             input_ids,
             attention_mask,
         )
-        return final_inputs_embeds.squeeze(0)  # remove batch dimension
+        return (mx.array([]), final_inputs_embeds.squeeze(0))  # remove batch dimension

--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -80,4 +80,5 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
             input_ids,
             attention_mask,
         )
+        # gemma3 generation does not require input_ids, so we return an empty array
         return mx.array([]), final_inputs_embeds.squeeze(0)  # remove batch dimension

--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -49,7 +49,7 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
         prompt_tokens: mx.array,
         images_b64: list[str],
     ) -> tuple[mx.array, mx.array]:
-        """Compute embeddings for text with images."""
+        """Compute input_ids and embeddings for text with images."""
         input_ids, pixel_values, attention_mask, other_model_inputs = (
             common_process_prompt_with_images(
                 prompt_tokens=prompt_tokens,
@@ -80,5 +80,5 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
             input_ids,
             attention_mask,
         )
-        # gemma3 generation does not require input_ids, so we return an empty array
-        return mx.array([]), final_inputs_embeds.squeeze(0)  # remove batch dimension
+        # remove batch dimension
+        return input_ids.squeeze(0), final_inputs_embeds.squeeze(0)

--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -1,4 +1,3 @@
-from typing import List, Tuple
 from pathlib import Path
 
 from mlx import nn
@@ -48,8 +47,8 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
         self,
         text_model: nn.Module,
         prompt_tokens: mx.array,
-        images_b64: List[str],
-    ) -> Tuple[mx.array, mx.array]:
+        images_b64: list[str],
+    ) -> tuple[mx.array, mx.array]:
         """Compute embeddings for text with images."""
         input_ids, pixel_values, attention_mask, other_model_inputs = (
             common_process_prompt_with_images(
@@ -81,4 +80,4 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
             input_ids,
             attention_mask,
         )
-        return (mx.array([]), final_inputs_embeds.squeeze(0))  # remove batch dimension
+        return mx.array([]), final_inputs_embeds.squeeze(0)  # remove batch dimension

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -93,7 +93,8 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
         assert input_ids is not None
 
         # See mlx_vlm.models.gemma3n.gemma3n.Model.get_input_embeddings
-        # The implementation differs slightly from mlx-vlm in the bounds on the vision_mask
+        # This implementation was based on commit mlx-vlm commit ebafa5a789ed1a8e050b8366ae4e845dbe640b90
+        # It differs slightly from mlx-vlm in the bounds on the vision_mask.
         # However, the two calculations should be equivalent (vision vocab offset + size) == audio vocab offset
         inputs_embeds = text_model.model.language_model.embed_tokens(input_ids)
         vision_mask = mx.logical_and(

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -86,7 +86,7 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
         prompt_tokens: mx.array,
         images_b64: list[str],
     ) -> tuple[mx.array, mx.array]:
-        """Compute embeddings for text with images."""
+        """Compute input_ids and embeddings for text with images."""
         input_ids, pixel_values, attention_mask, other_model_inputs = (
             common_process_prompt_with_images(
                 prompt_tokens=prompt_tokens,

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -1,0 +1,141 @@
+from typing import List, Tuple
+from pathlib import Path
+
+from mlx import nn
+import mlx.core as mx
+
+from mlx_vlm.models.gemma3n import (
+    VisionModel as Gemma3nVisionTower,
+    ModelConfig as Gemma3nModelConfig,
+    VisionConfig as Gemma3nVisionConfig,
+    TextConfig as Gemma3nTextConfig,
+    Model as Gemma3nCombinedModel,  # for prepare_inputs_for_multimodal
+)
+from mlx_vlm.models.gemma3n.gemma3n import Gemma3nMultimodalEmbedder
+from mlx_vlm.utils import sanitize_weights, load_processor
+from mlx_engine.logging import log_info
+
+from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
+from mlx_engine.model_kit.vision_add_ons.process_prompt_with_images import (
+    common_process_prompt_with_images,
+)
+from mlx_engine.model_kit.vision_add_ons.load_utils import (
+    load_and_filter_weights,
+    load_and_parse_config,
+    maybe_apply_quantization,
+    prepare_components,
+)
+
+
+class Gemma3nVisionProjector(Gemma3nMultimodalEmbedder):
+    """Compatability layer between embedder and expected projector interface"""
+
+    def __init__(self, config: Gemma3nModelConfig):
+        super().__init__(config.vision_config, config.text_config)
+
+
+class Gemma3nVisionComponents(nn.Module):
+    def __init__(self, vision_tower: nn.Module, embed_vision: nn.Module):
+        super().__init__()
+        self.vision_tower = vision_tower
+        self.embed_vision = embed_vision
+
+
+class Gemma3nVisionAddOn(BaseVisionAddOn):
+    """
+    Vision add-on for Gemma3n model. Uses mlx-vlm vision components of Gemma3n.
+    """
+
+    GEMMA3N_LOG_PREFIX = "Gemma3nVisionAddOn"
+
+    def __init__(self, model_path: Path):
+        """Initialize Gemma3nVisionAddOn with vision components loaded from the given path."""
+        super().__init__()
+
+        config, config_dict = load_and_parse_config(
+            model_path=model_path,
+            model_config_class=Gemma3nModelConfig,
+            vision_config_class=Gemma3nVisionConfig,
+            text_config_class=Gemma3nTextConfig,
+        )
+
+        components = Gemma3nVisionComponents(
+            vision_tower=Gemma3nVisionTower(config.vision_config),
+            embed_vision=Gemma3nVisionProjector(config),
+        )
+        processor = load_processor(model_path=model_path, add_detokenizer=True)
+        vision_weights = load_and_filter_weights(model_path, components)
+        vision_weights = sanitize_weights(
+            components.vision_tower.__class__, vision_weights, config.vision_config
+        )
+        maybe_apply_quantization(components, config_dict, vision_weights)
+        prepare_components(components, vision_weights)
+
+        log_info(
+            prefix=self.GEMMA3N_LOG_PREFIX,
+            message=f"Vision add-on loaded successfully from {model_path}",
+        )
+
+        self.vision_tower = components.vision_tower
+        self.embed_vision = components.embed_vision
+        self.config = config
+        self.processor = processor
+
+    def compute_embeddings(
+        self,
+        text_model: nn.Module,
+        prompt_tokens: mx.array,
+        images_b64: List[str],
+    ) -> Tuple[mx.array, mx.array]:
+        """Compute embeddings for text with images."""
+        input_ids, pixel_values, attention_mask, other_model_inputs = (
+            common_process_prompt_with_images(
+                prompt_tokens=prompt_tokens,
+                images_b64=images_b64,
+                processor=self.processor,
+                config=self.config,
+            )
+        )
+        assert input_ids is not None
+
+        # See mlx_vlm.models.gemma3n.gemma3n.Model.get_input_embeddings
+        # The implementation differs slightly from mlx-vlm in the bounds on the vision_mask
+        # However, the two calculations should be equivalent (vision vocab offset + size) == audio vocab offset
+        inputs_embeds = text_model.model.language_model.embed_tokens(input_ids)
+        vision_mask = mx.logical_and(
+            input_ids >= self.embed_vision.vocab_offset,
+            input_ids < self.embed_vision.vocab_offset + self.embed_vision.vocab_size,
+        )
+        dummy_vision_token_id = (
+            self.embed_vision.vocab_offset + self.embed_vision.vocab_size - 1
+        )
+        vision_tokens = mx.where(vision_mask, input_ids, dummy_vision_token_id)
+        vision_embeds_flat = self.embed_vision(input_ids=vision_tokens)
+        inputs_embeds = mx.where(
+            vision_mask[..., None], vision_embeds_flat, inputs_embeds
+        )
+
+        # Process image through vision tower, then embed into language model space
+        image_features = Gemma3nCombinedModel.get_image_features(
+            pixel_values,
+            self.vision_tower,
+            self.config,
+            self.embed_vision,
+        )
+
+        # Construct mask that matches image embedding locations
+        special_modality_mask = mx.expand_dims(
+            input_ids == self.config.image_token_id, -1
+        )
+        special_modality_mask = mx.broadcast_to(
+            special_modality_mask, inputs_embeds.shape
+        )
+
+        # Construct embeddings with image and text tokens interleaved per special modality mask
+        final_inputs_embeds = Gemma3nCombinedModel.prepare_inputs_for_multimodal(
+            inputs_embeds, image_features, "image", special_modality_mask
+        )
+        return (
+            input_ids.squeeze(0),
+            final_inputs_embeds.squeeze(0),
+        )  # remove batch dimension

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -26,13 +26,6 @@ from mlx_engine.model_kit.vision_add_ons.load_utils import (
 )
 
 
-class Gemma3nVisionProjector(Gemma3nMultimodalEmbedder):
-    """Compatability layer between embedder and expected projector interface"""
-
-    def __init__(self, config: Gemma3nModelConfig):
-        super().__init__(config.vision_config, config.text_config)
-
-
 class Gemma3nVisionComponents(nn.Module):
     def __init__(self, vision_tower: nn.Module, embed_vision: nn.Module):
         super().__init__()
@@ -60,7 +53,9 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
 
         components = Gemma3nVisionComponents(
             vision_tower=Gemma3nVisionTower(config.vision_config),
-            embed_vision=Gemma3nVisionProjector(config),
+            embed_vision=Gemma3nMultimodalEmbedder(
+                config.vision_config, config.text_config
+            ),
         )
         processor = load_processor(model_path=model_path, add_detokenizer=True)
         vision_weights = load_and_filter_weights(model_path, components)

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -9,7 +9,7 @@ from mlx_vlm.models.gemma3n import (
     ModelConfig as Gemma3nModelConfig,
     VisionConfig as Gemma3nVisionConfig,
     TextConfig as Gemma3nTextConfig,
-    Model as Gemma3nCombinedModel,  # for prepare_inputs_for_multimodal
+    Model as Gemma3nCombinedModel,
 )
 from mlx_vlm.models.gemma3n.gemma3n import Gemma3nMultimodalEmbedder
 from mlx_vlm.utils import sanitize_weights, load_processor

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -1,4 +1,3 @@
-from typing import List, Tuple
 from pathlib import Path
 
 from mlx import nn
@@ -85,8 +84,8 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
         self,
         text_model: nn.Module,
         prompt_tokens: mx.array,
-        images_b64: List[str],
-    ) -> Tuple[mx.array, mx.array]:
+        images_b64: list[str],
+    ) -> tuple[mx.array, mx.array]:
         """Compute embeddings for text with images."""
         input_ids, pixel_values, attention_mask, other_model_inputs = (
             common_process_prompt_with_images(
@@ -135,7 +134,6 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
         final_inputs_embeds = Gemma3nCombinedModel.prepare_inputs_for_multimodal(
             inputs_embeds, image_features, "image", special_modality_mask
         )
-        return (
-            input_ids.squeeze(0),
-            final_inputs_embeds.squeeze(0),
+        return input_ids.squeeze(0), final_inputs_embeds.squeeze(
+            0
         )  # remove batch dimension

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -134,6 +134,5 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
         final_inputs_embeds = Gemma3nCombinedModel.prepare_inputs_for_multimodal(
             inputs_embeds, image_features, "image", special_modality_mask
         )
-        return input_ids.squeeze(0), final_inputs_embeds.squeeze(
-            0
-        )  # remove batch dimension
+        # remove batch dimension
+        return input_ids.squeeze(0), final_inputs_embeds.squeeze(0)

--- a/mlx_engine/model_kit/vision_add_ons/pixtral.py
+++ b/mlx_engine/model_kit/vision_add_ons/pixtral.py
@@ -1,4 +1,3 @@
-from typing import List, Tuple
 from pathlib import Path
 
 from mlx import nn
@@ -50,8 +49,8 @@ class PixtralVisionAddOn(BaseVisionAddOn):
         self,
         text_model: nn.Module,
         prompt_tokens: mx.array,
-        images_b64: List[str],
-    ) -> Tuple[mx.array, mx.array]:
+        images_b64: list[str],
+    ) -> tuple[mx.array, mx.array]:
         """Compute embeddings for text with images."""
         input_ids, pixel_values, attention_mask, other_model_inputs = (
             common_process_prompt_with_images(
@@ -85,4 +84,4 @@ class PixtralVisionAddOn(BaseVisionAddOn):
         final_inputs_embeds = PixtralCombinedModel.merge_input_ids_with_image_features(
             self.config.image_token_index, image_features, input_embeddings, input_ids
         )
-        return (mx.array([]), final_inputs_embeds.squeeze(0))  # remove batch dimension
+        return mx.array([]), final_inputs_embeds.squeeze(0)  # remove batch dimension

--- a/mlx_engine/model_kit/vision_add_ons/pixtral.py
+++ b/mlx_engine/model_kit/vision_add_ons/pixtral.py
@@ -51,7 +51,7 @@ class PixtralVisionAddOn(BaseVisionAddOn):
         prompt_tokens: mx.array,
         images_b64: list[str],
     ) -> tuple[mx.array, mx.array]:
-        """Compute embeddings for text with images."""
+        """Compute input_ids and embeddings for text with images."""
         input_ids, pixel_values, attention_mask, other_model_inputs = (
             common_process_prompt_with_images(
                 prompt_tokens=prompt_tokens,
@@ -84,5 +84,5 @@ class PixtralVisionAddOn(BaseVisionAddOn):
         final_inputs_embeds = PixtralCombinedModel.merge_input_ids_with_image_features(
             self.config.image_token_index, image_features, input_embeddings, input_ids
         )
-        # pixtral generation does not require input_ids, so we return an empty array
-        return mx.array([]), final_inputs_embeds.squeeze(0)  # remove batch dimension
+        # remove batch dimension
+        return input_ids.squeeze(0), final_inputs_embeds.squeeze(0)

--- a/mlx_engine/model_kit/vision_add_ons/pixtral.py
+++ b/mlx_engine/model_kit/vision_add_ons/pixtral.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 from pathlib import Path
 
 from mlx import nn
@@ -51,7 +51,7 @@ class PixtralVisionAddOn(BaseVisionAddOn):
         text_model: nn.Module,
         prompt_tokens: mx.array,
         images_b64: List[str],
-    ) -> mx.array:
+    ) -> Tuple[mx.array, mx.array]:
         """Compute embeddings for text with images."""
         input_ids, pixel_values, attention_mask, other_model_inputs = (
             common_process_prompt_with_images(
@@ -85,4 +85,4 @@ class PixtralVisionAddOn(BaseVisionAddOn):
         final_inputs_embeds = PixtralCombinedModel.merge_input_ids_with_image_features(
             self.config.image_token_index, image_features, input_embeddings, input_ids
         )
-        return final_inputs_embeds.squeeze(0)  # remove batch dimension
+        return (mx.array([]), final_inputs_embeds.squeeze(0))  # remove batch dimension

--- a/mlx_engine/model_kit/vision_add_ons/pixtral.py
+++ b/mlx_engine/model_kit/vision_add_ons/pixtral.py
@@ -84,4 +84,5 @@ class PixtralVisionAddOn(BaseVisionAddOn):
         final_inputs_embeds = PixtralCombinedModel.merge_input_ids_with_image_features(
             self.config.image_token_index, image_features, input_embeddings, input_ids
         )
+        # pixtral generation does not require input_ids, so we return an empty array
         return mx.array([]), final_inputs_embeds.squeeze(0)  # remove batch dimension

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,9 @@ jsonschema-specifications==2025.4.1
 jsonschema==4.24.0
 lark==1.2.2
 markupsafe==2.1.5
-mlx-lm==0.25.2
-mlx-vlm==0.2.0
+# Temporarily point to the branches that support Gemma3n unification
+mlx-lm @ git+https://github.com/will-lms/mlx-lm.git@will/gemma3n-unified
+mlx-vlm @ git+https://github.com/will-lms/mlx-vlm.git@will/gemma3n-mm-embed-hooks
 mlx==0.26.1
 mpmath==1.3.0
 multidict==6.4.3

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -401,19 +401,14 @@ Summarize this in one sentence<end_of_turn>
     def test_gemma3n_vision(self):
         """Test gemma 3n model"""
         prompt = f"<bos><start_of_turn>user\n<image_soft_token>{self.description_prompt}<end_of_turn>\n<start_of_turn>model\n"
-        self.toucan_test_runner("lmstudio-community/gemma-3n-E2B-it-MLX-bf16", prompt)
+        self.toucan_test_runner("lmstudio-community/gemma-3n-E2B-it-MLX-4bit", prompt)
 
     def test_gemma3n_text_only(self):
         """Test gemma 3n model text only"""
         prompt = f"<bos><start_of_turn>user\n{self.text_only_prompt}<end_of_turn>\n<start_of_turn>model\n"
         self.toucan_test_runner(
-            "lmstudio-community/gemma-3n-E2B-it-MLX-bf16", prompt, text_only=True
+            "lmstudio-community/gemma-3n-E2B-it-MLX-4bit", prompt, text_only=True
         )
-
-    def test_gemma3n_vision_quant(self):
-        """Test gemma 3n model"""
-        prompt = f"<bos><start_of_turn>user\n<image_soft_token>{self.description_prompt}<end_of_turn>\n<start_of_turn>model\n"
-        self.toucan_test_runner("lmstudio-community/gemma-3n-E2B-it-MLX-4bit", prompt)
 
     # TODO(will): Parameterize and de-dup
     def test_gemma3n_text_only_generation_caching(self):

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -8,8 +8,6 @@ from mlx_engine.generate import (
     is_draft_model_compatible,
 )
 from .utils import model_getter
-import sys
-import subprocess
 from textwrap import dedent
 
 
@@ -17,7 +15,6 @@ class TestVisionModels(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up test resources that will be shared across all test methods"""
-        cls.model_path_prefix = Path("~/.cache/lm-studio/models").expanduser().resolve()
         cls.description_prompt = "What is this"
         cls.text_only_prompt = "What is a toucan?"
         cls.test_data_dir = Path(__file__).parent / "data"
@@ -38,25 +35,7 @@ class TestVisionModels(unittest.TestCase):
     def toucan_test_runner(self, model_name: str, prompt: str, text_only=False):
         """Helper method to test a single vision model"""
         print(f"Testing model {model_name}")
-
-        model_path = self.model_path_prefix / model_name
-
-        # Check if model exists, if not prompt user to download
-        if not model_path.exists():
-            print(f"\nModel {model_name} not found at {model_path}")
-
-            def greenify(text):
-                return f"\033[92m{text}\033[0m"
-
-            response = input(
-                f"Would you like to download the model {greenify(model_name)}? (y/N): "
-            )
-            if response.lower() == "y":
-                print(f"Downloading model with command: lms get {model_name}")
-                subprocess.run(["lms", "get", model_name], check=True)
-            else:
-                print(f"Model {model_name} not found")
-                sys.exit(1)
+        model_path = model_getter(model_name=model_name)
 
         # Load the model
         model_kit = load_model(
@@ -289,12 +268,12 @@ You are a helpful assistant.<|im_end|>
                 str(e),
             )
 
-    def test_gemma3(self):
+    def test_gemma3_vision(self):
         """Test Gemma 3 model"""
         prompt = f"<bos><start_of_turn>user\n{self.description_prompt}<start_of_image><end_of_turn>\n<start_of_turn>model\n"
         self.toucan_test_runner("mlx-community/gemma-3-4b-it-4bit", prompt)
 
-    def test_gemma3_text_only(self):
+    def test_gemma3_text_only_short(self):
         """Test Gemma 3 model"""
         prompt = f"<bos><start_of_turn>user\n{self.text_only_prompt}<end_of_turn>\n<start_of_turn>model\n"
         self.toucan_test_runner(
@@ -419,7 +398,7 @@ Summarize this in one sentence<end_of_turn>
         self.assertEqual(2, num_prompt_processing_callbacks)  # single batch - 0, 100
         self.assertIn("benjamin franklin", generated_text.lower())
 
-    def test_gemma3n(self):
+    def test_gemma3n_vision(self):
         """Test gemma 3n model"""
         prompt = f"<bos><start_of_turn>user\n<image_soft_token>{self.description_prompt}<end_of_turn>\n<start_of_turn>model\n"
         self.toucan_test_runner("lmstudio-community/gemma-3n-E2B-it-MLX-bf16", prompt)
@@ -430,6 +409,131 @@ Summarize this in one sentence<end_of_turn>
         self.toucan_test_runner(
             "lmstudio-community/gemma-3n-E2B-it-MLX-bf16", prompt, text_only=True
         )
+
+    def test_gemma3n_vision_quant(self):
+        """Test gemma 3n model"""
+        prompt = f"<bos><start_of_turn>user\n<image_soft_token>{self.description_prompt}<end_of_turn>\n<start_of_turn>model\n"
+        self.toucan_test_runner("lmstudio-community/gemma-3n-E2B-it-MLX-4bit", prompt)
+
+    # TODO(will): Parameterize and de-dup
+    def test_gemma3n_text_only_generation_caching(self):
+        """Ensure that text only prompts with vlms take full advantage of caching generated tokens"""
+        model_path = model_getter("lmstudio-community/gemma-3n-E2B-it-MLX-4bit")
+        model_kit = load_model(model_path=model_path, max_kv_size=4096)
+
+        def generate_text(prompt):
+            prompt_tokens = tokenize(model_kit, prompt)
+            num_prompt_processing_callbacks = 0
+
+            def progress_callback(progress: float) -> None:
+                nonlocal num_prompt_processing_callbacks
+                num_prompt_processing_callbacks += 1
+                print(f"Prompt processing progress: {progress}")
+
+            generated_text = ""
+            for result in create_generator(
+                model_kit=model_kit,
+                prompt_tokens=prompt_tokens,
+                seed=0,
+                temp=0.0,
+                max_tokens=1000,
+                repetition_penalty=1.01,  # to enable this code path
+                prompt_progress_callback=progress_callback,
+            ):
+                generated_text += result.text
+                print(result.text, end="", flush=True)
+                if result.stop_condition:
+                    break
+            print("\n", flush=True)
+            return generated_text, num_prompt_processing_callbacks
+
+        # Generation 1 - model creates a long story
+        prompt = dedent("""\
+            <bos><start_of_turn>user
+            Tell me a 500-word story<end_of_turn>
+            <start_of_turn>model
+            """)
+        generated_text, num_prompt_processing_callbacks = generate_text(prompt)
+        self.assertEqual(num_prompt_processing_callbacks, 2)  # single batch - 0, 100
+        self.assertIn("silas", generated_text.lower())
+
+        # Generation 2 - ask for a detail about the story, should not reprocess
+        prompt += generated_text + dedent("""\
+            <end_of_turn>
+            <start_of_turn>user
+            What was the main characters name?<end_of_turn>
+            <start_of_turn>model
+            """)
+        num_tokens = len(model_kit.tokenize(prompt))
+        # Without caching, prompts > 512 tokens cause multi-batch processing. Ensure prompt meets that condition
+        self.assertGreater(num_tokens, 512)
+        generated_text, num_prompt_processing_callbacks = generate_text(prompt)
+        self.assertEqual(2, num_prompt_processing_callbacks)  # single batch - 0, 100
+        self.assertIn("silas", generated_text.lower())
+
+    # TODO(will): Parameterize and de-dup
+    def test_gemma3n_text_only_long_original_prompt_caching(self):
+        """Ensure that text only prompts with vlms take full advantage of caching generated tokens"""
+        model_path = model_getter("lmstudio-community/gemma-3n-E2B-it-MLX-4bit")
+        model_kit = load_model(model_path=model_path, max_kv_size=4096)
+
+        def generate_text(prompt):
+            prompt_tokens = tokenize(model_kit, prompt)
+            num_prompt_processing_callbacks = 0
+
+            def progress_callback(progress: float) -> None:
+                nonlocal num_prompt_processing_callbacks
+                num_prompt_processing_callbacks += 1
+                print(f"Prompt processing progress: {progress}")
+
+            generated_text = ""
+            for result in create_generator(
+                model_kit=model_kit,
+                prompt_tokens=prompt_tokens,
+                seed=0,
+                temp=0.0,
+                max_tokens=1000,
+                repetition_penalty=1.01,  # to enable this code path
+                prompt_progress_callback=progress_callback,
+            ):
+                generated_text += result.text
+                print(result.text, end="", flush=True)
+                if result.stop_condition:
+                    break
+            print("\n", flush=True)
+            return generated_text, num_prompt_processing_callbacks
+
+        # Generation 1 - send model a long excerpt to summarize
+        file_path = self.test_data_dir / "ben_franklin_autobiography_start.txt"
+        file_content = file_path.read_text()
+        # don't use dedent below b/c file content doesn't match indentation on each newline
+        prompt = f"""\
+<bos><start_of_turn>user
+```
+{file_content}
+```
+Summarize this in one sentence<end_of_turn>
+<start_of_turn>model
+"""
+        num_tokens = len(model_kit.tokenize(prompt))
+        self.assertGreater(num_tokens, 1024)
+        generated_text, num_prompt_processing_callbacks = generate_text(prompt)
+        self.assertEqual(
+            4, num_prompt_processing_callbacks
+        )  # 4 batches, so 0, x, x, 100
+        self.assertIn("benjamin franklin", generated_text.lower())
+
+        # Generation 2 - ask for a detail about the excerpt, should not reprocess
+        prompt += generated_text + dedent("""\
+                <end_of_turn>
+                <start_of_turn>user
+                What was the main characters name?<end_of_turn>
+                <start_of_turn>model
+                """)
+        print(prompt)
+        generated_text, num_prompt_processing_callbacks = generate_text(prompt)
+        self.assertEqual(2, num_prompt_processing_callbacks)  # single batch - 0, 100
+        self.assertIn("benjamin franklin", generated_text.lower())
 
     ### NON-MODEL-SPECIFIC TESTS ###
     def test_draft_model_not_compatible_vision(self):


### PR DESCRIPTION
This PR introduces the necessary change to run Gemma3n as a unified model. The major portions of this are:

**1) Patch mlx-lm for compatibility with mlx-vlm models**
There are inconsistencies between how mlx-vlm writes the converted model and how mlx-lm expects to read the converted model. See the comments in the `model_kit/patches/gemma3n.py` file for details on the two changes.

**2) Create Gemma3n Vision Add-on**
I created the Gemma3n vision add on based on the mlx-vlm implementation.

The interface was not compatible with our existing vision add-on base class. Specifically, the mlx-lm Gemma3n model requires that `input_ids` (i.e. expanded prompt tokens) be provided to the call operator along with input embeddings. Previous models had only required the latter as input.

I updated the `compute_embeddings` method to return both `input_ids` and `input_embeddings` for all models. The newly returned value is disregarded by the pixtral and gemma implementations in mlx-lm anyway, but it makes them consistent with the gemma3n required interface.

**3) Upstream changes**
This change requires the changes in
 - [mlx-lm PR \#266](https://github.com/ml-explore/mlx-lm/pull/266)
 - [mlx-vlm PR \#407](https://github.com/Blaizzy/mlx-vlm/pull/407)

See the conversations in those PRs for more details.