### PR TITLE
Log image resize only when it happens

### DIFF
--- a/mlx_engine/utils/image_utils.py
+++ b/mlx_engine/utils/image_utils.py
@@ -56,12 +56,8 @@ def custom_resize(
     max_width, max_height = 0, 0
 
     for i, img in enumerate(pil_images):
-        original_size = (img.width, img.height)
+        original_width, original_height = img.width, img.height
         aspect_ratio = img.width / img.height
-
-        logger.info(
-            f"Image {i + 1}: Original size {original_size}",
-        )
 
         if max_size is not None and (
             img.width > max_size[0] or img.height > max_size[1]
@@ -74,11 +70,7 @@ def custom_resize(
                 new_width = int(new_height * aspect_ratio)
             img = img.resize((new_width, new_height), PIL.Image.LANCZOS)
             logger.info(
-                f"Image {i + 1}: Resized to {img.width}x{img.height}\n",
-            )
-        else:
-            logger.info(
-                f"Image {i + 1}: No resize needed\n",
+                f"Image {i + 1}: Resized from {original_width}x{original_height} to {img.width}x{img.height}\n",
             )
 
         max_width = max(max_width, img.width)


### PR DESCRIPTION
Since the LM Studio app can send downsized images to mlx-engine, we don't want to mislead users as to the original image size.

So, log only when a resize actually occurs by mlx-engine. This will only happen in `demo.py` and the tests, and not with LM Studio.

Logging by the LM Studio electron app when a resize occurs is a separate concern.