### PR TITLE
[Tests] Make Qwen2.5 images across messages test more flexible

### DIFF
--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -259,8 +259,17 @@ You are a helpful assistant.<|im_end|>
 <|im_start|>assistant
 """
         images_b64 = [self.toucan_image_b64]
-        unified_generated_text = generate_text(prompt, images_b64)
-        self.assertIn("toucan", unified_generated_text.lower())
+        generated_text = generate_text(prompt, images_b64)
+        # The logits for "Bird" and "T" are incredibly close to each other for this generation.
+        # Therefore, accept either to reduce flakiness, as both "toucan" and "bird" are acceptable.
+        acceptable_words = ["toucan", "bird"]
+        is_word_accepted = any(
+            word in generated_text.lower() for word in acceptable_words
+        )
+        self.assertTrue(
+            is_word_accepted,
+            f"Expected one of {acceptable_words} but got {generated_text.lower()}",
+        )
 
         # Test case 2: Second image added in continued conversation
         prompt += """Toucan.<|im_end|>
@@ -269,9 +278,9 @@ You are a helpful assistant.<|im_end|>
 <|im_start|>assistant
 """
         images_b64 = [self.toucan_image_b64, self.chameleon_image_b64]
-        unified_generated_text = generate_text(prompt, images_b64)
-        self.assertIn("toucan", unified_generated_text.lower())
-        self.assertIn("chameleon", unified_generated_text.lower())
+        generated_text = generate_text(prompt, images_b64)
+        self.assertIn("toucan", generated_text.lower())
+        self.assertIn("chameleon", generated_text.lower())
 
     @unittest.skip("Unavailable since this requires trust_remote_code")
     def test_florence_vision(self):


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/39591 caused `test_qwen2_5_images_across_messages` to begin failing on certain machines.

From a M2 Ultra Mac Studio on macOS Sequoia 15.6:

**Old (or with hacking `use_fast=False`)**
```
token: T, logit: 22.53125
token: Bird, logit: 22.53125
```

**New**
```
token: Bird, logit: 22.546875
token: T, logit: 22.53125
```
This has been deemed in the realm of acceptance, and expected behavior due to warning from transformers at https://github.com/huggingface/transformers/blob/0f9ce43687d5928d01a1715d7173af29c9d6ae62/src/transformers/models/auto/image_processing_auto.py#L528-L532 that says `"This is a breaking change and may produce slightly different outputs."`

Therefore, relax the test to allow "toucan" or "bird". Also remove `unified` from the generated text variable name, as Qwen2.5VL is not unified (yet), nor should the test know that.