### PR TITLE
Raise error when parallel batching for vision is configured

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -178,6 +178,10 @@ if __name__ == "__main__":
     # Parse arguments
     parser = setup_arg_parser()
     args = parser.parse_args()
+    max_seq_nums = 4
+    if args.images is not None:
+        max_seq_nums = 1
+
     if isinstance(args.images, str):
         args.images = [args.images]
 
@@ -191,6 +195,7 @@ if __name__ == "__main__":
         kv_bits=args.kv_bits,
         kv_group_size=args.kv_group_size,
         quantized_kv_start=args.quantized_kv_start,
+        max_seq_nums=max_seq_nums,
     )
     print("\rModel load complete ✓", end="\n", flush=True)
 

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -180,7 +180,10 @@ def load_model(
             raise ValueError(
                 "MLX vision models do not currently support KV cache quantization"
             )
-        warn_if_parallel("vision models do not support continuous batching yet")
+        if parallel_requested:
+            raise ValueError(
+                "numParallelSessions must be 1 for vision models as they do not currently support continuous batching"
+            )
         model_kit = VisionModelKit(model_path, vocab_only, trust_remote_code)
     else:
         # For non-vision models or ModelKit-supported vision models, choose between
@@ -214,9 +217,10 @@ def load_model(
                 return False
             # 3. Vision models are not compatible with batching yet
             if "vision_config" in config_json:
-                warn_if_parallel(
-                    "concurrency is not supported with image models right now"
-                )
+                if parallel_requested:
+                    raise ValueError(
+                        "numParallelSessions must be 1 for vision models as they do not currently support continuous batching"
+                    )
                 return False
             return True
 

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -50,7 +50,10 @@ class TestVisionModels:
 
         # Load the model
         model_kit = load_model(
-            model_path=model_path, max_kv_size=2048, trust_remote_code=True
+            model_path=model_path,
+            max_kv_size=2048,
+            max_seq_nums=1,
+            trust_remote_code=True,
         )
 
         # Tokenize the prompt
@@ -187,7 +190,11 @@ class TestVisionModels:
         """Ensure that text only prompts with vlms take full advantage of caching generated tokens"""
         model_path = model_getter(model)
 
-        model_kit = load_model(model_path=model_path, max_kv_size=MAX_KV_CACHE_SIZE)
+        model_kit = load_model(
+            model_path=model_path,
+            max_kv_size=MAX_KV_CACHE_SIZE,
+            max_seq_nums=1,
+        )
 
         def generate_text(prompt):
             prompt_tokens = tokenize(model_kit, prompt)
@@ -292,7 +299,11 @@ class TestVisionModels:
 
     def test_qwen2_5_images_across_messages(self):
         model_path = model_getter("mlx-community/Qwen2.5-VL-7B-Instruct-4bit")
-        model_kit = load_model(model_path=model_path, max_kv_size=MAX_KV_CACHE_SIZE)
+        model_kit = load_model(
+            model_path=model_path,
+            max_kv_size=MAX_KV_CACHE_SIZE,
+            max_seq_nums=1,
+        )
 
         def generate_text(prompt, images_b64):
             prompt_tokens = tokenize(model_kit, prompt)
@@ -455,7 +466,11 @@ You are a helpful assistant.<|im_end|>
     def test_gemma3_text_only_generation_caching(self):
         """Ensure that text only prompts with vlms take full advantage of caching generated tokens"""
         model_path = model_getter("mlx-community/gemma-3-4b-it-4bit")
-        model_kit = load_model(model_path=model_path, max_kv_size=MAX_KV_CACHE_SIZE)
+        model_kit = load_model(
+            model_path=model_path,
+            max_kv_size=MAX_KV_CACHE_SIZE,
+            max_seq_nums=1,
+        )
 
         def generate_text(prompt):
             prompt_tokens = tokenize(model_kit, prompt)
@@ -511,7 +526,11 @@ You are a helpful assistant.<|im_end|>
     def test_gemma3_text_only_long_original_prompt_caching(self):
         """Ensure that text only prompts with vlms take full advantage of caching generated tokens"""
         model_path = model_getter("mlx-community/gemma-3-4b-it-4bit")
-        model_kit = load_model(model_path=model_path, max_kv_size=MAX_KV_CACHE_SIZE)
+        model_kit = load_model(
+            model_path=model_path,
+            max_kv_size=MAX_KV_CACHE_SIZE,
+            max_seq_nums=1,
+        )
         print(type(model_kit))
 
         def generate_text(prompt):
@@ -587,7 +606,11 @@ Summarize this in one sentence<end_of_turn>
     def test_gemma3n_text_only_generation_caching(self):
         """Ensure that text only prompts with vlms take full advantage of caching generated tokens"""
         model_path = model_getter("lmstudio-community/gemma-3n-E2B-it-MLX-4bit")
-        model_kit = load_model(model_path=model_path, max_kv_size=MAX_KV_CACHE_SIZE)
+        model_kit = load_model(
+            model_path=model_path,
+            max_kv_size=MAX_KV_CACHE_SIZE,
+            max_seq_nums=1,
+        )
 
         def generate_text(prompt):
             prompt_tokens = tokenize(model_kit, prompt)
@@ -644,7 +667,11 @@ Summarize this in one sentence<end_of_turn>
     def test_gemma3n_text_only_long_original_prompt_caching(self):
         """Ensure that text only prompts with vlms take full advantage of caching generated tokens"""
         model_path = model_getter("lmstudio-community/gemma-3n-E2B-it-MLX-4bit")
-        model_kit = load_model(model_path=model_path, max_kv_size=MAX_KV_CACHE_SIZE)
+        model_kit = load_model(
+            model_path=model_path,
+            max_kv_size=MAX_KV_CACHE_SIZE,
+            max_seq_nums=1,
+        )
 
         def generate_text(prompt):
             prompt_tokens = tokenize(model_kit, prompt)
@@ -706,7 +733,11 @@ Summarize this in one sentence<end_of_turn>
     def test_gemma3n_vision_long_prompt_progress_reported(self):
         """Ensure progress is reported during prompt processing with a vision prompt"""
         model_path = model_getter("lmstudio-community/gemma-3n-E2B-it-MLX-4bit")
-        model_kit = load_model(model_path=model_path, max_kv_size=MAX_KV_CACHE_SIZE)
+        model_kit = load_model(
+            model_path=model_path,
+            max_kv_size=MAX_KV_CACHE_SIZE,
+            max_seq_nums=1,
+        )
 
         file_path = self.test_data_dir / "ben_franklin_autobiography_start.txt"
         file_content = file_path.read_text()
@@ -758,7 +789,7 @@ Summarize this in one sentence<end_of_turn>
         draft_model_path = model_getter(
             "lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit"
         )
-        model_kit = load_model(model_path=model_path)
+        model_kit = load_model(model_path=model_path, max_seq_nums=1)
         assert not is_draft_model_compatible(model_kit=model_kit, path=draft_model_path)
 
     @pytest.mark.heavy


### PR DESCRIPTION
Raise an Error when setting `max_seq_nums` greater than 1 for vision models.

Here is the codex review, which I am disregarding:
```
• The new error on vision models makes the default load_model behavior fail when max_seq_nums isn’t explicitly set, which is a regression from the previous warning-based fallback and breaks existing
  callers that rely on defaults.

  Review comment:

  - [P2] Avoid raising for default vision model loads — mlx_engine/generate.py:183-185
    max_seq_nums defaults to 4, so parallel_requested is true even when callers don’t explicitly request batching. With this new ValueError, any load_model(...) call that doesn’t override max_seq_nums
    now fails for vision models (e.g., batched_demo.py loads images without passing max_seq_nums). Previously this only warned and fell back to sequential processing. Consider clamping to 1 for vision
    models or keeping the warning to avoid breaking default loads.
```