### PR TITLE
disable qwen3-vl vision add ons

### DIFF
--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -14,8 +14,6 @@ from mlx_engine.model_kit.vision_add_ons.gemma3n import Gemma3nVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.mistral3 import Mistral3VisionAddOn
 from mlx_engine.model_kit.vision_add_ons.lfm2_vl import LFM2VisionAddOn
 from mlx_engine.model_kit.vision_add_ons.qwen2_vl import Qwen2_VLVisionAddOn
-from mlx_engine.model_kit.vision_add_ons.qwen3_vl_moe import Qwen3_VL_MoEVisionAddOn
-from mlx_engine.model_kit.vision_add_ons.qwen3_vl import Qwen3_VLVisionAddOn
 from mlx_engine.utils.kv_cache_quantization import get_kv_cache_quantization_params
 from mlx_engine.utils.prompt_processing import process_prompt_text_only
 
@@ -43,8 +41,9 @@ class ModelKit:
         "pixtral": PixtralVisionAddOn,
         "qwen2_vl": Qwen2_VLVisionAddOn,
         "qwen2_5_vl": Qwen2_VLVisionAddOn,
-        "qwen3_vl_moe": Qwen3_VL_MoEVisionAddOn,
-        "qwen3_vl": Qwen3_VLVisionAddOn,
+        # qwen3_vl and qwen3_vl_moe ports are bugged: https://github.com/lmstudio-ai/mlx-engine/issues/237
+        # "qwen3_vl_moe": Qwen3_VL_MoEVisionAddOn,
+        # "qwen3_vl": Qwen3_VLVisionAddOn,
     }
 
     # model state tracking


### PR DESCRIPTION
OCR performance improves by disabling these add ons. See #237 for the bug description. These add ons will be re-enabled once the port is fixed