### PR TITLE
Upgrade mlx-lm and update to use new BatchedGeneration API

### DIFF
--- a/mlx_engine/model_kit/batched_model_kit.py
+++ b/mlx_engine/model_kit/batched_model_kit.py
@@ -78,22 +78,28 @@ def _prepare_prompt_cache_for_generation(
     prompt_cache: LRUPromptCache, model_key: str, prompt_tokens: list[int]
 ):
     """
-    Return a cache plus prompt suffix that always leaves one token available to
-    seed the first generation step.
+    Return `(cache, cached_prefix, rest)` while ensuring batched decode still
+    has one prompt token left to seed its first generation step.
     """
 
+    # Start from mlx-lm's nearest reusable cache entry.
     cache, rest = prompt_cache.fetch_nearest_cache(model_key, prompt_tokens)
+
+    # Any uncached suffix already leaves a seed token outside the cache.
     if rest:
         cached_prefix_len = len(prompt_tokens) - len(rest)
         return cache, prompt_tokens[:cached_prefix_len], rest
 
+    # Empty prompts have no seed token to preserve.
     if len(prompt_tokens) == 0:
         return cache, [], []
 
+    # Exact cache hits need one token moved out of cache to start decoding.
     if cache is not None and can_trim_prompt_cache(cache):
         trim_prompt_cache(cache, 1)
         return cache, prompt_tokens[:-1], prompt_tokens[-1:]
 
+    # If we cannot trim an exact-hit cache, replay the full prompt instead.
     return None, [], prompt_tokens
 
 

--- a/mlx_engine/model_kit/batched_model_kit.py
+++ b/mlx_engine/model_kit/batched_model_kit.py
@@ -35,6 +35,9 @@ class _BatchedLogitsProcessorAdapter:
     BatchGenerator keeps prompt history in Python lists and passes the history
     before the current input token has been appended. Our processors are written
     against the sequential contract, so we restore that view here.
+
+    Remove this adapter after https://github.com/ml-explore/mlx-lm/pull/1115
+    is merged.
     """
 
     def __init__(self, processors, initial_input_tokens):

--- a/mlx_engine/model_kit/batched_model_kit.py
+++ b/mlx_engine/model_kit/batched_model_kit.py
@@ -8,6 +8,7 @@ import logging
 from mlx_engine.utils.fix_mistral_pre_tokenizer import fix_mistral_pre_tokenizer
 from mlx_lm.tokenizer_utils import TokenizerWrapper, StreamingDetokenizer
 from mlx_lm.generate import BatchGenerator
+from mlx_lm.models.cache import can_trim_prompt_cache, trim_prompt_cache
 import mlx.nn as nn
 import mlx.core as mx
 from pathlib import Path
@@ -27,45 +28,70 @@ from mlx_engine.model_kit.batched_model_kit_types import (
 logger = logging.getLogger(__name__)
 
 
-def _make_batched_logits_processor(processor, state, trim_prefix_len):
-    def wrapped(tokens, logits):
-        # Newer mlx-lm batch generation passes Python token lists here,
-        # while our processors still expect an MLX array.
-        if not hasattr(tokens, "shape"):
-            tokens = mx.array(tokens)
+class _BatchedLogitsProcessorAdapter:
+    """
+    Adapt mlx-engine logits processors to mlx-lm's batched generation contract.
 
-        if trim_prefix_len > 0:
-            tokens = tokens[trim_prefix_len:]
+    BatchGenerator keeps prompt history in Python lists and passes the history
+    before the current input token has been appended. Our processors are written
+    against the sequential contract, so we restore that view here.
+    """
 
-        # In batched mlx-lm, logits processors are called before the current
-        # input token has been appended to `tokens`. Restore the sequential-path
-        # view by appending the token that was just fed into the model.
-        pending_input_tokens = state["pending_input_tokens"]
-        if pending_input_tokens is not None and pending_input_tokens.size > 0:
-            tokens = mx.concatenate([tokens, pending_input_tokens])
+    def __init__(self, processors, initial_input_tokens):
+        self._processors = processors or []
+        self._current_input_tokens = (
+            mx.array(initial_input_tokens) if initial_input_tokens else None
+        )
 
-        return processor(tokens, logits)
+    def sampler(self, sampler):
+        if sampler is None:
+            return None
 
-    return wrapped
+        def wrapped(logprobs):
+            sampled = sampler(logprobs)
+            self._current_input_tokens = mx.array(sampled).reshape(-1)
+            return sampled
+
+        return wrapped
+
+    def logits_processors(self):
+        return [self._wrap_processor(processor) for processor in self._processors]
+
+    def _wrap_processor(self, processor):
+        def wrapped(tokens, logits):
+            if not hasattr(tokens, "shape"):
+                tokens = mx.array(tokens)
+            if (
+                self._current_input_tokens is not None
+                and self._current_input_tokens.size > 0
+            ):
+                tokens = mx.concatenate([tokens, self._current_input_tokens])
+            return processor(tokens, logits)
+
+        return wrapped
 
 
-def _wrap_batched_sampler(sampler, state):
-    if sampler is None:
-        return None
+def _prepare_prompt_cache_for_generation(
+    prompt_cache: LRUPromptCache, model_key: str, prompt_tokens: list[int]
+):
+    """
+    Return a cache plus prompt suffix that always leaves one token available to
+    seed the first generation step.
+    """
 
-    def wrapped(logprobs):
-        sampled = sampler(logprobs)
-        state["pending_input_tokens"] = mx.array(sampled).reshape(-1)
-        return sampled
+    cache, rest = prompt_cache.fetch_nearest_cache(model_key, prompt_tokens)
+    if rest:
+        cached_prefix_len = len(prompt_tokens) - len(rest)
+        return cache, prompt_tokens[:cached_prefix_len], rest
 
-    return wrapped
+    if len(prompt_tokens) == 0:
+        return cache, [], []
 
+    if cache is not None and can_trim_prompt_cache(cache):
+        trim_prompt_cache(cache, 1)
+        return cache, prompt_tokens[:-1], prompt_tokens[-1:]
 
-def _wrap_batched_logits_processors(logits_processors, state, trim_prefix_len=0):
-    return [
-        _make_batched_logits_processor(processor, state, trim_prefix_len)
-        for processor in (logits_processors or [])
-    ]
+    return None, [], prompt_tokens
 
 
 class BatchedModelKit:
@@ -336,31 +362,21 @@ class BatchedModelKit:
                         logger.warning(f"Could not cancel {request_id=} (id not found)")
                     continue
 
-                # Get cache
-                cache, rest = self._prompt_cache.fetch_nearest_cache(
-                    current_model_key, request.prompt_tokens
+                cache, cached_prefix, rest = _prepare_prompt_cache_for_generation(
+                    self._prompt_cache, current_model_key, request.prompt_tokens
                 )
-                initial_tokens = rest[-1:]
-                trim_prefix_len = max(len(rest) - len(initial_tokens), 0)
-                state = {
-                    "pending_input_tokens": (
-                        mx.array(initial_tokens) if initial_tokens else None
-                    )
-                }
+                adapter = _BatchedLogitsProcessorAdapter(
+                    request.logits_processors, rest[-1:]
+                )
 
                 # Add to batch
                 (uid,) = batch_generator.insert(
                     [rest],
                     [request.max_tokens],
                     caches=[cache],
-                    samplers=[_wrap_batched_sampler(request.samplers, state)],
-                    logits_processors=[
-                        _wrap_batched_logits_processors(
-                            request.logits_processors,
-                            state=state,
-                            trim_prefix_len=trim_prefix_len,
-                        )
-                    ],
+                    all_tokens=[cached_prefix],
+                    samplers=[adapter.sampler(request.samplers)],
+                    logits_processors=[adapter.logits_processors()],
                 )
 
                 # Track this request

--- a/mlx_engine/model_kit/batched_model_kit.py
+++ b/mlx_engine/model_kit/batched_model_kit.py
@@ -96,8 +96,8 @@ def _prepare_prompt_cache_for_generation(
 
     # Exact cache hits need one token moved out of cache to start decoding.
     if cache is not None and can_trim_prompt_cache(cache):
-        trim_prompt_cache(cache, 1)
-        return cache, prompt_tokens[:-1], prompt_tokens[-1:]
+        if trim_prompt_cache(cache, 1) == 1:
+            return cache, prompt_tokens[:-1], prompt_tokens[-1:]
 
     # If we cannot trim an exact-hit cache, replay the full prompt instead.
     return None, [], prompt_tokens

--- a/mlx_engine/model_kit/batched_model_kit.py
+++ b/mlx_engine/model_kit/batched_model_kit.py
@@ -59,7 +59,7 @@ class _BatchedLogitsProcessorAdapter:
 
     def _wrap_processor(self, processor):
         def wrapped(tokens, logits):
-            if not hasattr(tokens, "shape"):
+            if not isinstance(tokens, mx.array):
                 tokens = mx.array(tokens)
             if (
                 self._current_input_tokens is not None

--- a/mlx_engine/model_kit/batched_model_kit.py
+++ b/mlx_engine/model_kit/batched_model_kit.py
@@ -27,6 +27,47 @@ from mlx_engine.model_kit.batched_model_kit_types import (
 logger = logging.getLogger(__name__)
 
 
+def _make_batched_logits_processor(processor, state, trim_prefix_len):
+    def wrapped(tokens, logits):
+        # Newer mlx-lm batch generation passes Python token lists here,
+        # while our processors still expect an MLX array.
+        if not hasattr(tokens, "shape"):
+            tokens = mx.array(tokens)
+
+        if trim_prefix_len > 0:
+            tokens = tokens[trim_prefix_len:]
+
+        # In batched mlx-lm, logits processors are called before the current
+        # input token has been appended to `tokens`. Restore the sequential-path
+        # view by appending the token that was just fed into the model.
+        pending_input_tokens = state["pending_input_tokens"]
+        if pending_input_tokens is not None and pending_input_tokens.size > 0:
+            tokens = mx.concatenate([tokens, pending_input_tokens])
+
+        return processor(tokens, logits)
+
+    return wrapped
+
+
+def _wrap_batched_sampler(sampler, state):
+    if sampler is None:
+        return None
+
+    def wrapped(logprobs):
+        sampled = sampler(logprobs)
+        state["pending_input_tokens"] = mx.array(sampled).reshape(-1)
+        return sampled
+
+    return wrapped
+
+
+def _wrap_batched_logits_processors(logits_processors, state, trim_prefix_len=0):
+    return [
+        _make_batched_logits_processor(processor, state, trim_prefix_len)
+        for processor in (logits_processors or [])
+    ]
+
+
 class BatchedModelKit:
     """
     This model kit enables continuous batching by running `mlx_lm.BatchGenerator` in a worker thread
@@ -247,13 +288,6 @@ class BatchedModelKit:
         requests receive a RequestCancelled exception.
         """
 
-        def progress_callback(info):
-            for uid, processed, total in info:
-                if uid in self._batch_results:
-                    self._batch_results[uid]["rqueue"].put(
-                        (min(processed, total), total)
-                    )
-
         batch_generator = BatchGenerator(
             self.model,
             max_tokens=10000000,
@@ -262,11 +296,10 @@ class BatchedModelKit:
             # We probably want to make this behavior configurable, so that new prompts do not pause existing decodes
             prefill_batch_size=1,
             prefill_step_size=self._prefill_step_size,
-            stop_tokens=set(self.tokenizer.eos_token_ids),
+            stop_tokens=[[token] for token in self.tokenizer.eos_token_ids],
             # Do not set any global post-processors, sampler and logits_processor are set per-request
             sampler=None,
             logits_processors=None,
-            prompt_progress_callback=progress_callback,
             max_kv_size=self._max_kv_size,
         )
         # only using one model, so model key name value does not matter
@@ -307,14 +340,27 @@ class BatchedModelKit:
                 cache, rest = self._prompt_cache.fetch_nearest_cache(
                     current_model_key, request.prompt_tokens
                 )
+                initial_tokens = rest[-1:]
+                trim_prefix_len = max(len(rest) - len(initial_tokens), 0)
+                state = {
+                    "pending_input_tokens": (
+                        mx.array(initial_tokens) if initial_tokens else None
+                    )
+                }
 
                 # Add to batch
                 (uid,) = batch_generator.insert(
                     [rest],
                     [request.max_tokens],
                     caches=[cache],
-                    samplers=[request.samplers],
-                    logits_processors=[request.logits_processors],
+                    samplers=[_wrap_batched_sampler(request.samplers, state)],
+                    logits_processors=[
+                        _wrap_batched_logits_processors(
+                            request.logits_processors,
+                            state=state,
+                            trim_prefix_len=trim_prefix_len,
+                        )
+                    ],
                 )
 
                 # Track this request
@@ -339,16 +385,25 @@ class BatchedModelKit:
                 if time.time() - start > time_budget:
                     break
 
-                responses = batch_generator.next()
-                if not responses:
+                prompt_responses, generation_responses = batch_generator.next()
+                if not prompt_responses and not generation_responses:
                     break
 
-                for r in responses:
+                for r in prompt_responses:
+                    result = self._batch_results.get(r.uid)
+                    if result is not None:
+                        processed, total = r.progress
+                        result["rqueue"].put((min(processed, total), total))
+
+                for r in generation_responses:
                     # Create response object
                     result = self._batch_results[r.uid]
+                    detokenizer = result["detokenizer"]
                     result["cache_key"].append(r.token)
                     if r.finish_reason != "stop":
-                        result["detokenizer"].add_token(r.token)
+                        detokenizer.add_token(r.token)
+                    if r.finish_reason is not None:
+                        detokenizer.finalize()
                     token_logprob = r.logprobs[r.token].item()
                     top_logprobs_list = None
 
@@ -374,7 +429,7 @@ class BatchedModelKit:
                     # Send the result
                     result["rqueue"].put(
                         BatchedGenerationResponse(
-                            text=result["detokenizer"].last_segment,
+                            text=detokenizer.last_segment,
                             token=r.token,
                             token_logprob=token_logprob,
                             top_logprobs=top_logprobs_list,

--- a/mlx_engine/processors/repetition_penalty_processor.py
+++ b/mlx_engine/processors/repetition_penalty_processor.py
@@ -23,7 +23,7 @@ class RepetitionPenaltyProcessor:
             repetition_penalty, repetition_context_size
         )
 
-    def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
+    def __call__(self, tokens: mx.array | list[int], logits: mx.array) -> mx.array:
         """
         Apply repetition penalty to the logits, accounting for tokens that have already been processed within
         the same prediction.
@@ -32,6 +32,9 @@ class RepetitionPenaltyProcessor:
             tokens: The tokens to be processed.
             logits: The logits to be processed.
         """
+        if not hasattr(tokens, "shape"):
+            tokens = mx.array(tokens, dtype=mx.int64)
+
         # append historical tokens s.t. repetition penalty accounts tokens that have already been processed in this gen
         num_tokens_to_prepend_from_history = max(
             self.repetition_context_size - len(tokens), 0

--- a/mlx_engine/processors/repetition_penalty_processor.py
+++ b/mlx_engine/processors/repetition_penalty_processor.py
@@ -23,7 +23,7 @@ class RepetitionPenaltyProcessor:
             repetition_penalty, repetition_context_size
         )
 
-    def __call__(self, tokens: mx.array | list[int], logits: mx.array) -> mx.array:
+    def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
         """
         Apply repetition penalty to the logits, accounting for tokens that have already been processed within
         the same prediction.
@@ -32,9 +32,6 @@ class RepetitionPenaltyProcessor:
             tokens: The tokens to be processed.
             logits: The logits to be processed.
         """
-        if not hasattr(tokens, "shape"):
-            tokens = mx.array(tokens, dtype=mx.int64)
-
         # append historical tokens s.t. repetition penalty accounts tokens that have already been processed in this gen
         num_tokens_to_prepend_from_history = max(
             self.repetition_context_size - len(tokens), 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ lark==1.3.1
 markdown-it-py==4.0.0
 mdurl==0.1.2
 mlx==0.31.1
-mlx-lm @ git+https://github.com/ml-explore/mlx-lm.git@9dc023beed1cd01e7c935f84d29d70b74a38dfa3
+mlx-lm @ git+https://github.com/ml-explore/mlx-lm.git@3257c3df172977c97fdfe3740e3a5edeb812e0b5
 mlx-metal==0.31.1
 mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm.git@23e1dffd224488141a4f022b6d21d6a730f11507
 nest-asyncio==1.6.0


### PR DESCRIPTION
- Add an adapter for the logits processors for batched generation. This is needed right now due to a regression in mlx-lm in the logics processor API. This adapter can be removed after this PR: https://github.com/ml-explore/mlx-lm/pull/1115
- Start using the `all_tokens` API so that the logits processors see the entire history
- Switch to the new `batch_generator.next()` API, and get rid of the old `progress_callback` definition
- Switch to the new `stop_tokens` API
- Add helper function that trims cache by one to create a seed token on an exact cache hit.

Codex review:
<img width="472" height="150" alt="Screenshot 2026-04-06 at 4 06 17 PM" src="https://github.com/user-attachments/assets/f3335557-b0ab-4dfc-a53e-053d633e233e" />

