### PR TITLE
Add `mode` parameter to quantization options, allowing other quantization mode to work with vision add-on.

### DIFF
--- a/mlx_engine/model_kit/vision_add_ons/load_utils.py
+++ b/mlx_engine/model_kit/vision_add_ons/load_utils.py
@@ -160,6 +160,8 @@ def maybe_apply_quantization(
             quantize_kwargs["bits"] = quantization["bits"]
         if "group_size" in quantization:
             quantize_kwargs["group_size"] = quantization["group_size"]
+        if "mode" in quantization:
+            quantize_kwargs["mode"] = quantization["mode"]
         nn.quantize(
             components,
             class_predicate=get_class_predicate,


### PR DESCRIPTION
## TL;DR
`model_kit.vision_add_ons.load_utils.maybe_apply_quantization()` ignored `quantization.mode`.
Without this `mode` parameter, anything other than `affine` would break.

## Difference
**Before** this fix, `mxfp8` vision wouldn't load properly:
- Wrongly use `affine` mode when it should be `mxfp8`
- Complain missing `biases` parameters in `multi_modal_projector`
- `affine` quants can work (default is `affine`), which is to be expected.
Logs in lmstudio-ai/lmstudio-bug-tracker#1490

**After** this fix, both `mxfp8` and `affine` can work (tested that model).
And I assume `mxfp4`, `nvfp4` would also work, because this change only pass the `mode` kwarg.
If need more testing, I can also try other quantization modes.
But if dear reviewers have other model locally, please give it a test too, because I don't have that many downloaded.

## Tested model
`mistralai/Ministral-3-14B-Reasoning-2512` quantized using `mlx-vlm` version 0.3.11:
- `affine qgroup32 8bit`
- `mxfp8`
- Other tests in `tests/`

Sorry if the PR breaks the contribution guidelines, I followed it to my best understanding.