### PR TITLE
EOT tokens for gpt-oss

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -306,7 +306,7 @@ def create_generator(
 
     # Add eot token ids to tokenizer
     tokenizer.eos_token_ids = tokenizer.eos_token_ids.union(
-        get_eot_token_ids(tokenizer)
+        get_eot_token_ids(tokenizer, model_kit.model_type)
     )
 
     # Set up stop string processor if non-empty stop_strings are provided

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -52,6 +52,7 @@ class ModelKit:
     kv_group_size: Optional[int] = None
     quantized_kv_start: Optional[int] = None
     draft_model: Optional[nn.Module] = None
+    model_type: Optional[str] = None
 
     # multi-modal add-ons
     vision_add_on: Optional[BaseVisionAddOn] = None
@@ -88,7 +89,7 @@ class ModelKit:
         self.model_path = model_path
         log_info(prefix=LOG_PREFIX, message=f"Loading model from {model_path}...")
         config_json = json.loads((model_path / "config.json").read_text())
-        model_type = config_json.get("model_type", None)
+        self.model_type = config_json.get("model_type", None)
 
         self.model, self.tokenizer = mlx_lm.utils.load(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer
@@ -102,7 +103,7 @@ class ModelKit:
         self.kv_bits = kv_bits
         self.kv_group_size = kv_group_size
         self.quantized_kv_start = quantized_kv_start
-        vision_add_on_class = self.VISION_ADD_ON_MAP.get(model_type)
+        vision_add_on_class = self.VISION_ADD_ON_MAP.get(self.model_type)
         should_load_vision_add_on = (
             vision_add_on_class is not None and "vision_config" in config_json
         )

--- a/mlx_engine/utils/eot_tokens.py
+++ b/mlx_engine/utils/eot_tokens.py
@@ -1,5 +1,7 @@
+from typing import Optional
+
 # Taken from https://github.com/ggml-org/llama.cpp/blob/971f245/src/llama-vocab.cpp#L1807-L1814
-EOT_TOKENS = [
+DEFAULT_EOT_TOKENS = [
     "<|eot_id|>",
     "<|im_end|>",
     "<|end|>",
@@ -10,16 +12,26 @@ EOT_TOKENS = [
     "<｜end▁of▁sentence｜>",
 ]
 
+MODEL_TYPE_TO_EOT_TOKENS = {"gpt_oss": ["<|return|>", "<|call|>"]}
 
-def get_eot_token_ids(tokenizer) -> set[int]:
+
+def get_eot_token_ids(tokenizer, model_type: Optional[str] = None) -> set[int]:
     """
     Get the token ID of common end-of-text tokens, using the provided tokenizer.
 
-    If the EOT token str cannot be converted into a single token ID, it is discarded as a candidate
+    If the EOT token str cannot be converted into a single token ID, it is discarded as a candidate.
     """
+    if (
+        isinstance(model_type, str)
+        and len(MODEL_TYPE_TO_EOT_TOKENS.get(model_type, [])) > 0
+    ):
+        eot_tokens = MODEL_TYPE_TO_EOT_TOKENS[model_type]
+    else:
+        eot_tokens = DEFAULT_EOT_TOKENS
+
     # Convert EOT tokens to token IDs
     eot_token_ids = [
-        tokenizer.encode(eot_str, add_special_tokens=False) for eot_str in EOT_TOKENS
+        tokenizer.encode(eot_str, add_special_tokens=False) for eot_str in eot_tokens
     ]
 
     # Find all elements that are either a single integer or a list with a single integer


### PR DESCRIPTION
The `gpt-oss` model uses `"[<|return|>", "<|call|>"]` as EOT tokens. I hard-code those in here based on the model's `model_type`.