### PR TITLE
Partially Revert 'Disable KV Cache Quantization for models using MambaCache (#223)'

### DIFF
--- a/mlx_engine/__init__.py
+++ b/mlx_engine/__init__.py
@@ -11,11 +11,6 @@ __all__ = [
     "tokenize",
 ]
 
-
-class UnsupportedConfigError(Exception):
-    """Raised when mlx_engine does not support the user-provided configuration"""
-
-
 from pathlib import Path
 import os
 
@@ -32,7 +27,6 @@ from .generate import (
     create_generator,
     tokenize,
 )
-
 
 patch_huggingface_hub()
 register_models()

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -73,23 +73,19 @@ class ModelKit:
         kv_group_size: Optional[int] = None,
         quantized_kv_start: Optional[int] = None,
     ):
-        # Get model config
-        self.model_path = model_path
-        logger.info(f"Loading model from {model_path}...")
-        config_json = json.loads((model_path / "config.json").read_text())
-        self.model_type = config_json.get("model_type", None)
-
-        # Handle kv cache quantization
         kv_bits, kv_group_size, quantized_kv_start = get_kv_cache_quantization_params(
             kv_bits,
             kv_group_size,
             quantized_kv_start,
-            config_json,
         )
         if kv_bits and max_kv_size is not None:
             # Quantized KV cache is only supported for non-rotating KV cache
             logger.warning("max_kv_size is ignored when using KV cache quantization")
             max_kv_size = None
+        self.model_path = model_path
+        logger.info(f"Loading model from {model_path}...")
+        config_json = json.loads((model_path / "config.json").read_text())
+        self.model_type = config_json.get("model_type", None)
 
         self.model, self.tokenizer = mlx_lm.utils.load(self.model_path)
         self.detokenizer = self.tokenizer.detokenizer

--- a/mlx_engine/utils/kv_cache_quantization.py
+++ b/mlx_engine/utils/kv_cache_quantization.py
@@ -1,22 +1,15 @@
 from typing import Optional, Tuple
-from mlx_lm.utils import _get_classes
-from mlx_lm.models.cache import MambaCache
-from mlx_engine import UnsupportedConfigError
-import logging
 
 # https://github.com/ml-explore/mlx/blob/f288db8d34c0bcfa0867b6458ab0277c5e86ed45/mlx/fast.cpp#L782
 VALID_KV_BITS = (2, 3, 4, 6, 8)
 # https://github.com/ml-explore/mlx/blob/f288db8d34c0bcfa0867b6458ab0277c5e86ed45/mlx/fast.cpp#L775
 VALID_KV_GROUP_SIZE = (32, 64, 128)
 
-logger = logging.getLogger(__name__)
-
 
 def get_kv_cache_quantization_params(
     kv_bits: Optional[int],
     kv_group_size: Optional[int],
     quantized_kv_start: Optional[int],
-    config_json: dict,
 ) -> Tuple[Optional[int], Optional[int], Optional[int]]:
     """
     Validates and processes KV cache quantization parameters.
@@ -25,14 +18,12 @@ def get_kv_cache_quantization_params(
         kv_bits: Number of bits for quantization. If None, disables quantization.
         kv_group_size: Group size for quantization. Defaults to 64 if quantization enabled.
         quantized_kv_start: Step to begin quantization. Defaults to 0 if quantization enabled.
-        config_json: Model config.json
 
     Returns:
         Tuple of (kv_bits, kv_group_size, quantized_kv_start), all None if quantization disabled.
 
     Raises:
         ValueError: If kv_bits is invalid or missing when other params are set.
-        ValueError: If kv_bits is specified and the model arch does not support kv cache quantization
     """
     if any([kv_group_size, quantized_kv_start]) and kv_bits is None:
         raise ValueError("Enabling KV Cache Quantization requires kv_bits to be set")
@@ -52,25 +43,6 @@ def get_kv_cache_quantization_params(
     if kv_group_size not in VALID_KV_GROUP_SIZE:
         raise ValueError(
             f"Invalid kv_group_size value. Must be one of {VALID_KV_GROUP_SIZE}"
-        )
-
-    # Ensure that the model cache can be quantized
-    try:
-        model_cls, model_args_cls = _get_classes(config_json)
-        model_args = model_args_cls.from_dict(config_json)
-        model = model_cls(model_args)
-        if hasattr(model, "make_cache"):
-            cache = model.make_cache()
-            for c in cache:
-                if isinstance(c, MambaCache):
-                    raise UnsupportedConfigError(
-                        "This model does not support KV Cache Quantization. Please disable and reload"
-                    )
-    except UnsupportedConfigError:
-        raise
-    except Exception as e:
-        logger.warning(
-            f"Ignoring unexpected error when checking kv cache quantization support: {e}."
         )
 
     return kv_bits, kv_group_size, quantized_kv_start


### PR DESCRIPTION
Partially revert https://github.com/lmstudio-ai/mlx-engine/pull/223. The issue was fixed upstream by https://github.com/ml-explore/mlx-lm/pull/495, so we no longer need to throw a custom error message.

Per the upstream PR, the fix is...
> only the regular attention layers will be quantized. The mamba / other layers will be as usual.

After this, we can now load hybrid models with KV cache quantization on. Only the attention layers will be quantized.