### PR TITLE
Fix vision_model_load quantize

### DIFF
--- a/mlx_engine/model_kit/vision_add_ons/load_utils.py
+++ b/mlx_engine/model_kit/vision_add_ons/load_utils.py
@@ -141,10 +141,15 @@ def maybe_apply_quantization(
             # Handle legacy models which may not have everything quantized
             return f"{p}.scales" in vision_weights
 
+        quantize_kwargs = {}
+        if "bits" in quantization:
+            quantize_kwargs["bits"] = quantization["bits"]
+        if "group_size" in quantization:
+            quantize_kwargs["group_size"] = quantization["group_size"]
         nn.quantize(
             components,
-            **quantization,
             class_predicate=get_class_predicate,
+            **quantize_kwargs,
         )
 
 


### PR DESCRIPTION
Fixes `TypeError: quantize() got an unexpected keyword argument 'language_model.model.embed_tokens'`

This error is happening because MLX quantization configs now include keys of the layers. [Example](https://huggingface.co/mlx-community/ERNIE-4.5-300B-A47B-PT-4bit/blob/main/config.json#L38)