### PR TITLE
fix: qwen3-next quantised kv cache fix

### DIFF
--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -64,7 +64,13 @@ class CacheWrapper:
         Returns:
             int | None: The number of tokens in the cache, or None if the size cannot be determined.
         """
+        from mlx_lm.models.cache import MambaCache
+
         for c in self.cache:
+            # MambaCache (used by Mamba/SSM models like Qwen 3 Next) doesn't track tokens
+            # with an offset attribute like attention-based caches do
+            if isinstance(c, MambaCache):
+                return None
             if hasattr(c, "offset"):
                 return c.offset
         return None


### PR DESCRIPTION
Possible fix for `AttributeError: 'MambaCache' object has no attribute 'offset'` when loading Qwen 3 Next models with K/V cache quantisation

Might fix #221 

I did try to test it seems but getting the mlx-engine test suite running requires installing an old unsupported Python version (3.11!) and the tests fail on unrelated issues with the current stable Python 3.13.7 and when trying to run the `demo.py` file as mentioned in the readme I get an error stating qwen3_next is not supported: `ValueError: Model type qwen3_next not supported.`

Perhaps if there is a way to run a custom engine version within LM Studio?