### PR TITLE
Fix demo progress callback returning None causing cancellation

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -174,8 +174,7 @@ if __name__ == "__main__":
             print(f"\rProcessing prompt: |{bar}| ({percent:.1f}%)", end="", flush=True)
             if percent >= 100:
                 print()  # new line when done
-        else:
-            pass
+        return True  # Progress callback must return True to continue
 
     # Load the model
     model_path = resolve_model_path(args.model)


### PR DESCRIPTION
Progress callbacks now require explicit True/False return values after #224. The `prompt_progress_callback` in `demo.py` was implicitly returning None, which was treated as cancellation by the new `throw_to_stop` wrapper.