### PR TITLE
Use ModelKit if max_seq_nums is explicitly set to 1

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -225,7 +225,9 @@ def load_model(
             return True
 
         batchable = is_batchable()
-        # If max_seq_nums is set to 1, use ModelKit instead of BatchedModelKit. This gives users an escape hatch, which they could use to enable spec decoding. We can remove this additional restriction once we add spec decoding support to the batched backend
+        # If max_seq_nums is set to 1, use ModelKit instead of BatchedModelKit. This gives users an escape hatch,
+        # which they could use to enable spec decoding. We can remove this additional restriction once we add
+        # spec decoding support to the batched backend
         use_batched_kit = batchable and max_seq_nums != 1
 
         if use_batched_kit:


### PR DESCRIPTION
Provide an escape hatch to enable spec decoding for text models. Ref https://github.com/lmstudio-ai/mlx-engine/issues/269

Codex review:
<img width="1375" height="99" alt="Screenshot 2026-02-09 at 3 15 05 PM" src="https://github.com/user-attachments/assets/5785729e-95fe-4db0-99d4-5c902a1c1ee4" />
