### PR TITLE
[Mistral3] Send empty (instead of fake) input IDs

### DIFF
--- a/mlx_engine/model_kit/vision_add_ons/mistral3.py
+++ b/mlx_engine/model_kit/vision_add_ons/mistral3.py
@@ -100,8 +100,5 @@ class Mistral3VisionAddOn(BaseVisionAddOn):
         if input_ids.shape[1] == final_inputs_embeds.shape[1]:
             return input_ids.squeeze(0), final_inputs_embeds.squeeze(0)
         # Do not return input_ids b/c the original lmstudio-community MLX upload had an incorrect
-        # processor_config.json that caused input_ids have extra placeholder image tokens. Fake the
-        # values with the correct length of 0s for compatibility with the mlx-lm generate_step API.
-        return mx.zeros(
-            final_inputs_embeds.shape[1], mx.int32
-        ), final_inputs_embeds.squeeze(0)
+        # processor_config.json that caused input_ids have extra placeholder image tokens.
+        return mx.array([]), final_inputs_embeds.squeeze(0)


### PR DESCRIPTION
Now that [Allow empty prompt with input_embeddings #308](https://github.com/ml-explore/mlx-lm/pull/308) has been merged, we can return empty embeddings instead of fake ones. The two are effectively equivalent, but I think this is cleaner / less hacky.