### PR TITLE
Add unit test for batched gen

### DIFF
--- a/tests/test_batched_generation.py
+++ b/tests/test_batched_generation.py
@@ -2,6 +2,7 @@ import pytest
 import threading
 import time
 
+from mlx_engine.model_kit.batched_model_kit import BatchedModelKit
 from tests.shared import model_getter
 from mlx_engine.generate import load_model, create_generator, tokenize, unload
 
@@ -17,6 +18,8 @@ def model_kit():
 
 def test_batched_generation_two_threads(model_kit):
     """Test batched generation with two concurrent threads."""
+
+    assert isinstance(model_kit, BatchedModelKit)
 
     # Define two different prompts with different topics
     prompts = [


### PR DESCRIPTION
### Test output
<img width="1422" height="512" alt="Screenshot 2026-02-05 at 12 30 23 PM" src="https://github.com/user-attachments/assets/9153ab76-e4c2-4b85-a607-806776337cdd" />

### Codex review
<img width="1422" height="209" alt="Screenshot 2026-02-05 at 12 51 03 PM" src="https://github.com/user-attachments/assets/ed669898-4350-422d-b069-d7db41792e26" />

Don't think either of the points are relevant.
- The wall clock time for generation is less than a second. We're guaranteed to be running on a GPU
- `seed` is fixed, so generation should be mostly deterministic. The test is only looking for a single keyword, case insensitive. We probably want to have this test break if generation quality degrades enough on these simple prompts.