### PR TITLE
[unified arch] Cache the outputs of the vision encoder

### DIFF
--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -373,9 +373,6 @@ class CacheWrapper:
             if len(expanded_input_ids) <= len(self.prev_expanded_input_ids):
                 # Not extending - cache will need trimming (has generated tokens)
                 if num_tokens_in_cache > 0:
-                    logger.info(
-                        "Cannot reuse vision cache: cache is not trimmable and would require trimming"
-                    )
                     return False
 
         return True

--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -61,7 +61,7 @@ class CacheWrapper:
 
         # Vision prompt caching state
         self.prev_images_hash: Optional[str] = None
-        self.prev_expanded_input_ids: Optional[List[int]] = None
+        self.prev_expanded_input_ids: Optional[mx.array] = None
 
     def _get_num_tokens_in_cache(self) -> int | None:
         """
@@ -350,7 +350,7 @@ class CacheWrapper:
         return hashlib.sha256(combined.encode()).hexdigest()
 
     def can_reuse_vision_cache(
-        self, images_b64: List[str], expanded_input_ids: List[int]
+        self, images_b64: List[str], expanded_input_ids: mx.array
     ) -> bool:
         """
         Check if we can skip expensive vision processing and reuse cached KV states.
@@ -394,7 +394,7 @@ class CacheWrapper:
 
         return True
 
-    def record_vision_state(self, images_b64: List[str], expanded_input_ids: List[int]):
+    def record_vision_state(self, images_b64: List[str], expanded_input_ids: mx.array):
         """
         Record vision processing state for future cache validation.
 

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -208,6 +208,7 @@ def create_generator(
         ValueError: If top_logprobs exceeds MAX_TOP_LOGPROBS or if any parameters are invalid
     """
     set_seed(seed)
+    images_b64 = [] if images_b64 is None else images_b64
 
     generate_args = {}
     # For each call to create_generator, wrap all prompt progress calls with a ratchet that

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -163,7 +163,7 @@ class ModelKit:
                 speculative_decoding_toggle,
                 prompt_progress_callback,
             ), None
-        ### WITH IMAGES PROMPT PROCESSING ###s
+        ### WITH IMAGES PROMPT PROCESSING ###
         if self.vision_add_on is None:
             raise ValueError(
                 "Vision add-on is not loaded, but images were provided for processing"

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -2,7 +2,7 @@ import json
 from typing import Callable, Optional, List, Tuple
 import mlx_lm
 from mlx_lm.tokenizer_utils import TokenizerWrapper, StreamingDetokenizer
-from mlx_engine.cache_wrapper import CacheWrapper, CacheNotTrimmableError
+from mlx_engine.cache_wrapper import CacheWrapper
 from pathlib import Path
 import mlx.nn as nn
 import mlx.core as mx
@@ -208,36 +208,29 @@ class ModelKit:
         )
 
         if can_skip_vision_processing:
-            try:
-                # CHEAP PATH: Skip vision tower, reuse cached KV states
+            # CHEAP PATH: Skip vision tower, reuse cached KV states
+            logger.info("Reusing cached vision features from previous request")
 
-                # Get input_ids with image tokens
-                input_ids = self._get_input_ids_via_prepare_inputs(
-                    prompt_tokens, images_b64, max_image_size
-                )
+            # Get input_ids with image tokens (cheap - just tokenization + prepare_inputs)
+            input_ids = self._get_input_ids_via_prepare_inputs(
+                prompt_tokens, images_b64, max_image_size
+            )
 
-                # Process like text-only: use cache wrapper to preprocess new tokens
-                unprocessed_tokens = process_prompt_text_only(
-                    input_ids,
-                    self.cache_wrapper,
-                    generate_args,
-                    draft_model=None,  # Vision models don't support draft models
-                    speculative_decoding_toggle=None,
-                    prompt_progress_callback=prompt_progress_callback,
-                )
+            # Process like text-only: use cache wrapper to preprocess new tokens
+            unprocessed_tokens = process_prompt_text_only(
+                input_ids,
+                self.cache_wrapper,
+                generate_args,
+                draft_model=None,  # Vision models don't support draft models
+                speculative_decoding_toggle=None,
+                prompt_progress_callback=prompt_progress_callback,
+            )
 
-                # Update vision state for next request
-                self.cache_wrapper.record_vision_state(images_b64, prompt_tokens_list)
+            # Update vision state for next request
+            self.cache_wrapper.record_vision_state(images_b64, prompt_tokens_list)
 
-                # Return tokens only, no embeddings (model will use text embeddings for new tokens)
-                return unprocessed_tokens, None
-
-            except CacheNotTrimmableError:
-                pass
-                # Fall through to expensive path below
-
-        # EXPENSIVE PATH: Full vision processing (first request or images changed)
-        logger.info("Performing full vision processing with images")
+            # Return tokens only, no embeddings (model will use text embeddings for new tokens)
+            return unprocessed_tokens, None
 
         input_ids, embeddings = self.vision_add_on.compute_embeddings(
             self.model, prompt_tokens, images_b64, max_size=max_image_size

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -105,10 +105,7 @@ class ModelKit:
         self.kv_group_size = kv_group_size
         self.quantized_kv_start = quantized_kv_start
         vision_add_on_class = self.VISION_ADD_ON_MAP.get(self.model_type)
-        should_load_vision_add_on = (
-            vision_add_on_class is not None and "vision_config" in config_json
-        )
-        if should_load_vision_add_on:
+        if vision_add_on_class and "vision_config" in config_json:
             self.vision_add_on = vision_add_on_class(model_path)
         logger.info("Model loaded successfully")
 

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -203,14 +203,9 @@ class ModelKit:
             prompt_tokens, images_b64, max_image_size
         )
 
-        # Convert input_ids to list for cache validation
-        input_ids_list = (
-            input_ids.tolist() if hasattr(input_ids, "tolist") else list(input_ids)
-        )
-
         # Check if we can skip expensive vision processing
         can_skip_vision_processing = self.cache_wrapper.can_reuse_vision_cache(
-            images_b64, input_ids_list
+            images_b64, input_ids
         )
 
         if can_skip_vision_processing:
@@ -228,7 +223,7 @@ class ModelKit:
             )
 
             # Update vision state for next request
-            self.cache_wrapper.record_vision_state(images_b64, input_ids_list)
+            self.cache_wrapper.record_vision_state(images_b64, input_ids)
 
             # Return tokens only, no embeddings (model will use text embeddings for new tokens)
             return unprocessed_tokens, None
@@ -238,13 +233,8 @@ class ModelKit:
             self.model, prompt_tokens, images_b64, max_size=max_image_size
         )
 
-        # Update input_ids_list in case compute_embeddings returns different input_ids
-        input_ids_list = (
-            input_ids.tolist() if hasattr(input_ids, "tolist") else list(input_ids)
-        )
-
         # Record vision state for future requests
-        self.cache_wrapper.record_vision_state(images_b64, input_ids_list)
+        self.cache_wrapper.record_vision_state(images_b64, input_ids)
 
         # Initialize cache tracking with the processed input_ids
         # This is critical - tells cache_wrapper what tokens are being processed

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -222,12 +222,15 @@ class ModelKit:
             # Enable caching so generated tokens are recorded
             self._cross_prompt_cache_active = True
 
-            # Use cache wrapper to find common prefix and return unprocessed tokens
-            unprocessed_tokens = self.cache_wrapper.update_cache(
+            # Process like text-only: use cache wrapper to preprocess new tokens
+            unprocessed_tokens = process_prompt_text_only(
                 input_ids,
-                prompt_progress_callback,
+                self.cache_wrapper,
+                generate_args,
+                draft_model=None,  # Vision models don't support draft models
+                speculative_decoding_toggle=None,
+                prompt_progress_callback=prompt_progress_callback,
             )
-            generate_args["prompt_cache"] = self.cache_wrapper.cache
 
             # Update vision state for next request
             self.cache_wrapper.record_vision_state(images_b64, prompt_tokens_list)

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -16,6 +16,9 @@ from mlx_engine.model_kit.vision_add_ons.lfm2_vl import LFM2VisionAddOn
 from mlx_engine.model_kit.vision_add_ons.qwen2_vl import Qwen2_VLVisionAddOn
 from mlx_engine.utils.kv_cache_quantization import get_kv_cache_quantization_params
 from mlx_engine.utils.prompt_processing import process_prompt_text_only
+from mlx_engine.model_kit.vision_add_ons.process_prompt_with_images import (
+    common_process_prompt_with_images,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -146,10 +149,6 @@ class ModelKit:
         Get input_ids with image tokens inserted (cheap operation).
         Calls common_process_prompt_with_images but skips expensive vision processing.
         """
-        from mlx_engine.model_kit.vision_add_ons.process_prompt_with_images import (
-            common_process_prompt_with_images,
-        )
-
         # Determine should_pad based on model type
         # Qwen models need should_pad=False, others use True (default)
         should_pad = self.model_type not in ["qwen2_vl", "qwen2_5_vl"]

--- a/mlx_engine/model_kit/vision_add_ons/process_prompt_with_images.py
+++ b/mlx_engine/model_kit/vision_add_ons/process_prompt_with_images.py
@@ -22,6 +22,7 @@ def common_process_prompt_with_images(
     processor: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
     config,  # expected to be a ModelConfig object as defined by mlx-vlm. Can vary by model
     max_size: tuple[int, int] | None,
+    should_pad: bool = True,
 ) -> ProcessedImagePrompt:
     """
     Common prompt processing used by mlx-vlm vision add-ons.
@@ -33,6 +34,7 @@ def common_process_prompt_with_images(
         processor: Tokenizer/processor for the model
         config: Model configuration object
         max_size: Maximum image size as (width, height) tuple. If None, no resizing.
+        should_pad: Whether to pad images to uniform size. Defaults to True.
     """
     if len(images_b64) == 0:
         raise ValueError("Images must be non-empty")
@@ -45,7 +47,7 @@ def common_process_prompt_with_images(
     logger.info(f"Prompt dump: {prompt}\n")
 
     images = convert_to_pil(images_b64)
-    images = custom_resize(images, max_size=max_size)
+    images = custom_resize(images, max_size=max_size, should_pad=should_pad)
 
     if hasattr(config, "image_token_index"):
         image_token_index = config.image_token_index

--- a/mlx_engine/vision_model_kit/vision_model_kit.py
+++ b/mlx_engine/vision_model_kit/vision_model_kit.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, List, Tuple
+from typing import Union, Optional, Tuple
 from mlx_engine.model_kit.model_kit import ModelKit
 import logging
 
@@ -98,7 +98,7 @@ class VisionModelKit(ModelKit):
     def process_prompt(
         self,
         prompt_tokens,
-        images_b64: Optional[List[str]],
+        images_b64: list[str],
         prompt_progress_callback,
         generate_args,
         max_image_size: tuple[int, int] | None,
@@ -122,7 +122,7 @@ class VisionModelKit(ModelKit):
 
         # The VLM input_ids shape is important, but mlx_lm expects a flattened array
         #   Send back a fake shape and input_ids, and save the real shape in `self.model.input_ids`
-        if images_b64 is None or len(images_b64) == 0:
+        if len(images_b64) == 0:
             # For text-only, enable mlx-lm prompt processing
             return self.model.input_ids.reshape(-1), None
         # Disable mlx-lm prompt processing by returning a fake input

--- a/mlx_engine/vision_model_kit/vision_model_wrapper.py
+++ b/mlx_engine/vision_model_kit/vision_model_wrapper.py
@@ -2,7 +2,6 @@ import mlx.core as mx
 import logging
 
 from mlx_vlm.models.cache import KVCache, SimpleKVCache
-from typing import List, Optional
 from mlx_engine.model_kit.vision_add_ons.process_prompt_with_images import (
     common_process_prompt_with_images,
 )
@@ -158,7 +157,7 @@ class VisionModelWrapper:
 
     def process_prompt_with_images(
         self,
-        images_b64: Optional[List[str]],
+        images_b64: list[str],
         prompt_tokens: mx.array,
         processor,
         detokenizer,
@@ -168,9 +167,6 @@ class VisionModelWrapper:
         This method generates the input_ids, pixel_values, and mask for the vision model
         Call this before starting evaluation
         """
-        if images_b64 is None:
-            images_b64 = []
-
         # Handle the case with no images
         if len(images_b64) == 0:
             detokenizer.reset()

--- a/mlx_engine/vision_model_kit/vision_model_wrapper.py
+++ b/mlx_engine/vision_model_kit/vision_model_wrapper.py
@@ -110,11 +110,6 @@ class VisionModelWrapper:
                     "decoder_input_ids": self.decoder_input_ids,
                     "encoder_outputs": outputs.encoder_outputs,
                 }
-            # elif self.vision_model.config.model_type == "qwen3_vl":
-            #     self.language_model_kwargs = {
-            #         "visual_pos_masks": outputs.visual_pos_masks,
-            #         "deepstack_visual_embeds": outputs.deepstack_visual_embeds,
-            #     }
 
             # Add the cache we created here to the language model kwargs
             self.language_model_kwargs["cache"] = cache

--- a/mlx_engine/vision_model_kit/vision_model_wrapper.py
+++ b/mlx_engine/vision_model_kit/vision_model_wrapper.py
@@ -111,6 +111,11 @@ class VisionModelWrapper:
                     "decoder_input_ids": self.decoder_input_ids,
                     "encoder_outputs": outputs.encoder_outputs,
                 }
+            # elif self.vision_model.config.model_type == "qwen3_vl":
+            #     self.language_model_kwargs = {
+            #         "visual_pos_masks": outputs.visual_pos_masks,
+            #         "deepstack_visual_embeds": outputs.deepstack_visual_embeds,
+            #     }
 
             # Add the cache we created here to the language model kwargs
             self.language_model_kwargs["cache"] = cache

--- a/tests/test_vision_cache.py
+++ b/tests/test_vision_cache.py
@@ -1,0 +1,79 @@
+import unittest
+import base64
+from pathlib import Path
+from mlx_engine.generate import (
+    load_model,
+    tokenize,
+    create_generator,
+)
+from tests.shared import model_getter
+
+
+MAX_IMAGE_SIZE = (1024, 1024)
+
+
+class TestVisionCache(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up test resources that will be shared across all test methods"""
+        cls.description_prompt = "What is this"
+        cls.text_only_prompt = "What is a toucan?"
+        cls.test_data_dir = Path(__file__).parent / "data"
+        cls.demo_data_dir = Path(__file__).parent.parent / "demo-data"
+
+        # Read and encode test images
+        cls.toucan_path = Path(__file__).parent.parent / "demo-data" / "toucan.jpeg"
+        with open(cls.toucan_path, "rb") as image_file:
+            cls.toucan_image_b64 = base64.b64encode(image_file.read()).decode("utf-8")
+        cls.chameleon_image_path = (
+            Path(__file__).parent.parent / "demo-data" / "chameleon.webp"
+        )
+        with open(cls.chameleon_image_path, "rb") as chameleon_image_file:
+            cls.chameleon_image_b64 = base64.b64encode(
+                chameleon_image_file.read()
+            ).decode("utf-8")
+
+    ### MODEL-SPECIFIC TESTS ###
+    def test_gemma3n(self):
+        """Test LFM2-VL 450M model"""
+        prompt = "<bos><start_of_turn>user\n<image_soft_token><image_soft_token>In one word each, describe the images<end_of_turn>\n<start_of_turn>model\n"
+        model_name = "lmstudio-community/gemma-3n-E2B-it-MLX-4bit"
+        print(f"Testing model {model_name}")
+        model_path = model_getter(model_name=model_name)
+
+        # Load the model
+        model_kit = load_model(
+            model_path=model_path, max_kv_size=2048, trust_remote_code=True
+        )
+
+        def generate_text(prompt):
+            # Tokenize the prompt
+            prompt_tokens = tokenize(model_kit, prompt)
+
+            # Generate description
+            generated_text = ""
+            for result in create_generator(
+                model_kit=model_kit,
+                prompt_tokens=prompt_tokens,
+                images_b64=[self.toucan_image_b64, self.chameleon_image_b64],
+                max_image_size=MAX_IMAGE_SIZE,
+                seed=0,
+                max_tokens=100,
+                temp=0.0,
+                repetition_penalty=1.01,  # enable the logits processor code path
+            ):
+                generated_text += result.text
+                print(result.text, end="", flush=True)
+                if result.stop_condition:
+                    break
+            print()
+            return generated_text
+
+        generated_text = generate_text(prompt)
+        print("--")
+        prompt = (
+            prompt
+            + generated_text
+            + "<end_of_turn>\n<start_of_turn>user\nwhich direction is each animal facing?<end_of_turn>\n<start_of_turn>model\n"
+        )
+        generated_text = generate_text(prompt)

--- a/tests/test_vision_cache.py
+++ b/tests/test_vision_cache.py
@@ -7,7 +7,7 @@ from mlx_engine.generate import (
     create_generator,
 )
 from tests.shared import model_getter
-
+import pytest
 
 MAX_IMAGE_SIZE = (1024, 1024)
 
@@ -28,12 +28,15 @@ class TestVisionCache(unittest.TestCase):
                 chameleon_image_file.read()
             ).decode("utf-8")
 
-    def test_gemma3n(self):
-        """Test LFM2-VL 450M model"""
-        prompt = "<bos><start_of_turn>user\n<image_soft_token><image_soft_token>In one word each, describe the images<end_of_turn>\n<start_of_turn>model\n"
-        model_name = "lmstudio-community/gemma-3n-E2B-it-MLX-4bit"
-        print(f"Testing model {model_name}")
+    @pytest.mark.heavy
+    def test_nonswa_model(self):
+        """
+        Test that image caching works for models without a SWA cache
+        """
+        prompt = "<s>[INST][IMG][IMG]In one word each, describe the animal in the images[/INST]\n"
+        model_name = "lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit"
         model_path = model_getter(model_name=model_name)
+        images_b64 = [self.toucan_image_b64, self.chameleon_image_b64]
 
         # Load the model
         model_kit = load_model(
@@ -47,7 +50,10 @@ class TestVisionCache(unittest.TestCase):
             callback_history.append(x)
             return True
 
-        def generate_text(prompt, images_b64=None):
+        def generate_text(prompt):
+            nonlocal callback_history
+            callback_history = []
+
             # Tokenize the prompt
             prompt_tokens = tokenize(model_kit, prompt)
 
@@ -57,7 +63,7 @@ class TestVisionCache(unittest.TestCase):
                 model_kit=model_kit,
                 prompt_tokens=prompt_tokens,
                 prompt_progress_callback=prompt_callback,
-                images_b64=[self.toucan_image_b64, self.chameleon_image_b64],
+                images_b64=images_b64,
                 max_image_size=MAX_IMAGE_SIZE,
                 seed=0,
                 max_tokens=100,
@@ -73,22 +79,35 @@ class TestVisionCache(unittest.TestCase):
 
         generated_text = generate_text(prompt)
         self.assertEqual(len(callback_history), 4)  # prompt processing by mlx-lm
-        callback_history = []
 
         # ask a followup question
         print("--")
-        prompt = (
-            prompt
-            + generated_text
-            + "<end_of_turn>\n<start_of_turn>user\nwhich direction is each animal facing?<end_of_turn>\n"
-            + "also, remember this information: "
-            + ", ".join([str(x) for x in range(200)])
-            + "\n"
-            + "<start_of_turn>model\n"
+        prompt2 = (
+            prompt + generated_text + "[INST]what color is each animal's eyes?[/INST]"
         )
-        generated_text = generate_text(prompt)
+        generated_text2 = generate_text(prompt2)
 
         # prompt processing by cache_wrapper. less work is done since the images are cached
-        self.assertEqual(len(callback_history), 3)
-        self.assertRegex(generated_text, "toucan.*left")
-        self.assertRegex(generated_text, "chameleon.*right")
+        self.assertEqual(len(callback_history), 2)
+        self.assertRegex(generated_text2, "toucan.*dark")
+        self.assertRegex(generated_text2, "chameleon.*orange")
+
+        # rewind the cache but swap the images. full preprocessing happens
+        images_b64.reverse()
+        _ = generate_text(prompt)
+        self.assertEqual(len(callback_history), 4)
+
+        # rewind the cache and re-prompt; images are not processed
+        _ = generate_text(prompt)
+        self.assertEqual(len(callback_history), 2)
+
+        # add an image in the followup; all three images are re-processed
+        images_b64.append(self.chameleon_image_b64)
+        prompt3 = (
+            prompt
+            + generated_text
+            + "[INST][IMG]do you see two toucans or chameleons?[/INST]"
+        )
+        generated_text3 = generate_text(prompt3)
+        self.assertEqual(len(callback_history), 5)
+        self.assertRegex(generated_text3, "chameleon")

--- a/tests/test_vision_cache.py
+++ b/tests/test_vision_cache.py
@@ -31,7 +31,7 @@ class TestVisionCache(unittest.TestCase):
     @pytest.mark.heavy
     def test_nonswa_model(self):
         """
-        Test that image caching works for models without a SWA cache
+        Test that image caching works for models without SWA (sliding window attn) layers
         """
         prompt = "<s>[INST][IMG][IMG]In one word each, describe the animal in the images[/INST]\n"
         model_name = "lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit"
@@ -114,7 +114,7 @@ class TestVisionCache(unittest.TestCase):
 
     def test_swa_model(self):
         """
-        Test that image caching works for models with a SWA cache
+        Test that image caching works for models with SWA layers
         """
         prompt = "<bos><start_of_turn>user\n<image_soft_token><image_soft_token>In one word each, describe the images<end_of_turn>\n<start_of_turn>model\n"
         model_name = "lmstudio-community/gemma-3n-E2B-it-MLX-4bit"
@@ -164,7 +164,6 @@ class TestVisionCache(unittest.TestCase):
         self.assertEqual(len(callback_history), 4)  # prompt processing by mlx-lm
 
         # ask a followup question
-        print("--")
         prompt2 = (
             prompt
             + generated_text

--- a/tests/test_vision_cache.py
+++ b/tests/test_vision_cache.py
@@ -40,7 +40,7 @@ class TestVisionCache(unittest.TestCase):
 
         # Load the model
         model_kit = load_model(
-            model_path=model_path, max_kv_size=2048, trust_remote_code=True
+            model_path=model_path, max_kv_size=4096, trust_remote_code=True
         )
 
         callback_history = []
@@ -110,4 +110,90 @@ class TestVisionCache(unittest.TestCase):
         )
         generated_text3 = generate_text(prompt3)
         self.assertEqual(len(callback_history), 5)
+        self.assertRegex(generated_text3, "chameleon")
+
+    def test_swa_model(self):
+        """
+        Test that image caching works for models with a SWA cache
+        """
+        prompt = "<bos><start_of_turn>user\n<image_soft_token><image_soft_token>In one word each, describe the images<end_of_turn>\n<start_of_turn>model\n"
+        model_name = "lmstudio-community/gemma-3n-E2B-it-MLX-4bit"
+        model_path = model_getter(model_name=model_name)
+        images_b64 = [self.toucan_image_b64, self.chameleon_image_b64]
+
+        # Load the model
+        model_kit = load_model(
+            model_path=model_path, max_kv_size=4096, trust_remote_code=True
+        )
+
+        callback_history = []
+
+        def prompt_callback(x):
+            nonlocal callback_history
+            callback_history.append(x)
+            return True
+
+        def generate_text(prompt):
+            nonlocal callback_history
+            callback_history = []
+
+            # Tokenize the prompt
+            prompt_tokens = tokenize(model_kit, prompt)
+
+            # Generate description
+            generated_text = ""
+            for result in create_generator(
+                model_kit=model_kit,
+                prompt_tokens=prompt_tokens,
+                prompt_progress_callback=prompt_callback,
+                images_b64=images_b64,
+                max_image_size=MAX_IMAGE_SIZE,
+                seed=0,
+                max_tokens=100,
+                temp=0.0,
+                repetition_penalty=1.01,  # enable the logits processor code path
+            ):
+                generated_text += result.text
+                print(result.text, end="", flush=True)
+                if result.stop_condition:
+                    break
+            print()
+            return generated_text
+
+        generated_text = generate_text(prompt)
+        self.assertEqual(len(callback_history), 4)  # prompt processing by mlx-lm
+
+        # ask a followup question
+        print("--")
+        prompt2 = (
+            prompt
+            + generated_text
+            + "<end_of_turn>\n<start_of_turn>user\nwhich direction is each animal facing?<end_of_turn>\n"
+            + "<start_of_turn>model\n"
+        )
+        generated_text2 = generate_text(prompt2)
+
+        # prompt processing by cache_wrapper. less work is done since the images are cached
+        self.assertEqual(len(callback_history), 2)
+        self.assertRegex(generated_text2, "toucan.*left")
+        self.assertRegex(generated_text2, "chameleon.*right")
+
+        # swap the images; full preprocessing happens
+        images_b64.reverse()
+        _ = generate_text(prompt)
+        self.assertEqual(len(callback_history), 4)
+
+        # attempt cache rewind; images fully processed since the cache can't be trimmed
+        _ = generate_text(prompt)
+        self.assertEqual(len(callback_history), 4)
+
+        # add an image in the followup; all three images are re-processed
+        images_b64.append(self.chameleon_image_b64)
+        prompt3 = (
+            prompt
+            + generated_text
+            + "<start_of_turn>user\n<image_soft_token>how many animals do you count?<end_of_turn>\n<start_of_turn>model"
+        )
+        generated_text3 = generate_text(prompt3)
+        self.assertEqual(len(callback_history), 4)
         self.assertRegex(generated_text3, "chameleon")


### PR DESCRIPTION
Start tracking the tokens and cache in `cache_wrapper`. When we receive a followup prompt, we now no longer reprocess the images.
Cases:
- The hash of the input images changes --> Always do full reprocessing
- The prompt is extended --> Do text-only prompt processing
- The prompt is trimmed --> Trim the cache and do text-only prompt processing
- The cache cannot be trimmed --> Full vision reprocessing

I added two tests, one for SWA caches which often cannot be trimmed, and one for non-SWA caches, which are usually always trimmable.

Note that there are still opportunities for improvement. Namely, we could be caching the embeddings per image so that we can selectively re-use the embeddings. This can be added as a feature in a future PR, in cases where the cache cannot be trimmed.

Note that this doesn't cache images going through the non-unified stack, that can be added in a future PR.