### PR TITLE
Force correct processor config for LM Studio Mistral Small 3.2

### DIFF
--- a/mlx_engine/model_kit/vision_add_ons/load_utils.py
+++ b/mlx_engine/model_kit/vision_add_ons/load_utils.py
@@ -196,7 +196,7 @@ def load_vision_addon(
     vision_tower_class: Type[nn.Module],
     multi_modal_projector_class: Type[nn.Module] | None,
     logger: logging.Logger,
-    processor_kwargs: dict = {},
+    processor_kwargs: dict | None = None,
 ) -> Tuple[nn.Module, nn.Module | None, Any, Any]:
     """
     Load vision add-on components, configuration, and processor.
@@ -231,7 +231,9 @@ def load_vision_addon(
 
     # Load processor
     processor = load_processor(
-        model_path=model_path, add_detokenizer=True, **processor_kwargs
+        model_path=model_path,
+        add_detokenizer=True,
+        **(processor_kwargs or {}),
     )
 
     # Load and filter weights

--- a/mlx_engine/model_kit/vision_add_ons/mistral3.py
+++ b/mlx_engine/model_kit/vision_add_ons/mistral3.py
@@ -30,7 +30,7 @@ class Mistral3VisionAddOn(BaseVisionAddOn):
         """Initialize Mistral3VisionAddOn with vision components loaded from the given path."""
         super().__init__()
 
-        processor_kwargs = None
+        processor_kwargs: dict | None = None
         if self._is_lmstudio_mistral_3_2_small(model_path):
             processor_kwargs = {
                 "patch_size": 14,


### PR DESCRIPTION
https://github.com/Blaizzy/mlx-vlm/commit/d7d73de14d600c5fcb12d37e46ecbdcd458c3c6b introduced [strict checks to Mistral3's `merge_input_ids_with_image_features`](https://github.com/Blaizzy/mlx-vlm/blob/1a6357421af4cdb3bb0815dc76b20bc8b5a82bc5/mlx_vlm/models/mistral3/mistral3.py#L293-L298) that make it so that [lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit](https://huggingface.co/lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit) model's pre [processor_config.json fix](https://huggingface.co/lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit/commit/61d29b9c1c12db05b4d156ea4bd743e9f00be8e6) will now throw on errors like:
```
ValueError: Number of image token positions (209) does not match number of image features (60) for batch 0
```
This previously was not an issue, as the `merge_input_ids_with_image_features` used to still succeed even with the image features <-> image tokens mismatch, and when passing embeddings into mlx-lm only the embeddings are considered.

Solution here is to run a very strict check if model path contains "lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX", and if it does, override the processor config to be the one that we know is correct.