### PR TITLE
Continuous batching

### DIFF
--- a/demo_server.py
+++ b/demo_server.py
@@ -1,0 +1,445 @@
+import argparse
+import json
+import os
+import queue
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Optional
+
+from mlx_engine.generate import load_model, tokenize
+from mlx_engine.batch_generate import BatchGenerationResult, create_batch_generator
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8080
+DEFAULT_MAX_TOKENS = 128
+
+
+def resolve_model_path(model_argument: str) -> str:
+    if os.path.exists(model_argument):
+        return model_argument
+
+    local_paths = [
+        os.path.expanduser("~/.lmstudio/models"),
+        os.path.expanduser("~/.cache/lm-studio/models"),
+    ]
+
+    for path in local_paths:
+        candidate_path = os.path.join(path, model_argument)
+        if os.path.exists(candidate_path):
+            return candidate_path
+
+    raise ValueError(f"Could not find model '{model_argument}' in local directories")
+
+
+class RequestState:
+    def __init__(self) -> None:
+        self.request_slot_id: Optional[int] = None
+        self.cached_tokens: Optional[int] = None
+        self.total_prompt_tokens: Optional[int] = None
+        self.result_queue: queue.Queue[Optional[BatchGenerationResult]] = queue.Queue()
+        self.ready_event = threading.Event()
+        self.error_message: Optional[str] = None
+
+
+@dataclass
+class PendingRequest:
+    request_state: RequestState
+    session_id: str
+    prompt_tokens: list[int]
+    max_tokens: int
+    stop_strings: Optional[list[str]]
+    top_logprobs: Optional[int]
+    repetition_penalty: Optional[float]
+    temp: Optional[float]
+    top_p: Optional[float]
+    min_p: Optional[float]
+    top_k: Optional[int]
+    seed: Optional[int]
+
+
+class BatchScheduler:
+    def __init__(self, batch_generator) -> None:
+        self._batch_generator = batch_generator
+        self._pending_requests: queue.Queue[PendingRequest] = queue.Queue()
+        self._active_requests: dict[int, RequestState] = {}
+        self._lock = threading.Lock()
+        self._shutdown_event = threading.Event()
+        self._worker_thread = threading.Thread(
+            target=self._worker_loop, name="mlx-batch-worker", daemon=True
+        )
+
+    def start(self) -> None:
+        self._worker_thread.start()
+
+    def shutdown(self) -> None:
+        self._shutdown_event.set()
+        self._worker_thread.join()
+        self._batch_generator.close()
+
+    def enqueue(self, pending_request: PendingRequest) -> RequestState:
+        self._pending_requests.put(pending_request)
+        ready = pending_request.request_state.ready_event.wait(timeout=30)
+        if ready is False:
+            pending_request.request_state.error_message = (
+                "Timed out while enqueuing request"
+            )
+        return pending_request.request_state
+
+    def _worker_loop(self) -> None:
+        while self._shutdown_event.is_set() is False:
+            pending_requests = self._drain_pending_requests()
+            for pending_request in pending_requests:
+                self._handle_pending_request(pending_request)
+
+            if self._has_active_requests() is False:
+                self._shutdown_event.wait(0.01)
+                continue
+
+            self._process_batch_results()
+
+    def _drain_pending_requests(self) -> list[PendingRequest]:
+        pending_requests: list[PendingRequest] = []
+        try:
+            pending_requests.append(self._pending_requests.get(timeout=0.01))
+        except queue.Empty:
+            return pending_requests
+
+        while True:
+            try:
+                pending_requests.append(self._pending_requests.get_nowait())
+            except queue.Empty:
+                break
+        return pending_requests
+
+    def _handle_pending_request(self, pending_request: PendingRequest) -> None:
+        request_state = pending_request.request_state
+        try:
+            (
+                request_slot_id,
+                cached_tokens,
+                total_prompt_tokens,
+            ) = self._batch_generator.insert(
+                session_id=pending_request.session_id,
+                prompt_tokens=pending_request.prompt_tokens,
+                max_tokens=pending_request.max_tokens,
+                stop_strings=pending_request.stop_strings,
+                top_logprobs=pending_request.top_logprobs,
+                repetition_penalty=pending_request.repetition_penalty,
+                temp=pending_request.temp,
+                top_p=pending_request.top_p,
+                min_p=pending_request.min_p,
+                top_k=pending_request.top_k,
+                seed=pending_request.seed,
+            )
+            request_state.request_slot_id = request_slot_id
+            request_state.cached_tokens = cached_tokens
+            request_state.total_prompt_tokens = total_prompt_tokens
+            with self._lock:
+                self._active_requests[request_slot_id] = request_state
+        except Exception as exception:
+            request_state.error_message = str(exception)
+        request_state.ready_event.set()
+
+    def _has_active_requests(self) -> bool:
+        with self._lock:
+            return len(self._active_requests) > 0
+
+    def _process_batch_results(self) -> None:
+        try:
+            batch_results = self._batch_generator.next()
+        except Exception as exception:
+            self._fail_active_requests(str(exception))
+            return
+
+        if len(batch_results) == 0:
+            self._shutdown_event.wait(0.005)
+            return
+
+        for result in batch_results:
+            request_state = self._get_request_state(result.request_slot_id)
+            if request_state is None:
+                continue
+            request_state.result_queue.put(result)
+            if result.stop_condition is not None:
+                self._remove_request_state(result.request_slot_id)
+
+    def _get_request_state(self, request_slot_id: int) -> Optional[RequestState]:
+        with self._lock:
+            return self._active_requests.get(request_slot_id)
+
+    def _remove_request_state(self, request_slot_id: int) -> None:
+        with self._lock:
+            if request_slot_id in self._active_requests:
+                del self._active_requests[request_slot_id]
+
+    def _fail_active_requests(self, error_message: str) -> None:
+        with self._lock:
+            request_states = list(self._active_requests.values())
+            self._active_requests.clear()
+        for request_state in request_states:
+            request_state.error_message = error_message
+            request_state.result_queue.put(None)
+
+
+class BatchHTTPServer(ThreadingHTTPServer):
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        request_handler_class: type[BaseHTTPRequestHandler],
+        model_kit,
+        batch_scheduler: BatchScheduler,
+        default_max_tokens: int,
+    ) -> None:
+        super().__init__(server_address, request_handler_class)
+        self.model_kit = model_kit
+        self.batch_scheduler = batch_scheduler
+        self.default_max_tokens = default_max_tokens
+
+
+class BatchRequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path != "/health":
+            self._send_json_response(404, {"error": "Not found"})
+            return
+        self._send_json_response(200, {"status": "ok"})
+
+    def do_POST(self) -> None:
+        if self.path != "/generate":
+            self._send_json_response(404, {"error": "Not found"})
+            return
+
+        content_length = self._read_content_length()
+        if content_length is None:
+            return
+
+        request_body = self.rfile.read(content_length)
+        request_json = self._parse_json(request_body)
+        if request_json is None:
+            return
+
+        prompt_value = request_json.get("prompt")
+        if isinstance(prompt_value, str) is False or prompt_value == "":
+            self._send_json_response(400, {"error": "prompt must be a non-empty string"})
+            return
+
+        session_id_value = request_json.get("session_id")
+        if isinstance(session_id_value, str) is False:
+            session_id_value = ""
+
+        max_tokens_value = request_json.get("max_tokens")
+        if isinstance(max_tokens_value, int) is False:
+            max_tokens_value = self.server.default_max_tokens
+
+        stop_strings_value = request_json.get("stop_strings")
+        if isinstance(stop_strings_value, list) is False:
+            stop_strings_value = None
+        else:
+            stop_strings_value = [
+                stop_string
+                for stop_string in stop_strings_value
+                if isinstance(stop_string, str)
+            ]
+
+        top_logprobs_value = request_json.get("top_logprobs")
+        if isinstance(top_logprobs_value, int) is False:
+            top_logprobs_value = None
+
+        repetition_penalty_value = request_json.get("repetition_penalty")
+        if isinstance(repetition_penalty_value, (float, int)) is False:
+            repetition_penalty_value = None
+        else:
+            repetition_penalty_value = float(repetition_penalty_value)
+
+        temp_value = request_json.get("temp")
+        if isinstance(temp_value, (float, int)) is False:
+            temp_value = None
+        else:
+            temp_value = float(temp_value)
+
+        top_p_value = request_json.get("top_p")
+        if isinstance(top_p_value, (float, int)) is False:
+            top_p_value = None
+        else:
+            top_p_value = float(top_p_value)
+
+        min_p_value = request_json.get("min_p")
+        if isinstance(min_p_value, (float, int)) is False:
+            min_p_value = None
+        else:
+            min_p_value = float(min_p_value)
+
+        top_k_value = request_json.get("top_k")
+        if isinstance(top_k_value, int) is False:
+            top_k_value = None
+
+        seed_value = request_json.get("seed")
+        if isinstance(seed_value, int) is False:
+            seed_value = None
+
+        prompt_tokens = tokenize(self.server.model_kit, prompt_value)
+        pending_request = PendingRequest(
+            request_state=RequestState(),
+            session_id=session_id_value,
+            prompt_tokens=prompt_tokens,
+            max_tokens=max_tokens_value,
+            stop_strings=stop_strings_value,
+            top_logprobs=top_logprobs_value,
+            repetition_penalty=repetition_penalty_value,
+            temp=temp_value,
+            top_p=top_p_value,
+            min_p=min_p_value,
+            top_k=top_k_value,
+            seed=seed_value,
+        )
+        request_state = self.server.batch_scheduler.enqueue(pending_request)
+        if request_state.error_message is not None:
+            self._send_json_response(500, {"error": request_state.error_message})
+            return
+
+        response_payload = self._collect_response_payload(request_state)
+        if response_payload is None:
+            return
+        self._send_json_response(200, response_payload)
+
+    def log_message(self, format, *arguments) -> None:
+        return
+
+    def _read_content_length(self) -> Optional[int]:
+        content_length_header = self.headers.get("Content-Length")
+        if content_length_header is None:
+            self._send_json_response(411, {"error": "Missing Content-Length header"})
+            return None
+        try:
+            return int(content_length_header)
+        except ValueError:
+            self._send_json_response(400, {"error": "Invalid Content-Length header"})
+            return None
+
+    def _parse_json(self, request_body: bytes) -> Optional[dict]:
+        try:
+            return json.loads(request_body)
+        except json.JSONDecodeError:
+            self._send_json_response(400, {"error": "Invalid JSON payload"})
+            return None
+
+    def _collect_response_payload(self, request_state: RequestState) -> Optional[dict]:
+        collected_text_segments: list[str] = []
+        token_count = 0
+        stop_reason = None
+        stop_string = None
+        stop_tokens: list[int] = []
+
+        while True:
+            result = request_state.result_queue.get()
+            if result is None:
+                error_message = request_state.error_message or "Unknown error"
+                self._send_json_response(500, {"error": error_message})
+                return None
+            if result.text != "":
+                collected_text_segments.append(result.text)
+            token_count += len(result.tokens)
+            if result.stop_condition is not None:
+                stop_reason = result.stop_condition.stop_reason
+                stop_string = result.stop_condition.stop_string
+                stop_tokens = result.stop_condition.stop_tokens
+                break
+
+        response_text = "".join(collected_text_segments)
+        return {
+            "request_slot_id": request_state.request_slot_id,
+            "cached_tokens": request_state.cached_tokens,
+            "total_prompt_tokens": request_state.total_prompt_tokens,
+            "text": response_text,
+            "token_count": token_count,
+            "stop_reason": stop_reason,
+            "stop_string": stop_string,
+            "stop_tokens": stop_tokens,
+        }
+
+    def _send_json_response(self, status_code: int, payload: dict) -> None:
+        response_bytes = json.dumps(payload).encode("utf-8")
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response_bytes)))
+        self.end_headers()
+        self.wfile.write(response_bytes)
+
+
+def setup_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Simple HTTP server using mlx-engine continuous batching"
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        type=str,
+        help="The file system path or model name to load",
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST, type=str)
+    parser.add_argument("--port", default=DEFAULT_PORT, type=int)
+    parser.add_argument("--max-kv-size", type=int)
+    parser.add_argument(
+        "--completion-batch-size",
+        default=8,
+        type=int,
+        help="Maximum number of active completion slots",
+    )
+    parser.add_argument(
+        "--prefill-batch-size",
+        default=2,
+        type=int,
+        help="Maximum number of prompts prefilling concurrently",
+    )
+    parser.add_argument(
+        "--prefill-step-size",
+        default=2048,
+        type=int,
+        help="Prompt prefill chunk size",
+    )
+    parser.add_argument("--default-max-tokens", default=DEFAULT_MAX_TOKENS, type=int)
+    return parser
+
+
+def main() -> None:
+    parser = setup_arg_parser()
+    arguments = parser.parse_args()
+
+    model_path = resolve_model_path(arguments.model)
+    print("Loading model...", flush=True)
+    model_kit = load_model(
+        model_path=model_path,
+        max_kv_size=arguments.max_kv_size,
+    )
+    print("Model load complete", flush=True)
+
+    batch_generator = create_batch_generator(
+        model_kit=model_kit,
+        completion_batch_size=arguments.completion_batch_size,
+        prefill_batch_size=arguments.prefill_batch_size,
+        prefill_step_size=arguments.prefill_step_size,
+    )
+    batch_scheduler = BatchScheduler(batch_generator)
+    batch_scheduler.start()
+
+    server = BatchHTTPServer(
+        (arguments.host, arguments.port),
+        BatchRequestHandler,
+        model_kit=model_kit,
+        batch_scheduler=batch_scheduler,
+        default_max_tokens=arguments.default_max_tokens,
+    )
+
+    print(f"Listening on http://{arguments.host}:{arguments.port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+        server.server_close()
+        batch_scheduler.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_engine/__init__.py
+++ b/mlx_engine/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "is_draft_model_compatible",
     "unload_draft_model",
     "create_generator",
+    "create_batch_generator",
     "tokenize",
 ]
 
@@ -27,6 +28,7 @@ from .generate import (
     create_generator,
     tokenize,
 )
+from .batch_generate import create_batch_generator
 
 patch_huggingface_hub()
 register_models()

--- a/mlx_engine/batch_generate.py
+++ b/mlx_engine/batch_generate.py
@@ -1,0 +1,613 @@
+from collections import deque
+from dataclasses import dataclass
+import inspect
+from typing import Any, Callable, Dict, List, Optional, Tuple
+import copy
+
+import mlx.core as mx
+from mlx_lm.generate import BatchGenerator
+from mlx_lm.models.cache import can_trim_prompt_cache, trim_prompt_cache
+from mlx_lm.sample_utils import make_sampler
+
+from mlx_engine.model_kit.model_kit import ModelKit
+from mlx_engine.vision_model_kit.vision_model_kit import VisionModelKit
+from mlx_engine.processors.repetition_penalty_processor import (
+    RepetitionPenaltyProcessor,
+)
+from mlx_engine.utils.token import Token
+from mlx_engine.utils.top_logprobs import summarize_top_logprobs
+from mlx_engine.stop_string_processor import (
+    StopStringProcessor,
+    StopStringProcessorResult,
+)
+from mlx_engine.utils.set_seed import set_seed
+from outlines.processors.structured import JSONLogitsProcessor
+from mlx_engine.utils.outlines_transformer_tokenizer import OutlinesTransformerTokenizer
+from mlx_engine.generate import GenerationStopCondition, MAX_TOP_LOGPROBS
+
+
+EPHEMERAL_SESSION_PREFIX = "__ephemeral_session/"
+
+
+@dataclass
+class BatchGenerationResult:
+    request_slot_id: int
+    text: str
+    tokens: List[Token]
+    top_logprobs: List[List[Token]]
+    stop_condition: Optional[GenerationStopCondition]
+
+
+class PromptCacheStore:
+    @dataclass
+    class CacheEntry:
+        prompt_cache: List[Any]
+        count: int
+
+    @dataclass
+    class SearchResult:
+        exact: Optional[List[int]]
+        shorter: Optional[List[int]]
+        longer: Optional[List[int]]
+        common_prefix: int
+
+    def __init__(self, max_size: int = 10):
+        self._max_size = max_size
+        self._cache_by_session: Dict[str, Dict[int, Dict[str, Any]]] = {}
+        self._least_recently_used: deque[Tuple[str, List[int]]] = deque()
+
+    def _search(self, session_id: str, tokens: List[int]) -> SearchResult:
+        if session_id not in self._cache_by_session:
+            return self.SearchResult(None, None, None, 0)
+
+        current_node = self._cache_by_session[session_id]
+        last_cache_index = -1
+        token_index = 0
+
+        while token_index < len(tokens) and tokens[token_index] in current_node:
+            current_node = current_node[tokens[token_index]]
+            if "cache" in current_node:
+                last_cache_index = token_index
+            token_index += 1
+
+        if last_cache_index == len(tokens) - 1:
+            return self.SearchResult(tokens, None, None, 0)
+
+        shorter = None
+        if last_cache_index > 0:
+            shorter = tokens[: last_cache_index + 1]
+
+        longer = None
+        common_prefix = token_index
+        if token_index > 0 and last_cache_index <= 0:
+            best_suffix = None
+            stack: List[Tuple[Dict[str, Any], List[int]]] = [(current_node, [])]
+            while len(stack) > 0:
+                next_node, suffix_tokens = stack.pop()
+                if "cache" in next_node:
+                    if best_suffix is None or len(suffix_tokens) < len(best_suffix):
+                        best_suffix = suffix_tokens
+                else:
+                    for token_value in next_node:
+                        stack.append((next_node[token_value], suffix_tokens + [token_value]))
+            if best_suffix is not None:
+                longer = tokens[:token_index] + best_suffix
+
+        return self.SearchResult(
+            tokens if last_cache_index == len(tokens) - 1 else None,
+            shorter,
+            longer,
+            common_prefix,
+        )
+
+    def _get(self, session_id: str, tokens: List[int]) -> CacheEntry:
+        current_node = self._cache_by_session[session_id]
+        for token_value in tokens:
+            current_node = current_node[token_value]
+        return current_node["cache"]
+
+    def _delete(self, session_id: str, tokens: List[int]) -> None:
+        path: List[Dict[str, Any]] = [self._cache_by_session[session_id]]
+        for token_value in tokens:
+            path.append(path[-1][token_value])
+        del path[-1]["cache"]
+        for index in reversed(range(len(tokens))):
+            previous_node = path[index]
+            next_node = path[index + 1]
+            token_value = tokens[index]
+            if len(next_node) > 0:
+                break
+            del previous_node[token_value]
+
+        if len(self._cache_by_session[session_id]) == 0:
+            del self._cache_by_session[session_id]
+
+    def _extract(self, session_id: str, tokens: List[int]) -> CacheEntry:
+        cache_entry = self._get(session_id, tokens)
+        if cache_entry.count == 1:
+            self._delete(session_id, tokens)
+            self._least_recently_used.remove((session_id, tokens))
+            return cache_entry
+
+        cache_entry.count -= 1
+        return self.CacheEntry(copy.deepcopy(cache_entry.prompt_cache), 1)
+
+    def fetch_nearest_cache(
+        self, session_id: str, tokens: List[int]
+    ) -> Tuple[Optional[List[Any]], List[int]]:
+        result = self._search(session_id, tokens)
+        if result.exact is not None:
+            cache_entry = self._extract(session_id, result.exact)
+            return cache_entry.prompt_cache, []
+
+        if result.shorter is not None:
+            cache_entry = self._extract(session_id, result.shorter)
+            prefix_length = len(result.shorter)
+            return cache_entry.prompt_cache, tokens[prefix_length:]
+
+        if result.longer is not None:
+            cache_entry = self._get(session_id, result.longer)
+            if can_trim_prompt_cache(cache_entry.prompt_cache):
+                cache_entry = self.CacheEntry(copy.deepcopy(cache_entry.prompt_cache), 1)
+                prefix_length = min(len(tokens) - 1, result.common_prefix)
+                num_to_trim = len(result.longer) - prefix_length
+                trim_prompt_cache(cache_entry.prompt_cache, num_to_trim)
+                return cache_entry.prompt_cache, tokens[prefix_length:]
+
+        return None, tokens
+
+    def insert_cache(self, session_id: str, tokens: List[int], prompt_cache: List[Any]) -> None:
+        if len(tokens) == 0:
+            return
+
+        if session_id not in self._cache_by_session:
+            self._cache_by_session[session_id] = {}
+        current_node = self._cache_by_session[session_id]
+        for token_value in tokens:
+            if token_value not in current_node:
+                current_node[token_value] = {}
+            current_node = current_node[token_value]
+
+        entry_key = (session_id, tokens)
+        if "cache" in current_node:
+            current_node["cache"].count += 1
+            if entry_key in self._least_recently_used:
+                self._least_recently_used.remove(entry_key)
+        else:
+            current_node["cache"] = self.CacheEntry(prompt_cache, 1)
+
+        self._least_recently_used.append(entry_key)
+        if len(self._least_recently_used) > self._max_size:
+            oldest_session_id, oldest_tokens = self._least_recently_used.popleft()
+            self._delete(oldest_session_id, oldest_tokens)
+
+
+@dataclass
+class BatchRequestState:
+    session_id: str
+    cache_key: List[int]
+    cached_tokens: int
+    total_prompt_tokens: int
+    detokenizer: Any
+    stop_string_processor: Optional[StopStringProcessor]
+    token_buffer: List[Token]
+    top_logprobs_buffer: List[List[Token]]
+    text_buffer: str
+    top_logprobs: int
+    should_cache: bool
+
+
+class BatchGeneratorWrapper:
+    """Continuous batching wrapper around mlx-lm's BatchGenerator."""
+
+    def __init__(
+        self,
+        model_kit: ModelKit,
+        *,
+        completion_batch_size: int = 32,
+        prefill_batch_size: int = 8,
+        prefill_step_size: int = 2048,
+        prompt_progress_callback: Optional[
+            Callable[[List[Tuple[int, int, int]]], None]
+        ] = None,
+    ):
+        if isinstance(model_kit, VisionModelKit):
+            raise ValueError("Batching is not supported for vision models")
+        # TODO(christian): it's not supported for speculative decoding, either, where to put?
+
+        self._model_kit = model_kit
+        self._tokenizer = model_kit.tokenizer
+        # the underlying BatchGenerator will only start to process new prompts if
+        # completion_batch_size - num_active_generations >= prefill_batch_size.
+        # if prefill_batch_size != 1, this can lead to situations where continuous batching
+        # appears to hang
+        self._batch_generator = BatchGenerator(
+            model_kit.model,
+            stop_tokens=self._tokenizer.eos_token_ids,
+            completion_batch_size=completion_batch_size,
+            prefill_batch_size=prefill_batch_size,
+            prefill_step_size=prefill_step_size,
+            prompt_progress_callback=prompt_progress_callback,
+        )
+        self._request_states: Dict[int, BatchRequestState] = {}
+        self._prompt_cache_store = PromptCacheStore()
+
+    def close(self) -> None:
+        """Close the batch generator and release its resources."""
+        self._batch_generator.close()
+
+    def insert(
+        self,
+        *,
+        session_id: str,
+        prompt_tokens: List[int],
+        max_tokens: int,
+        stop_strings: Optional[List[str]] = None,
+        top_logprobs: Optional[int] = None,
+        repetition_penalty: Optional[float] = None,
+        temp: Optional[float] = None,
+        top_p: Optional[float] = None,
+        min_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        seed: Optional[int] = None,
+        json_schema: Optional[str] = None,
+    ) -> Tuple[int, int, int]:
+        """
+        Insert a request into the batch generator.
+
+        This method configures caching, sampling, and stop string processing, then
+        enqueues a prompt into the underlying batch generator for batched inference.
+
+        Args:
+            session_id (str): Session identifier used for prompt caching.
+            prompt_tokens (List[int]): Prompt tokens to enqueue for generation.
+            max_tokens (int): Maximum number of tokens to generate.
+            stop_strings (Optional[List[str]]): Strings that stop generation when matched.
+            top_logprobs (Optional[int]): Number of top logprobs to include per token.
+            repetition_penalty (Optional[float]): Penalty applied to repeated tokens.
+            temp (Optional[float]): Sampling temperature.
+            top_p (Optional[float]): Top-p (nucleus) sampling parameter.
+            min_p (Optional[float]): Minimum probability threshold for sampling.
+            top_k (Optional[int]): Top-k sampling parameter.
+            seed (Optional[int]): Seed for deterministic sampling.
+            json_schema (Optional[str]): JSON schema for structured output.
+
+        Returns:
+            Tuple[int, int, int]: The request slot id, cached token count, and total prompt tokens.
+        """
+        if len(prompt_tokens) == 0:
+            prompt_tokens = self._model_kit.tokenize(" ")
+
+        if seed is not None:
+            set_seed(seed)
+
+        if top_logprobs is None:
+            top_logprobs = 0
+        if top_logprobs > MAX_TOP_LOGPROBS:
+            raise ValueError(
+                f"top_logprobs must be less than or equal to {MAX_TOP_LOGPROBS}"
+            )
+
+        should_cache = session_id != "" and not session_id.startswith(
+            EPHEMERAL_SESSION_PREFIX
+        )
+        prompt_cache = None
+        remaining_prompt_tokens = prompt_tokens
+        cached_tokens = 0
+        total_prompt_tokens = len(prompt_tokens)
+        if should_cache:
+            prompt_cache, remaining_prompt_tokens = self._prompt_cache_store.fetch_nearest_cache(
+                session_id, prompt_tokens
+            )
+            cached_tokens = total_prompt_tokens - len(remaining_prompt_tokens)
+
+        if len(remaining_prompt_tokens) == 0:
+            if prompt_cache is not None and can_trim_prompt_cache(prompt_cache):
+                trim_prompt_cache(prompt_cache, 1)
+                remaining_prompt_tokens = prompt_tokens[-1:]
+                cached_tokens = max(0, total_prompt_tokens - 1)
+            else:
+                prompt_cache = None
+                remaining_prompt_tokens = prompt_tokens
+                cached_tokens = 0
+
+        stop_strings = stop_strings if stop_strings is not None else []
+        stop_string_processor = (
+            StopStringProcessor(stop_strings, self._tokenizer)
+            if len(stop_strings) > 0
+            else None
+        )
+
+        logits_processors: List[Callable[[mx.array, mx.array], mx.array]] = []
+        if repetition_penalty is not None and repetition_penalty != 0.0:
+            if len(remaining_prompt_tokens) > 0:
+                token_history = prompt_tokens[:cached_tokens]
+            else:
+                token_history = prompt_tokens
+            logits_processors.append(
+                RepetitionPenaltyProcessor(
+                    token_history=token_history, repetition_penalty=repetition_penalty
+                )
+            )
+
+        if json_schema is not None and json_schema != "":
+            logits_processors.append(
+                JSONLogitsProcessor(
+                    json_schema,
+                    OutlinesTransformerTokenizer(self._tokenizer._tokenizer),
+                    tensor_library_name="mlx",
+                )
+            )
+
+        sampler = make_sampler(
+            temp=temp if temp is not None else 0.0,
+            top_p=top_p if top_p is not None else 0.0,
+            min_p=min_p if min_p is not None else 0.0,
+            top_k=top_k if top_k is not None else 0,
+        )
+
+        insert_parameters = inspect.signature(self._batch_generator.insert).parameters
+        insert_kwargs: Dict[str, Any] = {}
+        cache_list = [prompt_cache]
+        if "caches" in insert_parameters:
+            insert_kwargs["caches"] = cache_list
+        elif "cache" in insert_parameters:
+            insert_kwargs["cache"] = prompt_cache
+
+        if "samplers" in insert_parameters:
+            insert_kwargs["samplers"] = [sampler]
+        elif "sampler" in insert_parameters:
+            insert_kwargs["sampler"] = sampler
+
+        if "logits_processors" in insert_parameters:
+            insert_kwargs["logits_processors"] = [logits_processors]
+
+        request_slot_ids = self._batch_generator.insert(
+            [remaining_prompt_tokens],
+            max_tokens,
+            **insert_kwargs,
+        )
+        request_slot_id = request_slot_ids[0]
+        request_state = BatchRequestState(
+            session_id=session_id,
+            cache_key=list(prompt_tokens),
+            cached_tokens=cached_tokens,
+            total_prompt_tokens=total_prompt_tokens,
+            detokenizer=self._tokenizer.detokenizer,
+            stop_string_processor=stop_string_processor,
+            token_buffer=[],
+            top_logprobs_buffer=[],
+            text_buffer="",
+            top_logprobs=top_logprobs,
+            should_cache=should_cache,
+        )
+        self._request_states[request_slot_id] = request_state
+        return request_slot_id, cached_tokens, total_prompt_tokens
+
+    def remove(self, request_slot_ids: List[int]) -> None:
+        """
+        Remove requests by slot id from the batch generator and local state.
+
+        This method removes request state and informs the underlying batch generator
+        so that the request is no longer scheduled.
+
+        Args:
+            request_slot_ids (List[int]): Request slot ids to remove.
+
+        Returns:
+            None
+        """
+        if len(request_slot_ids) == 0:
+            return
+        self._batch_generator.remove(request_slot_ids)
+        for request_slot_id in request_slot_ids:
+            if request_slot_id in self._request_states:
+                del self._request_states[request_slot_id]
+
+    def next(self) -> List[BatchGenerationResult]:
+        """
+        Advance the batch generator and return any newly generated results.
+
+        This method steps the underlying batch generator and assembles results for
+        each request slot that produced tokens during this step.
+
+        Args:
+            None
+
+        Returns:
+            List[BatchGenerationResult]: Results generated since the last call.
+        """
+        results: List[BatchGenerationResult] = []
+        responses = self._batch_generator.next()
+        if len(responses) == 0:
+            return results
+
+        for response in responses:
+            request_slot_id = response.uid
+            request_state = self._request_states.get(request_slot_id)
+            if request_state is None:
+                continue
+            result = self._process_response(request_slot_id, response, request_state)
+            if result is not None:
+                results.append(result)
+
+        return results
+
+    def _process_response(
+        self,
+        request_slot_id: int,
+        response: BatchGenerator.Response,
+        request_state: BatchRequestState,
+    ) -> Optional[BatchGenerationResult]:
+        token_id = response.token
+        request_state.cache_key.append(token_id)
+
+        request_state.detokenizer.add_token(token_id)
+        text_segment = request_state.detokenizer.last_segment
+        if text_segment != "":
+            request_state.text_buffer += text_segment
+
+        logprob_value = response.logprobs[token_id].item()
+        token_entry = Token(
+            id=token_id, text=self._tokenizer.decode(token_id), logprob=float(logprob_value)
+        )
+        request_state.token_buffer.append(token_entry)
+
+        if request_state.top_logprobs > 0:
+            request_state.top_logprobs_buffer.append(
+                summarize_top_logprobs(
+                    self._tokenizer, response.logprobs, request_state.top_logprobs
+                )
+            )
+
+        if request_state.stop_string_processor is not None:
+            stop_result = request_state.stop_string_processor.process_token(token_id)
+            if stop_result.status == "full_stop":
+                stop_condition = self._handle_stop_string_detected(
+                    request_state, stop_result
+                )
+                prompt_cache = self._extract_prompt_cache_for_request_slot(request_slot_id)
+                self._batch_generator.remove([request_slot_id])
+                result = self._build_result(
+                    request_slot_id, request_state, stop_condition
+                )
+                self._finish_request(request_slot_id, request_state, prompt_cache)
+                return result
+            if stop_result.status in ("partial_match", "multi_byte"):
+                return None
+
+        if response.finish_reason is not None:
+            request_state.detokenizer.finalize()
+            if request_state.detokenizer.last_segment != "":
+                request_state.text_buffer += request_state.detokenizer.last_segment
+
+            stop_condition = self._finish_reason_to_stop_condition(
+                response.finish_reason, token_id
+            )
+            prompt_cache = response.prompt_cache
+            result = self._build_result(request_slot_id, request_state, stop_condition)
+            self._finish_request(request_slot_id, request_state, prompt_cache)
+            return result
+
+        if request_state.text_buffer != "":
+            return self._build_result(request_slot_id, request_state, None)
+        return None
+
+    def _handle_stop_string_detected(
+        self, request_state: BatchRequestState, stop_result: StopStringProcessorResult
+    ) -> GenerationStopCondition:
+        request_state.detokenizer.finalize()
+        if request_state.detokenizer.last_segment != "":
+            request_state.text_buffer += request_state.detokenizer.last_segment
+
+        stop_string = stop_result.stop_string or ""
+        stop_string_start = request_state.text_buffer.find(stop_string)
+        if stop_string_start != -1:
+            request_state.text_buffer = request_state.text_buffer[:stop_string_start]
+        stop_tokens = stop_result.stop_tokens if stop_result.stop_tokens is not None else []
+        return GenerationStopCondition(
+            stop_reason="stop_string",
+            stop_string=stop_string,
+            stop_tokens=stop_tokens,
+        )
+
+    def _finish_reason_to_stop_condition(
+        self, finish_reason: str, token_id: int
+    ) -> GenerationStopCondition:
+        if finish_reason == "stop":
+            return GenerationStopCondition(
+                stop_reason="eos_token",
+                stop_string=self._tokenizer.decode(token_id),
+                stop_tokens=[token_id],
+            )
+        if finish_reason == "length":
+            return GenerationStopCondition(
+                stop_reason="length",
+                stop_string="",
+                stop_tokens=[token_id],
+            )
+        return GenerationStopCondition(
+            stop_reason="length",
+            stop_string="",
+            stop_tokens=[token_id],
+        )
+
+    def _build_result(
+        self,
+        request_slot_id: int,
+        request_state: BatchRequestState,
+        stop_condition: Optional[GenerationStopCondition],
+    ) -> BatchGenerationResult:
+        tokens = list(request_state.token_buffer)
+        top_logprobs = list(request_state.top_logprobs_buffer)
+        text = request_state.text_buffer
+        request_state.token_buffer = []
+        request_state.top_logprobs_buffer = []
+        request_state.text_buffer = ""
+        return BatchGenerationResult(
+            request_slot_id=request_slot_id,
+            text=text,
+            tokens=tokens,
+            top_logprobs=top_logprobs,
+            stop_condition=stop_condition,
+        )
+
+    def _extract_prompt_cache_for_request_slot(
+        self, request_slot_id: int
+    ) -> Optional[List[Any]]:
+        batch = self._batch_generator.active_batch
+        if batch is None:
+            return None
+        if request_slot_id not in batch.uids:
+            return None
+        request_index = batch.uids.index(request_slot_id)
+        return batch.extract_cache(request_index)
+
+    def _finish_request(
+        self,
+        request_slot_id: int,
+        request_state: BatchRequestState,
+        prompt_cache: Optional[List[Any]],
+    ) -> None:
+        if request_state.should_cache and prompt_cache is not None:
+            self._prompt_cache_store.insert_cache(
+                request_state.session_id, request_state.cache_key, prompt_cache
+            )
+        if request_slot_id in self._request_states:
+            del self._request_states[request_slot_id]
+
+
+def create_batch_generator(
+    model_kit: ModelKit | VisionModelKit,
+    *,
+    completion_batch_size: int = 32,
+    prefill_batch_size: int = 8,
+    prefill_step_size: int = 2048,
+    prompt_progress_callback: Optional[
+        Callable[[List[Tuple[int, int, int]]], None]
+    ] = None,
+) -> BatchGeneratorWrapper:
+    """
+    Create a batch generator wrapper for continuous batching inference.
+
+    This function initializes a BatchGeneratorWrapper with batching-specific settings
+    and an optional prompt progress callback for reporting prefill progress.
+
+    Args:
+        model_kit (ModelKit | VisionModelKit): The model to use for batching.
+        completion_batch_size (int): Maximum number of concurrent completion slots.
+        prefill_batch_size (int): Maximum number of prompts prefilling concurrently.
+        prefill_step_size (int): Number of prompt tokens to prefill per step.
+        prompt_progress_callback (Optional[Callable[[List[Tuple[int, int, int]]], None]]):
+            Callback that receives prompt prefill progress events.
+
+    Returns:
+        BatchGeneratorWrapper: A wrapper that manages batch request insertion and iteration.
+    """
+    return BatchGeneratorWrapper(
+        model_kit,
+        completion_batch_size=completion_batch_size,
+        prefill_batch_size=prefill_batch_size,
+        prefill_step_size=prefill_step_size,
+        prompt_progress_callback=prompt_progress_callback,
+    )

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -35,7 +35,7 @@ from mlx_engine.utils.prompt_progress_reporter import (
 
 MAX_TOP_LOGPROBS = 10
 
-StopReason = Literal["eos_token", "stop_string", "user_cancelled"]
+StopReason = Literal["eos_token", "stop_string", "user_cancelled", "length"]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_batch_generator_wrapper.py
+++ b/tests/test_batch_generator_wrapper.py
@@ -1,0 +1,399 @@
+import pytest
+
+from mlx_engine.generate import (
+    MAX_TOP_LOGPROBS,
+    create_generator,
+    load_model,
+    tokenize,
+)
+from mlx_engine.batch_generate import create_batch_generator
+from tests.shared import model_getter
+
+MODEL_NAME = "lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit"
+PROMPT_TEXT = """<|im_start|>user
+Write one short sentence about continuous batching.
+<|im_end|>\n<|im_start|>assistant\n"""
+SECOND_PROMPT_TEXT = """<|im_start|>user
+Name two benefits of continuous batching.
+<|im_end|>\n<|im_start|>assistant\n"""
+ASYNC_PROMPT_TEXT = """<|im_start|>user
+Write a detailed, multi-paragraph explanation of continuous batching.
+<|im_end|>\n<|im_start|>assistant\n"""
+DEFAULT_MAX_TOKENS = 512
+MAX_ITERATIONS = DEFAULT_MAX_TOKENS * 4
+ASYNC_WAIT_CYCLES = 3
+VERBOSE = False
+
+
+@pytest.fixture(scope="module")
+def model_kit():
+    model_path = model_getter(MODEL_NAME)
+    return load_model(model_path=model_path, max_kv_size=4096)
+
+
+def _collect_request_tokens(
+    batch_generator,
+    request_slot_id: int,
+    max_iterations: int = MAX_ITERATIONS,
+) -> list[int]:
+    collected_tokens: list[int] = []
+    stop_emitted = False
+    iteration_count = 0
+    while stop_emitted is False and iteration_count < max_iterations:
+        batch_results = batch_generator.next()
+        iteration_count += 1
+        if len(batch_results) == 0:
+            continue
+        for result in batch_results:
+            if result.request_slot_id != request_slot_id:
+                continue
+            _print_batch_text(result.request_slot_id, result.text)
+            for token in result.tokens:
+                collected_tokens.append(token.id)
+            if result.stop_condition is not None:
+                stop_emitted = True
+                break
+    if stop_emitted is False:
+        raise AssertionError("Batch generator did not stop within the expected iterations")
+    return collected_tokens
+
+
+def _drain_request(
+    batch_generator,
+    request_slot_id: int,
+    max_iterations: int = MAX_ITERATIONS,
+) -> None:
+    stop_emitted = False
+    iteration_count = 0
+    while stop_emitted is False and iteration_count < max_iterations:
+        batch_results = batch_generator.next()
+        iteration_count += 1
+        if len(batch_results) == 0:
+            continue
+        for result in batch_results:
+            if result.request_slot_id != request_slot_id:
+                continue
+            _print_batch_text(result.request_slot_id, result.text)
+            if result.stop_condition is not None:
+                stop_emitted = True
+                break
+    if stop_emitted is False:
+        raise AssertionError("Batch generator did not stop within the expected iterations")
+
+
+def _collect_parallel_results(
+    batch_generator,
+    request_slot_ids: list[int],
+    max_iterations: int = MAX_ITERATIONS,
+) -> tuple[dict[int, list[int]], dict[int, object], bool]:
+    tokens_by_request: dict[int, list[int]] = {
+        request_slot_id: [] for request_slot_id in request_slot_ids
+    }
+    stop_conditions_by_request: dict[int, object] = {}
+    remaining_request_slot_ids = set(request_slot_ids)
+    iteration_count = 0
+    saw_interleaved = False
+
+    while len(remaining_request_slot_ids) > 0 and iteration_count < max_iterations:
+        batch_results = batch_generator.next()
+        iteration_count += 1
+        if len(batch_results) == 0:
+            continue
+        batch_request_slot_ids = set()
+        for result in batch_results:
+            request_slot_id = result.request_slot_id
+            if request_slot_id not in tokens_by_request:
+                continue
+            batch_request_slot_ids.add(request_slot_id)
+            _print_batch_text(request_slot_id, result.text)
+            for token in result.tokens:
+                tokens_by_request[request_slot_id].append(token.id)
+            if result.stop_condition is not None:
+                stop_conditions_by_request[request_slot_id] = result.stop_condition
+                if request_slot_id in remaining_request_slot_ids:
+                    remaining_request_slot_ids.remove(request_slot_id)
+        if len(batch_request_slot_ids) > 1:
+            saw_interleaved = True
+
+    if len(remaining_request_slot_ids) > 0:
+        raise AssertionError("Batch generator did not finish all requests in time")
+
+    return tokens_by_request, stop_conditions_by_request, saw_interleaved
+
+
+def _print_generation_text(text: str) -> None:
+    if not VERBOSE or text == "":
+        return
+    print(text, end="", flush=True)
+
+
+def _print_batch_text(request_slot_id: int, text: str) -> None:
+    if not VERBOSE or text == "":
+        return
+    print(f"[request {request_slot_id}] {text}", end="", flush=True)
+
+
+def test_create_generator_smoke_text_model(model_kit):
+    prompt_tokens = tokenize(model_kit, PROMPT_TEXT)
+    generated_text = ""
+    for result in create_generator(
+        model_kit=model_kit,
+        prompt_tokens=prompt_tokens,
+        max_tokens=DEFAULT_MAX_TOKENS,
+        seed=0,
+        temp=0.0,
+    ):
+        generated_text += result.text
+        _print_generation_text(result.text)
+        if result.stop_condition is not None:
+            break
+    assert len(generated_text) > 0
+
+
+def test_batch_generator_wrapper_caches_prompt_per_session(model_kit):
+    prompt_tokens = tokenize(model_kit, PROMPT_TEXT)
+    batch_generator = create_batch_generator(
+        model_kit=model_kit,
+        completion_batch_size=1,
+        prefill_batch_size=1,
+        prefill_step_size=8,
+    )
+    try:
+        (
+            first_request_slot_id,
+            cached_tokens,
+            total_prompt_tokens,
+        ) = batch_generator.insert(
+            session_id="session-a",
+            prompt_tokens=prompt_tokens,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+        assert cached_tokens == 0
+        assert total_prompt_tokens == len(prompt_tokens)
+
+        generated_tokens = _collect_request_tokens(
+            batch_generator, first_request_slot_id
+        )
+        assert len(generated_tokens) > 0
+
+        extended_prompt_tokens = prompt_tokens + generated_tokens
+        (
+            second_request_slot_id,
+            cached_tokens,
+            total_prompt_tokens,
+        ) = batch_generator.insert(
+            session_id="session-a",
+            prompt_tokens=extended_prompt_tokens,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+        assert cached_tokens > 0
+        assert cached_tokens < len(extended_prompt_tokens)
+        assert total_prompt_tokens == len(extended_prompt_tokens)
+        _drain_request(batch_generator, second_request_slot_id)
+
+        (
+            third_request_slot_id,
+            cached_tokens,
+            total_prompt_tokens,
+        ) = batch_generator.insert(
+            session_id="session-b",
+            prompt_tokens=extended_prompt_tokens,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+        assert cached_tokens == 0
+        assert total_prompt_tokens == len(extended_prompt_tokens)
+        _drain_request(batch_generator, third_request_slot_id)
+    finally:
+        batch_generator.close()
+
+
+def test_batch_generator_parallel_generation(model_kit):
+    prompt_tokens = tokenize(model_kit, PROMPT_TEXT)
+    second_prompt_tokens = tokenize(model_kit, SECOND_PROMPT_TEXT)
+    prompt_progress_events: list[tuple[int, int, int]] = []
+
+    def prompt_progress_callback(events: list[tuple[int, int, int]]) -> None:
+        prompt_progress_events.extend(events)
+
+    batch_generator = create_batch_generator(
+        model_kit=model_kit,
+        completion_batch_size=2,
+        prefill_batch_size=2,
+        prefill_step_size=8,
+        prompt_progress_callback=prompt_progress_callback,
+    )
+    try:
+        (
+            first_request_slot_id,
+            first_cached_tokens,
+            first_total_prompt_tokens,
+        ) = batch_generator.insert(
+            session_id="parallel-session-a",
+            prompt_tokens=prompt_tokens,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+        (
+            second_request_slot_id,
+            second_cached_tokens,
+            second_total_prompt_tokens,
+        ) = batch_generator.insert(
+            session_id="parallel-session-b",
+            prompt_tokens=second_prompt_tokens,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+
+        assert first_request_slot_id != second_request_slot_id
+        assert first_cached_tokens == 0
+        assert second_cached_tokens == 0
+        assert first_total_prompt_tokens == len(prompt_tokens)
+        assert second_total_prompt_tokens == len(second_prompt_tokens)
+
+        tokens_by_request, stop_conditions_by_request, saw_interleaved = _collect_parallel_results(
+            batch_generator, [first_request_slot_id, second_request_slot_id]
+        )
+        assert len(tokens_by_request[first_request_slot_id]) > 0
+        assert len(tokens_by_request[second_request_slot_id]) > 0
+        assert first_request_slot_id in stop_conditions_by_request
+        assert second_request_slot_id in stop_conditions_by_request
+        assert saw_interleaved is True
+
+        assert len(prompt_progress_events) > 0
+        for request_slot_id, processed_tokens, total_tokens in prompt_progress_events:
+            assert request_slot_id in (first_request_slot_id, second_request_slot_id)
+            assert processed_tokens <= total_tokens
+    finally:
+        batch_generator.close()
+
+
+def test_batch_generator_wrapper_rejects_top_logprobs_over_max(model_kit):
+    prompt_tokens = tokenize(model_kit, "Hello from the batch generator.")
+    batch_generator = create_batch_generator(
+        model_kit=model_kit,
+        completion_batch_size=1,
+        prefill_batch_size=1,
+        prefill_step_size=8,
+    )
+    try:
+        with pytest.raises(ValueError):
+            batch_generator.insert(
+                session_id="session-a",
+                prompt_tokens=prompt_tokens,
+                max_tokens=DEFAULT_MAX_TOKENS,
+                top_logprobs=MAX_TOP_LOGPROBS + 1,
+            )
+    finally:
+        batch_generator.close()
+
+
+def test_batch_generator_returns_top_logprobs(model_kit):
+    prompt_tokens = tokenize(model_kit, "Return a short response.")
+    batch_generator = create_batch_generator(
+        model_kit=model_kit,
+        completion_batch_size=1,
+        prefill_batch_size=1,
+        prefill_step_size=8,
+    )
+    try:
+        (
+            request_slot_id,
+            cached_tokens,
+            total_prompt_tokens,
+        ) = batch_generator.insert(
+            session_id="top-logprobs-session",
+            prompt_tokens=prompt_tokens,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            top_logprobs=1,
+        )
+        assert cached_tokens == 0
+        assert total_prompt_tokens == len(prompt_tokens)
+
+        top_logprobs_entries: list[list] = []
+        stop_emitted = False
+        iteration_count = 0
+        while stop_emitted is False and iteration_count < MAX_ITERATIONS:
+            batch_results = batch_generator.next()
+            iteration_count += 1
+            if len(batch_results) == 0:
+                continue
+            for result in batch_results:
+                if result.request_slot_id != request_slot_id:
+                    continue
+                _print_batch_text(result.request_slot_id, result.text)
+                if len(result.top_logprobs) > 0:
+                    top_logprobs_entries.extend(result.top_logprobs)
+                if result.stop_condition is not None:
+                    stop_emitted = True
+                    break
+
+        assert stop_emitted is True
+        assert len(top_logprobs_entries) > 0
+        for entry in top_logprobs_entries:
+            assert len(entry) == 1
+    finally:
+        batch_generator.close()
+
+
+def test_batch_generator_async_insert(model_kit):
+    prompt_tokens = tokenize(model_kit, ASYNC_PROMPT_TEXT)
+    second_prompt_tokens = tokenize(model_kit, SECOND_PROMPT_TEXT)
+    batch_generator = create_batch_generator(
+        model_kit=model_kit,
+        completion_batch_size=2,
+        prefill_batch_size=1,
+        prefill_step_size=8,
+    )
+    try:
+        (
+            first_request_slot_id,
+            first_cached_tokens,
+            first_total_prompt_tokens,
+        ) = batch_generator.insert(
+            session_id="async-session-a",
+            prompt_tokens=prompt_tokens,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+        assert first_cached_tokens == 0
+        assert first_total_prompt_tokens == len(prompt_tokens)
+
+        cycle_count = 0
+        stop_before_insert = False
+        while cycle_count < ASYNC_WAIT_CYCLES and stop_before_insert is False:
+            batch_results = batch_generator.next()
+            cycle_count += 1
+            if len(batch_results) == 0:
+                continue
+            for result in batch_results:
+                if result.request_slot_id != first_request_slot_id:
+                    continue
+                _print_batch_text(result.request_slot_id, result.text)
+                if result.stop_condition is not None:
+                    stop_before_insert = True
+                    break
+
+        if stop_before_insert is True:
+            raise AssertionError(
+                "Async insert test ended early; reduce ASYNC_WAIT_CYCLES or adjust ASYNC_PROMPT_TEXT."
+            )
+        
+        (
+            second_request_slot_id,
+            second_cached_tokens,
+            second_total_prompt_tokens,
+        ) = batch_generator.insert(
+            session_id="async-session-b",
+            prompt_tokens=second_prompt_tokens,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+        assert second_cached_tokens == 0
+        assert second_total_prompt_tokens == len(second_prompt_tokens)
+
+        tokens_by_request, stop_conditions_by_request, saw_interleaved = _collect_parallel_results(
+            batch_generator, [first_request_slot_id, second_request_slot_id]
+        )
+        assert len(tokens_by_request[first_request_slot_id]) > 0
+        assert len(tokens_by_request[second_request_slot_id]) > 0
+        assert first_request_slot_id in stop_conditions_by_request
+        assert second_request_slot_id in stop_conditions_by_request
+        assert saw_interleaved is True
+    finally:
+        batch_generator.close()


### PR DESCRIPTION
This draft PR introduces continuous batching support for mlx-engine.

Conveniently, this is mostly handled under the hood in mlx-lm by the `BatchGenerator`. This PR introduces a `BatchGeneratorWrapper` and a few other utilities to (roughly) adapt this to the previous `create_generator` API, as well as a server demo that I used in debugging.

## Additions

`create_batch_generator`: Creates the `BatchGeneratorWrapper`. This should be called (ideally only) once, at the beginning of the lifecycle of the `ModelKit`. The `BatchGeneratorWrapper`, being stateful, should be kept alive between generations.

`BatchGeneratorWrapper`: Stateful wrapper around `BatchGenerator` to wire through a `ModelKit`, performs MOSTLY the same operations as `create_generator` in the current API (e.g. tracking stop strings, setting up generation, etc. See "Open problems").
The major methods of the `BatchGenerator` are as follows:
- `insert()`: Schedule/queue a prediction request. This is the most direct equivalent of the previous `create_generator`.
- `remove()`: Deschedule a prediction request or list of such.
- `next()`: Advance the batch generator, obtaining the next results for each request slot. **This requires a separate thread to be kept alive to constantly be calling `next()`, unlike the old design!**

`PromptCacheStore`: Per-session prompt cache store across (parallel) requests. Stores cache prefixes in a trie-like structure and evicts oldest entries. We can change the caching method in the future (per-slot cache instead of overall, for instance) but I thought this was reasonable for now.

`demo_server.py`: Example server to host continuous batching through the continuous batching API developed here. I had Codex write this and vetted it. Seems to work fine.

I also added a few tests to `tests/test_batch_generator_wrapper.py` to validate the basic behavior of continuous batching.

### Open problems
- **There is no support for VLMs or speculative decoding yet.**
- Related to the latter, `BatchGenerator` lacks many of the features of `stream_generate`, which can be roughly summed up in the difference between the signatures of `create_generator` and `BatchGeneratorWrapper.insert`. For instance, there is currently no way to wire up a prompt progress callback for a particular slot. Likely we will have to figure out how to get as much of this back as possible.

cc @neilmehta24 @yagil 