### PR TITLE
Bump mlx-lm to 0.26.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,8 @@ jsonschema-specifications==2025.4.1
 jsonschema==4.24.0
 lark==1.2.2
 markupsafe==2.1.5
+mlx-lm==0.26.0
 # Temporarily point to the branches that support Gemma3n unification
-mlx-lm @ git+https://github.com/ml-explore/mlx-lm.git@main
 mlx-vlm @ git+https://github.com/will-lms/mlx-vlm.git@will/gemma3n-mm-embed-hooks
 mlx==0.26.3
 mpmath==1.3.0


### PR DESCRIPTION
Depend on `mlx==0.26.0` instead of `main`. This release now includes the gemma3n changes.