### PR TITLE
Disable qwen 2 VL unified arch

### DIFF
--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -13,7 +13,6 @@ from mlx_engine.model_kit.vision_add_ons.pixtral import PixtralVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.gemma3n import Gemma3nVisionAddOn
 from mlx_engine.model_kit.vision_add_ons.mistral3 import Mistral3VisionAddOn
 from mlx_engine.model_kit.vision_add_ons.lfm2_vl import LFM2VisionAddOn
-from mlx_engine.model_kit.vision_add_ons.qwen2_vl import Qwen2_VLVisionAddOn
 from mlx_engine.utils.kv_cache_quantization import get_kv_cache_quantization_params
 from mlx_engine.utils.prompt_processing import process_prompt_text_only
 
@@ -39,9 +38,9 @@ class ModelKit:
         "lfm2-vl": LFM2VisionAddOn,
         "mistral3": Mistral3VisionAddOn,
         "pixtral": PixtralVisionAddOn,
-        "qwen2_vl": Qwen2_VLVisionAddOn,
-        "qwen2_5_vl": Qwen2_VLVisionAddOn,
-        # qwen3_vl and qwen3_vl_moe ports are bugged: https://github.com/lmstudio-ai/mlx-engine/issues/237
+        # qwen vl ports are bugged: https://github.com/lmstudio-ai/mlx-engine/issues/237
+        # "qwen2_vl": Qwen2_VLVisionAddOn,
+        # "qwen2_5_vl": Qwen2_VLVisionAddOn,
         # "qwen3_vl_moe": Qwen3_VL_MoEVisionAddOn,
         # "qwen3_vl": Qwen3_VLVisionAddOn,
     }


### PR DESCRIPTION
Disabled unified arch for qwen2_vl and qwen2_5_vl, since the quality of generation with multimodal input is degraded. See #237 