### PR TITLE
Stop prompt processing upon user request

### DIFF
--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -12,7 +12,7 @@ import mlx.nn as nn
 import sys
 
 
-class LmsStopPromptProcessing(Exception):
+class StopPromptProcessing(Exception):
     """
     Exception to signal that the user aborted generation during prompt processing.
     """
@@ -234,7 +234,7 @@ class CacheWrapper:
                 else:
                     # Remember which tokens were processed so far, so that we can continue processing at a later point
                     self.tokens = self.tokens[:num_tokens_in_cache]
-                raise LmsStopPromptProcessing
+                raise StopPromptProcessing
 
     def set_draft_model(self, draft_model: nn.Module):
         """

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -25,7 +25,7 @@ from mlx_engine.utils.speculative_decoding import (
 )
 from outlines.processors.structured import JSONLogitsProcessor
 from mlx_engine.utils.outlines_transformer_tokenizer import OutlinesTransformerTokenizer
-from mlx_engine.cache_wrapper import LmsStopPromptProcessing
+from mlx_engine.cache_wrapper import StopPromptProcessing
 
 MAX_TOP_LOGPROBS = 10
 
@@ -223,7 +223,7 @@ def create_generator(
             generate_args,
             speculative_decoding_toggle,
         )
-    except LmsStopPromptProcessing:
+    except StopPromptProcessing:
         yield GenerationResult(
             text="",
             tokens=[],

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, List, Tuple
+from typing import Callable, Optional, List, Tuple
 
 import mlx_lm
 from mlx_lm.tokenizer_utils import TokenizerWrapper, StreamingDetokenizer
@@ -140,8 +140,8 @@ class ModelKit:
         self,
         prompt_tokens,
         images_b64: Optional[List[str]],
-        prompt_progress_callback,
-        generate_args,
+        prompt_progress_callback: Optional[Callable[[float], bool]],
+        generate_args: dict,
         speculative_decoding_toggle: Optional[bool] = None,
     ) -> Tuple[mx.array, Optional[mx.array]]:
         ### TEXT-ONLY PROCESS_PROMPT ###

--- a/mlx_engine/utils/prompt_processing.py
+++ b/mlx_engine/utils/prompt_processing.py
@@ -9,15 +9,13 @@ from mlx_engine.cache_wrapper import CacheWrapper
 def process_prompt_text_only(
     prompt_tokens: mx.array,
     cache_wrapper: CacheWrapper,
-    generate_args: dict = None,
-    draft_model: Optional[nn.Module] = None,
-    speculative_decoding_toggle: Optional[bool] = None,
-    prompt_progress_callback: Optional[Callable[[float], None]] = None,
+    generate_args: dict,
+    draft_model: Optional[nn.Module],
+    speculative_decoding_toggle: Optional[bool],
+    prompt_progress_callback: Optional[Callable[[float], bool]],
 ):
     if cache_wrapper is None:
         raise ValueError("Cache wrapper is not initialized, cannot process prompt")
-    if generate_args is None:
-        generate_args = {}
     # Make sure cache's draft model setting aligns with speculative decoding toggle
     should_use_draft_model = (
         speculative_decoding_toggle

--- a/tests/test_cache_wrapper.py
+++ b/tests/test_cache_wrapper.py
@@ -1,6 +1,6 @@
 import unittest
 import mlx.core as mx
-from mlx_engine.cache_wrapper import CacheWrapper, LmsStopPromptProcessing
+from mlx_engine.cache_wrapper import CacheWrapper, StopPromptProcessing
 from tests.utils import model_getter
 from mlx_engine.generate import load_model, tokenize
 
@@ -51,7 +51,7 @@ class TestCacheWrapper(unittest.TestCase):
         model_kit.cache_wrapper = CacheWrapper(
             model_kit.model,
             max_kv_size=4096,
-            chunk_size=chunk_size,  
+            chunk_size=chunk_size,
         )
 
         long_prompt = (
@@ -60,7 +60,7 @@ class TestCacheWrapper(unittest.TestCase):
         )
         prompt_tokens = mx.array(tokenize(model_kit, long_prompt))
         tokens_to_process = len(prompt_tokens) - num_tokens_to_exclude
-          # ceiling division
+        # ceiling division
         expected_chunks = (tokens_to_process + chunk_size - 1) // chunk_size
 
         # First attempt: Progress callback that cancels after a few updates
@@ -72,7 +72,7 @@ class TestCacheWrapper(unittest.TestCase):
                 return False
             return True
 
-        with self.assertRaises(LmsStopPromptProcessing):
+        with self.assertRaises(StopPromptProcessing):
             model_kit.cache_wrapper.update_cache(
                 prompt_tokens=prompt_tokens,
                 prompt_progress_callback=cancelling_progress_callback,
@@ -96,7 +96,7 @@ class TestCacheWrapper(unittest.TestCase):
 
         self.assertEqual(
             second_attempt_progress_calls,
-             # +1 for the final 100% callback, +1 for the duplicate 0% callback
+            # +1 for the final 100% callback, +1 for the duplicate 0% callback
             expected_chunks - first_attempt_progress_calls + 2,
         )
 

--- a/tests/test_cache_wrapper.py
+++ b/tests/test_cache_wrapper.py
@@ -1,6 +1,8 @@
 import unittest
 import mlx.core as mx
-from mlx_engine.cache_wrapper import CacheWrapper
+from mlx_engine.cache_wrapper import CacheWrapper, LmsStopPromptProcessing
+from tests.utils import model_getter
+from mlx_engine.generate import load_model, tokenize
 
 
 class TestCacheWrapper(unittest.TestCase):
@@ -37,6 +39,100 @@ class TestCacheWrapper(unittest.TestCase):
         self.assertEqual(
             result, 4
         )  # Should find 4 matching tokens (5-1 due to num_tokens_to_exclude)
+
+    def test_prompt_processing_cancellation(self):
+        """Test that progress is saved when processing is cancelled and cache is reused on retry"""
+
+        model_path = model_getter("lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit")
+        model_kit = load_model(model_path=model_path, max_kv_size=4096)
+        model_kit.cache_wrapper = CacheWrapper(
+            model_kit.model,
+            max_kv_size=4096,
+            chunk_size=20,  # Small chunk size to ensure multiple progress callbacks
+        )
+
+        long_prompt = (
+            "This is a test prompt that needs to be long enough to require multiple chunks for processing. "
+            * 50
+        )
+        prompt_tokens = mx.array(tokenize(model_kit, long_prompt))
+        tokens_to_process = len(prompt_tokens) - 1  # minus num_tokens_to_exclude
+        expected_chunks = (
+            tokens_to_process + 19
+        ) // 20  # ceiling division for chunk_size=20
+
+        # First attempt: Progress callback that cancels after a few updates
+        first_progress_calls = []
+
+        def cancelling_progress_callback(progress):
+            first_progress_calls.append(progress)
+            if len(first_progress_calls) >= 3:
+                return False
+            return True
+
+        with self.assertRaises(LmsStopPromptProcessing):
+            model_kit.cache_wrapper.update_cache(
+                prompt_tokens=prompt_tokens,
+                prompt_progress_callback=cancelling_progress_callback,
+                num_tokens_to_exclude=1,
+            )
+        first_attempt_progress_calls = len(first_progress_calls)
+
+        # Second attempt: Progress callback that doesn't cancel
+        second_progress_calls = []
+
+        def non_cancelling_progress_callback(progress):
+            second_progress_calls.append(progress)
+            return True
+
+        result_tokens = model_kit.cache_wrapper.update_cache(
+            prompt_tokens=prompt_tokens,
+            prompt_progress_callback=non_cancelling_progress_callback,
+            num_tokens_to_exclude=1,
+        )
+        second_attempt_progress_calls = len(second_progress_calls)
+
+        # Calculate total work that would be done if no caching occurred
+        total_work_without_cache = (
+            expected_chunks * 2
+        )  # Both attempts would do full work
+
+        # Calculate actual work done (first attempt partial + second attempt remaining)
+        actual_work_done = (
+            first_attempt_progress_calls + second_attempt_progress_calls - 1
+        )  # -1 because both start with 0%
+
+        # Verify that progress was preserved:
+        # The total work done should be less than doing the full work twice
+        self.assertLess(
+            actual_work_done,
+            total_work_without_cache,
+            f"Cache should prevent duplicate work. Actual: {actual_work_done}, Without cache: {total_work_without_cache}",
+        )
+
+        # Verify that the second attempt had fewer progress callbacks than expected for full processing
+        # because some tokens were already cached from the first attempt
+        self.assertLess(
+            second_attempt_progress_calls,
+            expected_chunks + 1,  # +1 for the initial 0% callback
+            f"Second attempt should have fewer progress callbacks due to cached progress. "
+            f"Second: {second_attempt_progress_calls}, Expected for full: {expected_chunks + 1}",
+        )
+
+        # Verify that the second attempt completed successfully
+        self.assertIsNotNone(result_tokens)
+
+        # Verify that progress callbacks were called in both attempts
+        self.assertGreaterEqual(
+            first_attempt_progress_calls,
+            3,
+            "First attempt should have at least 3 progress calls before cancellation",
+        )
+        self.assertGreaterEqual(
+            second_attempt_progress_calls,
+            2,
+            "Second attempt should have at least 2 progress calls (0% and 100%)",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_text_models.py
+++ b/tests/test_text_models.py
@@ -69,10 +69,11 @@ Who is this passage about? Only say the name, and nothing else<|im_end|>
         generated_text = ""
         prompt_progress_callback_times_called = 0
 
-        def prompt_progress_callback(progress: float) -> None:
+        def prompt_progress_callback(progress: float) -> bool:
             nonlocal prompt_progress_callback_times_called
             prompt_progress_callback_times_called += 1
             print(f"Prompt Progress: {progress:.2f}")
+            return True
 
         def generate() -> None:
             nonlocal generated_text
@@ -146,10 +147,11 @@ Who is this passage about? Only say the name, and nothing else<end_of_turn>
         generated_text_list_1 = []
         prompt_progress_callback_times_called = 0
 
-        def prompt_progress_callback(progress: float) -> None:
+        def prompt_progress_callback(progress: float) -> bool:
             nonlocal prompt_progress_callback_times_called
             prompt_progress_callback_times_called += 1
             print(f"Prompt Progress: {progress:.2f}")
+            return True
 
         # accumulating to list allows pass by reference
         def generate(text_accumulator: list) -> None:


### PR DESCRIPTION
When clicking the stop button in LM Studio during prompt processing, `mlx-engine` does not respond and keeps processing the entire prompt.

Fix this by checking the return value of the prompt_processing callback. If the callback return False, stop gracefully.

Care was taken to ensure that the prompt processing work that was done until the cancellation request is saved, so that upon retry the calculations are not repeated.

I tested in app with multiple models, and with speculative decoding enabled and disabled.


https://github.com/user-attachments/assets/cfd38c4d-ae09-463f-8255-58953763fc90

