### PR TITLE
Add a fix for outlines handling of the Ernie tokenizer

### DIFF
--- a/mlx_engine/model_kit/__init__.py
+++ b/mlx_engine/model_kit/__init__.py
@@ -6,5 +6,7 @@ by replacing classes in their respective modules with derived, compatible versio
 """
 
 from .patches.gemma3n import apply_patches as _apply_patches_gemma3n
+from .patches.ernie_4_5 import apply_patches as _apply_patches_ernie_4_5
 
 _apply_patches_gemma3n()
+_apply_patches_ernie_4_5()

--- a/mlx_engine/model_kit/patches/ernie_4_5.py
+++ b/mlx_engine/model_kit/patches/ernie_4_5.py
@@ -1,0 +1,11 @@
+import re
+
+import outlines_core.fsm.regex
+
+
+def apply_patches():
+    """
+    Apply patches to the outlines_core module.
+    """
+    # Update the replacement regex to fix the ernie tokenizer
+    outlines_core.fsm.regex.re_replacement_seq = re.compile(r"^▁*\.*>*�+\.*s*@*(�@)*$")

--- a/mlx_engine/model_kit/patches/ernie_4_5.py
+++ b/mlx_engine/model_kit/patches/ernie_4_5.py
@@ -1,5 +1,15 @@
-import re
+""" "
+Patch outlines_core to handler ERNIE tokenizer.
+Specifically, fix the handling of these tokens:
+- `>�`
+- `�@`
+- `�@�@`
 
+An issue is opened in outlines_core tracking this issue:
+https://github.com/dottxt-ai/outlines-core/issues/222
+"""
+
+import re
 import outlines_core.fsm.regex
 
 
@@ -8,4 +18,5 @@ def apply_patches():
     Apply patches to the outlines_core module.
     """
     # Update the replacement regex to fix the ernie tokenizer
+    # Patching this line https://github.com/dottxt-ai/outlines-core/blob/0.1.26/python/outlines_core/fsm/regex.py#L349
     outlines_core.fsm.regex.re_replacement_seq = re.compile(r"^▁*\.*>*�+\.*s*@*(�@)*$")


### PR DESCRIPTION
This PR fixes `outlines` handling of the Ernie tokenizer, by expanding the replacement character regex.

This technique is used for other tokenizers containing this character, [example here](https://github.com/dottxt-ai/outlines-core/blob/0.1.26/python/outlines_core/fsm/regex.py#L345).

I opened up an issue upstream here: https://github.com/dottxt-ai/outlines-core/issues/222