### PR TITLE
GPT-OSS prompt caching fix

### DIFF
--- a/mlx_engine/cache_wrapper.py
+++ b/mlx_engine/cache_wrapper.py
@@ -93,6 +93,10 @@ class CacheWrapper:
         for c in self.cache:
             if hasattr(c, "offset"):
                 return c.offset
+        # Fallback: use the length of tracked tokens if cache offset is unavailable
+        # This handles models where cache layers don't expose offset (e.g., GPT-OSS)
+        if self.tokens is not None:
+            return len(self.tokens)
         return None
 
     @staticmethod

--- a/mlx_engine/model_kit/batched_model_kit.py
+++ b/mlx_engine/model_kit/batched_model_kit.py
@@ -318,8 +318,11 @@ class BatchedModelKit:
                 )
 
                 # Track this request
+                # Use separate tracking for cross-prompt cache key (original prompt only)
+                # and live cache key (updated during generation for intra-request caching)
                 self._batch_results[uid] = {
-                    "cache_key": request.prompt_tokens[:],
+                    "cross_prompt_cache_key": request.prompt_tokens[:],
+                    "live_cache_key": request.prompt_tokens[:],
                     "rqueue": request.rqueue,
                     "detokenizer": self.tokenizer.detokenizer,
                     "top_logprobs": request.top_logprobs,
@@ -346,7 +349,7 @@ class BatchedModelKit:
                 for r in responses:
                     # Create response object
                     result = self._batch_results[r.uid]
-                    result["cache_key"].append(r.token)
+                    result["live_cache_key"].append(r.token)
                     if r.finish_reason != "stop":
                         result["detokenizer"].add_token(r.token)
                     token_logprob = r.logprobs[r.token].item()
@@ -386,8 +389,13 @@ class BatchedModelKit:
                     # Clean up if necessary
                     if r.finish_reason is not None:
                         result["rqueue"].put(None)
+                        # Use cross_prompt_cache_key for cross-prompt caching
+                        # This ensures the cache is keyed by the original prompt,
+                        # not by the prompt + generated tokens
                         self._prompt_cache.insert_cache(
-                            current_model_key, result["cache_key"], r.prompt_cache
+                            current_model_key,
+                            result["cross_prompt_cache_key"],
+                            r.prompt_cache,
                         )
                         del self._batch_results[r.uid]
 

--- a/tests/test_cache_wrapper.py
+++ b/tests/test_cache_wrapper.py
@@ -42,6 +42,7 @@ class TestCacheWrapper(unittest.TestCase):
 
     def test_prompt_processing_cancellation(self):
         """Test that progress is saved when processing is cancelled and cache is reused on retry"""
+        self.skipTest("Requires model download")
 
         model_path = model_getter("lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit")
         model_kit = load_model(model_path=model_path, max_kv_size=4096)
@@ -92,6 +93,21 @@ class TestCacheWrapper(unittest.TestCase):
 
         # Verify that the second attempt completed successfully
         self.assertIsNotNone(result_tokens)
+
+    def test_get_num_tokens_in_cache_without_offset(self):
+        """Test that _get_num_tokens_in_cache falls back to len(self.tokens) when offset is unavailable"""
+        mock_cache = [object() for _ in range(10)]
+
+        wrapper = object.__new__(CacheWrapper)
+        wrapper.cache = mock_cache
+        wrapper.tokens = mx.array([1, 2, 3, 4, 5])
+
+        result = wrapper._get_num_tokens_in_cache()
+        self.assertEqual(result, 5)
+
+        wrapper.tokens = None
+        result = wrapper._get_num_tokens_in_cache()
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/tests/test_cache_wrapper.py
+++ b/tests/test_cache_wrapper.py
@@ -42,7 +42,6 @@ class TestCacheWrapper(unittest.TestCase):
 
     def test_prompt_processing_cancellation(self):
         """Test that progress is saved when processing is cancelled and cache is reused on retry"""
-        self.skipTest("Requires model download")
 
         model_path = model_getter("lmstudio-community/Qwen2.5-0.5B-Instruct-MLX-8bit")
         model_kit = load_model(model_path=model_path, max_kv_size=4096)


### PR DESCRIPTION
Fixes https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/1697

Fixed prompt caching for GPT-OSS 20B MLX models.

Two fixes:

1. cache_wrapper.py: Added fallback when cache layers don't expose `offset` attribute
2. batched_model_kit.py: Separated cross-prompt cache key from live cache key

The main issue was that batched models (like GPT-OSS) were tracking generated tokens in the cross-prompt cache key, preventing cache hits for new prompts with overlapping content.

Testing:

- Unit test added in tests/test_cache_wrapper.py
- Verified locally with GPT-OSS 20B model in LM Studio (replaced the contents of `~/.lmstudio/extensions/backends/vendor/_amphibian/app-mlx-generate-mac14-arm64@20/lib/python3.11/site-packages/mlx_engine/` with the updated file)