### PR TITLE
Add Qwen2/2.5-VL unified implementation

### DIFF
--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -13,6 +13,7 @@ from mlx_engine.model_kit.vision_add_ons.pixtral import PixtralVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.gemma3n import Gemma3nVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.mistral3 import Mistral3VisionAddOn
 from mlx_engine.model_kit.vision_add_ons.lfm2_vl import LFM2VisionAddOn
+from mlx_engine.model_kit.vision_add_ons.qwen2_vl import Qwen2_VLVisionAddOn
 from mlx_engine.utils.kv_cache_quantization import get_kv_cache_quantization_params
 from mlx_engine.utils.prompt_processing import process_prompt_text_only
 
@@ -38,6 +39,8 @@ class ModelKit:
         "lfm2-vl": LFM2VisionAddOn,
         "mistral3": Mistral3VisionAddOn,
         "pixtral": PixtralVisionAddOn,
+        "qwen2_vl": Qwen2_VLVisionAddOn,
+        "qwen2_5_vl": Qwen2_VLVisionAddOn,
     }
 
     # model state tracking

--- a/mlx_engine/model_kit/vision_add_ons/lfm2_vl.py
+++ b/mlx_engine/model_kit/vision_add_ons/lfm2_vl.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from mlx import nn
@@ -20,13 +21,13 @@ from mlx_engine.model_kit.vision_add_ons.process_prompt_with_images import (
 )
 from mlx_engine.model_kit.vision_add_ons.load_utils import load_vision_addon
 
+logger = logging.getLogger(__name__)
+
 
 class LFM2VisionAddOn(BaseVisionAddOn):
     """
     Vision add-on for LFM2 models.
     """
-
-    LOG_PREFIX = "LFM2VisionAddOn"
 
     def __init__(self, model_path: Path):
         """Initialize LFM2VisionAddOn with vision components loaded from the given path."""
@@ -40,7 +41,7 @@ class LFM2VisionAddOn(BaseVisionAddOn):
                 text_config_class=LFM2VlTextConfig,
                 vision_tower_class=LFM2VlVisionTower,
                 multi_modal_projector_class=Lfm2VlMultiModalProjector,
-                log_prefix=self.LOG_PREFIX,
+                logger=logger,
             )
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/load_utils.py
+++ b/mlx_engine/model_kit/vision_add_ons/load_utils.py
@@ -60,6 +60,12 @@ class VisionComponents(nn.Module):
         self.multi_modal_projector = multi_modal_projector
 
 
+class QwenVisionComponents(nn.Module):
+    def __init__(self, vision_tower: nn.Module):
+        super().__init__()
+        self.vision_tower = vision_tower
+
+
 def create_vision_components(
     config: Any,
     vision_tower_class: Type[nn.Module],
@@ -245,3 +251,78 @@ def load_vision_addon(
     )
 
     return components.vision_tower, components.multi_modal_projector, config, processor
+
+
+def load_qwen_vision_addon(
+    model_path: Path,
+    model_config_class: Any,
+    vision_config_class: Any,
+    text_config_class: Any,
+    vision_tower_class: Type[nn.Module],
+    logger: logging.Logger,
+) -> Tuple[nn.Module, Any, Any]:
+    """
+    Load Qwen2/2.5-VL vision add-on components, configuration, and processor.
+
+    This is a specialized version of load_vision_addon for Qwen2/2.5-VL models,
+    which only use a vision tower without a multi-modal projector.
+
+    Args:
+        model_path: Path to the model directory
+        model_config_class: Configuration class for the model
+        vision_config_class: Configuration class for vision component
+        text_config_class: Configuration class for text component
+        vision_tower_class: The vision tower model class
+        logger: logging.Logger
+
+    Returns:
+        Tuple containing:
+            - The vision tower module
+            - The model configuration
+            - The processor for handling images and text
+    """
+    # Load and parse configuration with correct classes
+    config, config_dict = load_and_parse_config(
+        model_path=model_path,
+        model_config_class=model_config_class,
+        vision_config_class=vision_config_class,
+        text_config_class=text_config_class,
+    )
+
+    # Create vision components container (Qwen2/2.5-VL only use vision tower)
+    components = QwenVisionComponents(
+        vision_tower=vision_tower_class(config.vision_config)
+    )
+
+    # Load processor
+    processor = load_processor(model_path=model_path, add_detokenizer=True)
+
+    # Load and filter weights
+    vision_weights = load_and_filter_weights(
+        model_path=model_path,
+        components=components,
+    )
+
+    # Sanitize vision weights
+    vision_weights = sanitize_weights(
+        components.vision_tower.__class__, vision_weights, config.vision_config
+    )
+
+    # Apply quantization if specified
+    maybe_apply_quantization(
+        components=components,
+        config_dict=config_dict,
+        vision_weights=vision_weights,
+    )
+
+    # Prepare components
+    prepare_components(
+        components=components,
+        vision_weights=vision_weights,
+    )
+
+    logger.info(
+        f"Qwen2/2.5-VL vision add-on loaded successfully from {model_path}",
+    )
+
+    return components.vision_tower, config, processor

--- a/mlx_engine/model_kit/vision_add_ons/mistral3.py
+++ b/mlx_engine/model_kit/vision_add_ons/mistral3.py
@@ -100,6 +100,8 @@ class Mistral3VisionAddOn(BaseVisionAddOn):
         )
         if input_ids.shape[1] == final_inputs_embeds.shape[1]:
             return input_ids.squeeze(0), final_inputs_embeds.squeeze(0)
-        # Do not return input_ids b/c the original lmstudio-community MLX upload had an incorrect
+        # Return fake input_ids b/c the original lmstudio-community MLX upload had an incorrect
         # processor_config.json that caused input_ids have extra placeholder image tokens.
-        return mx.array([]), final_inputs_embeds.squeeze(0)
+        return mx.array(
+            [0] * final_inputs_embeds.squeeze(0).shape[0]
+        ), final_inputs_embeds.squeeze(0)

--- a/mlx_engine/model_kit/vision_add_ons/qwen2_vl.py
+++ b/mlx_engine/model_kit/vision_add_ons/qwen2_vl.py
@@ -1,0 +1,206 @@
+from pathlib import Path
+
+from mlx import nn
+import mlx.core as mx
+
+from mlx_vlm.utils import prepare_inputs
+
+from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
+from mlx_engine.model_kit.vision_add_ons.load_utils import (
+    load_and_parse_config,
+    maybe_apply_quantization,
+    load_and_filter_weights,
+    prepare_components,
+)
+from mlx_engine.model_kit.vision_add_ons.load_utils import (
+    load_processor,
+    sanitize_weights,
+)
+from mlx_engine.utils.image_utils import convert_to_pil
+
+
+class Qwen2VLVisionComponents(nn.Module):
+    """Container for Qwen2-VL vision components."""
+
+    def __init__(self, vision_tower: nn.Module):
+        super().__init__()
+        self.vision_tower = vision_tower
+
+
+class Qwen2_VLVisionAddOn(BaseVisionAddOn):
+    """
+    Vision add-on for Qwen2-VL and Qwen2.5-VL models.
+    """
+
+    def __init__(self, model_path: Path):
+        """Initialize Qwen2_VLVisionAddOn with vision components loaded from the given path."""
+        super().__init__()
+
+        # Determine model type from config to select appropriate classes
+        config_path = model_path / "config.json"
+        with open(config_path, "r") as f:
+            import json
+
+            config_dict = json.load(f)
+            model_type = config_dict.get("model_type")
+
+        # Import appropriate classes based on model type
+        if model_type == "qwen2_5_vl":
+            from mlx_vlm.models.qwen2_5_vl import (
+                VisionModel as VisionTower,
+                ModelConfig as ModelConfigClass,
+                VisionConfig as VisionConfigClass,
+                TextConfig as TextConfigClass,
+                Model as CombinedModel,
+            )
+        else:  # Default to qwen2_vl
+            from mlx_vlm.models.qwen2_vl import (
+                VisionModel as VisionTower,
+                ModelConfig as ModelConfigClass,
+                VisionConfig as VisionConfigClass,
+                TextConfig as TextConfigClass,
+                Model as CombinedModel,
+            )
+
+        # Store the combined model class for use in compute_embeddings
+        self.CombinedModel = CombinedModel
+
+        # Load and parse configuration with correct classes
+        config, config_dict = load_and_parse_config(
+            model_path=model_path,
+            model_config_class=ModelConfigClass,
+            vision_config_class=VisionConfigClass,
+            text_config_class=TextConfigClass,
+        )
+
+        # Create vision components container
+        components = Qwen2VLVisionComponents(
+            vision_tower=VisionTower(config.vision_config)
+        )
+
+        # Load and filter weights
+        vision_weights = load_and_filter_weights(
+            model_path=model_path,
+            components=components,
+        )
+
+        # Sanitize vision weights
+        vision_weights = sanitize_weights(
+            components.vision_tower.__class__, vision_weights, config.vision_config
+        )
+
+        # Apply quantization if specified
+        maybe_apply_quantization(
+            components=components,
+            config_dict=config_dict,
+            vision_weights=vision_weights,
+        )
+
+        # Prepare components
+        prepare_components(
+            components=components,
+            vision_weights=vision_weights,
+        )
+
+        self.vision_tower = components.vision_tower
+        self.config = config
+        self.processor = load_processor(model_path)
+
+    def compute_embeddings(
+        self,
+        text_model: nn.Module,
+        prompt_tokens: mx.array,
+        images_b64: list[str],
+    ) -> tuple[mx.array, mx.array]:
+        """Compute input_ids and embeddings for text with images."""
+
+        # Convert prompt tokens to text
+        detokenizer = self.processor.detokenizer
+        detokenizer.reset()
+        [detokenizer.add_token(token) for token in prompt_tokens]
+        detokenizer.finalize()
+        prompt = detokenizer.text
+
+        # Convert images from base64
+        images = convert_to_pil(images_b64)
+
+        # Resize large images (without padding for multi-image support)
+        images = self._resize_images(images)
+
+        # Prepare inputs using mlx_vlm's prepare_inputs
+        inputs = prepare_inputs(
+            processor=self.processor,
+            images=images,
+            prompts=prompt,
+            image_token_index=self.config.image_token_id,
+            resize_shape=None,  # Let processor handle sizing
+        )
+
+        input_ids = inputs["input_ids"]
+        pixel_values = inputs["pixel_values"]
+        grid_thw = inputs["image_grid_thw"]
+
+        # Get prompt text embeddings
+        input_embeddings = text_model.language_model.model.embed_tokens(input_ids)
+
+        # If no images, return input_ids and input_embeddings
+        if pixel_values is None:
+            return input_ids.squeeze(0), input_embeddings.squeeze(0)
+
+        # Process through vision tower to get hidden states
+        hidden_states = self.vision_tower(
+            pixel_values, grid_thw, output_hidden_states=False
+        )
+
+        # Merge image features with text embeddings
+        final_inputs_embeds = self.CombinedModel.merge_input_ids_with_image_features(
+            self.config.image_token_id,
+            self.config.video_token_id,
+            hidden_states,
+            input_embeddings,
+            input_ids,
+        )
+
+        # Remove batch dimension
+        return input_ids.squeeze(0), final_inputs_embeds.squeeze(0)
+
+    def _resize_images(self, images, max_size=(1000, 1000)):
+        """
+        Resize large images without padding (preserves multi-image support).
+
+        Args:
+            images: List of PIL images
+            max_size: Maximum dimensions (width, height)
+
+        Returns:
+            List of resized PIL images (no padding applied)
+        """
+        import PIL.Image
+        import logging
+
+        logger = logging.getLogger(__name__)
+        resized_images = []
+
+        for i, img in enumerate(images):
+            original_size = (img.width, img.height)
+
+            if img.width > max_size[0] or img.height > max_size[1]:
+                # Resize while maintaining aspect ratio
+                aspect_ratio = img.width / img.height
+                if img.width > img.height:
+                    new_width = max_size[0]
+                    new_height = int(new_width / aspect_ratio)
+                else:
+                    new_height = max_size[1]
+                    new_width = int(new_height * aspect_ratio)
+
+                img = img.resize((new_width, new_height), PIL.Image.LANCZOS)
+                logger.info(
+                    f"Image {i + 1}: Resized from {original_size} to {img.width}x{img.height}"
+                )
+            else:
+                logger.info(f"Image {i + 1}: No resize needed {original_size}")
+
+            resized_images.append(img)
+
+        return resized_images

--- a/mlx_engine/model_kit/vision_add_ons/qwen2_vl.py
+++ b/mlx_engine/model_kit/vision_add_ons/qwen2_vl.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Tuple, Type
 from pathlib import Path
 
 from mlx import nn
@@ -7,10 +8,98 @@ import mlx.core as mx
 from mlx_vlm.utils import prepare_inputs
 
 from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
-from mlx_engine.model_kit.vision_add_ons.load_utils import load_qwen_vision_addon
+from mlx_engine.model_kit.vision_add_ons.load_utils import (
+    load_and_parse_config,
+    load_processor,
+    load_and_filter_weights,
+    sanitize_weights,
+    maybe_apply_quantization,
+    prepare_components,
+)
 from mlx_engine.utils.image_utils import convert_to_pil, custom_resize
 
 logger = logging.getLogger(__name__)
+
+
+class QwenVisionComponents(nn.Module):
+    def __init__(self, vision_tower: nn.Module):
+        super().__init__()
+        self.vision_tower = vision_tower
+
+
+def load_qwen_vision_addon(
+    model_path: Path,
+    model_config_class: Any,
+    vision_config_class: Any,
+    text_config_class: Any,
+    vision_tower_class: Type[nn.Module],
+    logger: logging.Logger,
+) -> Tuple[nn.Module, Any, Any]:
+    """
+    Load Qwen2/2.5-VL vision add-on components, configuration, and processor.
+
+    This is a specialized version of load_vision_addon for Qwen2/2.5-VL models,
+    which only use a vision tower without a multi-modal projector.
+
+    Args:
+        model_path: Path to the model directory
+        model_config_class: Configuration class for the model
+        vision_config_class: Configuration class for vision component
+        text_config_class: Configuration class for text component
+        vision_tower_class: The vision tower model class
+        logger: logging.Logger
+
+    Returns:
+        Tuple containing:
+            - The vision tower module
+            - The model configuration
+            - The processor for handling images and text
+    """
+    # Load and parse configuration with correct classes
+    config, config_dict = load_and_parse_config(
+        model_path=model_path,
+        model_config_class=model_config_class,
+        vision_config_class=vision_config_class,
+        text_config_class=text_config_class,
+    )
+
+    # Create vision components container (Qwen2/2.5-VL only use vision tower)
+    components = QwenVisionComponents(
+        vision_tower=vision_tower_class(config.vision_config)
+    )
+
+    # Load processor
+    processor = load_processor(model_path=model_path, add_detokenizer=True)
+
+    # Load and filter weights
+    vision_weights = load_and_filter_weights(
+        model_path=model_path,
+        components=components,
+    )
+
+    # Sanitize vision weights
+    vision_weights = sanitize_weights(
+        components.vision_tower.__class__, vision_weights, config.vision_config
+    )
+
+    # Apply quantization if specified
+    maybe_apply_quantization(
+        components=components,
+        config_dict=config_dict,
+        vision_weights=vision_weights,
+    )
+
+    # Prepare components
+    prepare_components(
+        components=components,
+        vision_weights=vision_weights,
+    )
+
+    logger.info(
+        f"Qwen2/2.5-VL vision add-on loaded successfully from {model_path}",
+    )
+
+    return components.vision_tower, config, processor
 
 
 class Qwen2_VLVisionAddOn(BaseVisionAddOn):

--- a/mlx_engine/model_kit/vision_add_ons/qwen2_vl.py
+++ b/mlx_engine/model_kit/vision_add_ons/qwen2_vl.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from mlx import nn
@@ -6,25 +7,10 @@ import mlx.core as mx
 from mlx_vlm.utils import prepare_inputs
 
 from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
-from mlx_engine.model_kit.vision_add_ons.load_utils import (
-    load_and_parse_config,
-    maybe_apply_quantization,
-    load_and_filter_weights,
-    prepare_components,
-)
-from mlx_engine.model_kit.vision_add_ons.load_utils import (
-    load_processor,
-    sanitize_weights,
-)
-from mlx_engine.utils.image_utils import convert_to_pil
+from mlx_engine.model_kit.vision_add_ons.load_utils import load_qwen_vision_addon
+from mlx_engine.utils.image_utils import convert_to_pil, custom_resize
 
-
-class Qwen2VLVisionComponents(nn.Module):
-    """Container for Qwen2-VL vision components."""
-
-    def __init__(self, vision_tower: nn.Module):
-        super().__init__()
-        self.vision_tower = vision_tower
+logger = logging.getLogger(__name__)
 
 
 class Qwen2_VLVisionAddOn(BaseVisionAddOn):
@@ -65,46 +51,14 @@ class Qwen2_VLVisionAddOn(BaseVisionAddOn):
         # Store the combined model class for use in compute_embeddings
         self.CombinedModel = CombinedModel
 
-        # Load and parse configuration with correct classes
-        config, config_dict = load_and_parse_config(
+        self.vision_tower, self.config, self.processor = load_qwen_vision_addon(
             model_path=model_path,
             model_config_class=ModelConfigClass,
             vision_config_class=VisionConfigClass,
             text_config_class=TextConfigClass,
+            vision_tower_class=VisionTower,
+            logger=logger,
         )
-
-        # Create vision components container
-        components = Qwen2VLVisionComponents(
-            vision_tower=VisionTower(config.vision_config)
-        )
-
-        # Load and filter weights
-        vision_weights = load_and_filter_weights(
-            model_path=model_path,
-            components=components,
-        )
-
-        # Sanitize vision weights
-        vision_weights = sanitize_weights(
-            components.vision_tower.__class__, vision_weights, config.vision_config
-        )
-
-        # Apply quantization if specified
-        maybe_apply_quantization(
-            components=components,
-            config_dict=config_dict,
-            vision_weights=vision_weights,
-        )
-
-        # Prepare components
-        prepare_components(
-            components=components,
-            vision_weights=vision_weights,
-        )
-
-        self.vision_tower = components.vision_tower
-        self.config = config
-        self.processor = load_processor(model_path)
 
     def compute_embeddings(
         self,
@@ -125,7 +79,7 @@ class Qwen2_VLVisionAddOn(BaseVisionAddOn):
         images = convert_to_pil(images_b64)
 
         # Resize large images (without padding for multi-image support)
-        images = self._resize_images(images)
+        images = custom_resize(images, should_pad=False)
 
         # Prepare inputs using mlx_vlm's prepare_inputs
         inputs = prepare_inputs(
@@ -163,44 +117,3 @@ class Qwen2_VLVisionAddOn(BaseVisionAddOn):
 
         # Remove batch dimension
         return input_ids.squeeze(0), final_inputs_embeds.squeeze(0)
-
-    def _resize_images(self, images, max_size=(1000, 1000)):
-        """
-        Resize large images without padding (preserves multi-image support).
-
-        Args:
-            images: List of PIL images
-            max_size: Maximum dimensions (width, height)
-
-        Returns:
-            List of resized PIL images (no padding applied)
-        """
-        import PIL.Image
-        import logging
-
-        logger = logging.getLogger(__name__)
-        resized_images = []
-
-        for i, img in enumerate(images):
-            original_size = (img.width, img.height)
-
-            if img.width > max_size[0] or img.height > max_size[1]:
-                # Resize while maintaining aspect ratio
-                aspect_ratio = img.width / img.height
-                if img.width > img.height:
-                    new_width = max_size[0]
-                    new_height = int(new_width / aspect_ratio)
-                else:
-                    new_height = max_size[1]
-                    new_width = int(new_height * aspect_ratio)
-
-                img = img.resize((new_width, new_height), PIL.Image.LANCZOS)
-                logger.info(
-                    f"Image {i + 1}: Resized from {original_size} to {img.width}x{img.height}"
-                )
-            else:
-                logger.info(f"Image {i + 1}: No resize needed {original_size}")
-
-            resized_images.append(img)
-
-        return resized_images

--- a/mlx_engine/utils/image_utils.py
+++ b/mlx_engine/utils/image_utils.py
@@ -15,7 +15,7 @@ def convert_to_pil(images_b64: List[str]) -> List[PIL.Image.Image]:
     ]
 
 
-def custom_resize(pil_images, max_size=(1000, 1000)):
+def custom_resize(pil_images, max_size=(1000, 1000), should_pad=True):
     """
     Resize and optionally pad a list of PIL images.
 
@@ -27,6 +27,8 @@ def custom_resize(pil_images, max_size=(1000, 1000)):
         pil_images (list): A list of PIL Image objects to be processed.
         max_size (tuple): Maximum allowed dimensions (width, height) for the images.
                         Defaults to (1000, 1000).
+        should_pad (bool): Whether to pad the images to the same size.
+                        Defaults to True.
 
     Returns:
         list: A list of processed PIL Image objects. If there was only one input image,
@@ -68,7 +70,7 @@ def custom_resize(pil_images, max_size=(1000, 1000)):
 
         resized_images.append(img)
 
-    if len(pil_images) > 1:
+    if len(pil_images) > 1 and should_pad:
         logger.info(
             f"[mlx-engine] Maximum dimensions: {max_width}x{max_height}. "
             f"Adding padding so that all images are the same size.\n",

--- a/mlx_engine/vision_model_kit/vision_model_kit.py
+++ b/mlx_engine/vision_model_kit/vision_model_kit.py
@@ -119,12 +119,13 @@ class VisionModelKit(ModelKit):
         )
         self.has_processed_prompt = True
 
-        # disable `prefill_step_size` prompt pre-processing in mlx_lm::generate_step
-        generate_args["prefill_step_size"] = float("inf")
-
         # The VLM input_ids shape is important, but mlx_lm expects a flattened array
-        #   Send the prompt back reshaped, and save the real shape in `self.model.input_ids`
-        return self.model.input_ids.reshape(-1), None
+        #   Send back a fake shape and input_ids, and save the real shape in `self.model.input_ids`
+        if images_b64 is None or len(images_b64) == 0:
+            # For text-only, enable mlx-lm prompt processing
+            return self.model.input_ids.reshape(-1), None
+        # Disable mlx-lm prompt processing by returning a fake input
+        return mx.array([0]), mx.array([0])
 
     def is_cross_prompt_cache_active(self) -> bool:
         """VisionModelKit does not support cross prompt caching"""

--- a/mlx_engine/vision_model_kit/vision_model_wrapper.py
+++ b/mlx_engine/vision_model_kit/vision_model_wrapper.py
@@ -58,7 +58,7 @@ class VisionModelWrapper:
         else:
             setattr(self.vision_model, name, value)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, input_embeddings=None, **kwargs):
         """
         See this reference implementation
         https://github.com/Blaizzy/mlx-vlm/blob/6c98971/mlx_vlm/utils.py#L783-L810

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ jsonschema-specifications==2025.4.1
 jsonschema==4.24.0
 lark==1.2.2
 markupsafe==2.1.5
-mlx-lm @ git+https://github.com/ml-explore/mlx-lm.git@d9a3ece1543fe20b070b78c6f61fe48ed3576d35
+mlx-lm @ git+https://github.com/ml-explore/mlx-lm.git@24fefe3d0587d81829bfb851647acd4e433fc10d
 mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm.git@231b294c648464defc2abbef53b38bfb1034bcfc
 mlx==0.26.3
 mpmath==1.3.0

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -101,9 +101,10 @@ class TestVisionModels(unittest.TestCase):
                 prompt,
                 text_only=True,
             )
-        except ValueError as e:
+        except AttributeError as e:
+            # mlx-lm prompt processing fails
             self.assertIn(
-                "Using this model without any images attached is not supported yet.",
+                "'NoneType' object has no attribute 'shape'",
                 str(e),
             )
 


### PR DESCRIPTION
Resolves #167 

Requires a sibling PR to `mlx-lm` to bring in the `qwen2_vl` language model [ml-explore/mlx-lm#384](https://github.com/ml-explore/mlx-lm/pull/384)

This implementation is cleaner and more consistent with the current codebase than my earlier PR #210 . No changes are made to the core logic of `ModelKit`. All updates are contained within the new vision add-on:

-  During initialization, the `load_vision_addon` function found in the other vision add-ons is supplemented due to Qwen2/2.5-VL not having a multi-modal projector.
- When computing embeddings, the `common_process_prompt_with_images` function found in the other vision add-ons is  supplemented due to the way Qwen2/2.5-VL models handle padding with multi-image prompts.

Tests continue to pass with this addition.

