### PR TITLE
Set max_seq_nums to 1 in demo.py

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -178,9 +178,7 @@ if __name__ == "__main__":
     # Parse arguments
     parser = setup_arg_parser()
     args = parser.parse_args()
-    max_seq_nums = 4
-    if args.images is not None:
-        max_seq_nums = 1
+    max_seq_nums = 1
 
     if isinstance(args.images, str):
         args.images = [args.images]


### PR DESCRIPTION
This PR sets `max_seq_nums` to 1 in `demo.py`.

I hit an issue where I cannot run a vision model with a text only prompt via `demo.py` because load fails with

```
ValueError: numParallelSessions must be 1 for vision models as they do not currently support continuous batching
```

The `demo.py` script doesn't do anything with parallel decoding slots anyway, and there already is a separate `batched_demo.py` to exercise that feature.