### PR TITLE
Add vision feature caching for unified models

### DIFF
--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -262,8 +262,6 @@ class ModelKit:
         return False
 
     def shutdown(self) -> None:
-        if self.vision_add_on is not None:
-            self.vision_add_on.clear_feature_cache()
         self._shutdown.set()
 
     def is_shutdown(self) -> None:

--- a/mlx_engine/model_kit/model_kit.py
+++ b/mlx_engine/model_kit/model_kit.py
@@ -262,6 +262,8 @@ class ModelKit:
         return False
 
     def shutdown(self) -> None:
+        if self.vision_add_on is not None:
+            self.vision_add_on.clear_feature_cache()
         self._shutdown.set()
 
     def is_shutdown(self) -> None:

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -49,28 +49,6 @@ class BaseVisionAddOn(ABC):
         inject state into the text model (e.g., MRoPE positions).
         """
 
-    def get_cached_vision_features(
-        self,
-        images_b64: list[str],
-        max_size: tuple[int, int] | None,
-    ) -> Any | None:
-        """Return cached image features for an ordered image list, if present."""
-        return self._vision_feature_cache.get(
-            self._build_vision_cache_key(images_b64, max_size)
-        )
-
-    def store_cached_vision_features(
-        self,
-        images_b64: list[str],
-        max_size: tuple[int, int] | None,
-        features: Any,
-    ) -> None:
-        """Store image features for an ordered image list."""
-        self._vision_feature_cache.put(
-            self._build_vision_cache_key(images_b64, max_size),
-            features,
-        )
-
     def get_or_compute_cached_vision_features(
         self,
         images_b64: list[str],
@@ -78,13 +56,14 @@ class BaseVisionAddOn(ABC):
         compute_features: Callable[[], Any],
     ) -> Any:
         """Return cached image features or compute, materialize, and cache them."""
-        features = self.get_cached_vision_features(images_b64, max_size)
+        cache_key = self._build_vision_cache_key(images_b64, max_size)
+        features = self._vision_feature_cache.get(cache_key)
         if features is not None:
             return features
 
         features = compute_features()
         mx.eval(features)
-        self.store_cached_vision_features(images_b64, max_size, features)
+        self._vision_feature_cache.put(cache_key, features)
         return features
 
     def clear_feature_cache(self) -> None:
@@ -96,9 +75,9 @@ class BaseVisionAddOn(ABC):
         images_b64: list[str],
         max_size: tuple[int, int] | None,
     ) -> str:
+        """Keep cache hits exact across image changes, reorderings, and resize settings."""
         size_key = "orig" if max_size is None else f"{max_size[0]}x{max_size[1]}"
         image_hashes = [
-            hashlib.sha256(image.encode("utf-8")).hexdigest()[:16]
-            for image in images_b64
+            hashlib.sha256(image.encode("utf-8")).hexdigest() for image in images_b64
         ]
         return f"{size_key}:{'|'.join(image_hashes)}"

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -12,6 +12,44 @@ from mlx_vlm.vision_cache import VisionFeatureCache
 DEFAULT_VISION_FEATURE_CACHE_SIZE = 20
 
 
+class VisionFeatureMemoizer:
+    def __init__(self):
+        self._cache = VisionFeatureCache(max_size=DEFAULT_VISION_FEATURE_CACHE_SIZE)
+
+    def get_or_compute(
+        self,
+        images_b64: list[str],
+        max_size: tuple[int, int] | None,
+        compute_features: Callable[[], Any],
+    ) -> Any:
+        """Return cached image features or compute, materialize, and cache them."""
+        cache_key = self._build_key(images_b64, max_size)
+        features = self._cache.get(cache_key)
+        if features is not None:
+            return features
+
+        features = compute_features()
+        mx.eval(features)
+        self._cache.put(cache_key, features)
+        return features
+
+    def clear(self) -> None:
+        """Release cached image features."""
+        self._cache.clear()
+
+    def _build_key(
+        self,
+        images_b64: list[str],
+        max_size: tuple[int, int] | None,
+    ) -> str:
+        """Keep cache hits exact across image changes, reorderings, and resize settings."""
+        size_key = "orig" if max_size is None else f"{max_size[0]}x{max_size[1]}"
+        image_hashes = [
+            hashlib.sha256(image.encode("utf-8")).hexdigest() for image in images_b64
+        ]
+        return f"{size_key}:{'|'.join(image_hashes)}"
+
+
 class BaseVisionAddOn(ABC):
     """
     Base class that defines the interface for a VisionAddOn.
@@ -21,9 +59,7 @@ class BaseVisionAddOn(ABC):
         """
         Where load of vision model components is intended to occur.
         """
-        self._vision_feature_cache = VisionFeatureCache(
-            max_size=DEFAULT_VISION_FEATURE_CACHE_SIZE
-        )
+        self.vision_feature_cache = VisionFeatureMemoizer()
 
     @abstractmethod
     def compute_embeddings(
@@ -50,35 +86,6 @@ class BaseVisionAddOn(ABC):
         inject state into the text model (e.g., MRoPE positions).
         """
 
-    def get_or_compute_cached_vision_features(
-        self,
-        images_b64: list[str],
-        max_size: tuple[int, int] | None,
-        compute_features: Callable[[], Any],
-    ) -> Any:
-        """Return cached image features or compute, materialize, and cache them."""
-        cache_key = self._build_vision_cache_key(images_b64, max_size)
-        features = self._vision_feature_cache.get(cache_key)
-        if features is not None:
-            return features
-
-        features = compute_features()
-        mx.eval(features)
-        self._vision_feature_cache.put(cache_key, features)
-        return features
-
     def clear_feature_cache(self) -> None:
         """Release cached image features."""
-        self._vision_feature_cache.clear()
-
-    def _build_vision_cache_key(
-        self,
-        images_b64: list[str],
-        max_size: tuple[int, int] | None,
-    ) -> str:
-        """Keep cache hits exact across image changes, reorderings, and resize settings."""
-        size_key = "orig" if max_size is None else f"{max_size[0]}x{max_size[1]}"
-        image_hashes = [
-            hashlib.sha256(image.encode("utf-8")).hexdigest() for image in images_b64
-        ]
-        return f"{size_key}:{'|'.join(image_hashes)}"
+        self.vision_feature_cache.clear()

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -1,53 +1,11 @@
-import hashlib
 from abc import ABC, abstractmethod
-from collections.abc import Callable
-from typing import Any
 
 import mlx.core as mx
 from mlx import nn
-from mlx_vlm.vision_cache import VisionFeatureCache
 
-
-# Match mlx-vlm's default cache size to keep behavior aligned across servers.
-DEFAULT_VISION_FEATURE_CACHE_SIZE = 20
-
-
-class VisionFeatureMemoizer:
-    def __init__(self):
-        self._cache = VisionFeatureCache(max_size=DEFAULT_VISION_FEATURE_CACHE_SIZE)
-
-    def get_or_compute(
-        self,
-        images_b64: list[str],
-        max_size: tuple[int, int] | None,
-        compute_features: Callable[[], Any],
-    ) -> Any:
-        """Return cached image features or compute, materialize, and cache them."""
-        cache_key = self._build_key(images_b64, max_size)
-        features = self._cache.get(cache_key)
-        if features is not None:
-            return features
-
-        features = compute_features()
-        mx.eval(features)
-        self._cache.put(cache_key, features)
-        return features
-
-    def clear(self) -> None:
-        """Release cached image features."""
-        self._cache.clear()
-
-    def _build_key(
-        self,
-        images_b64: list[str],
-        max_size: tuple[int, int] | None,
-    ) -> str:
-        """Keep cache hits exact across image changes, reorderings, and resize settings."""
-        size_key = "orig" if max_size is None else f"{max_size[0]}x{max_size[1]}"
-        image_hashes = [
-            hashlib.sha256(image.encode("utf-8")).hexdigest() for image in images_b64
-        ]
-        return f"{size_key}:{'|'.join(image_hashes)}"
+from mlx_engine.model_kit.vision_add_ons.vision_feature_memoizer import (
+    VisionFeatureMemoizer,
+)
 
 
 class BaseVisionAddOn(ABC):
@@ -59,7 +17,7 @@ class BaseVisionAddOn(ABC):
         """
         Where load of vision model components is intended to occur.
         """
-        self.vision_feature_cache = VisionFeatureMemoizer()
+        self._vision_feature_memoizer = VisionFeatureMemoizer()
 
     @abstractmethod
     def compute_embeddings(
@@ -85,7 +43,3 @@ class BaseVisionAddOn(ABC):
         previous request. Default is a no-op; override in add-ons that
         inject state into the text model (e.g., MRoPE positions).
         """
-
-    def clear_feature_cache(self) -> None:
-        """Release cached image features."""
-        self.vision_feature_cache.clear()

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -8,7 +8,8 @@ from mlx import nn
 from mlx_vlm.vision_cache import VisionFeatureCache
 
 
-DEFAULT_VISION_FEATURE_CACHE_SIZE = 8
+# Match mlx-vlm's default cache size to keep behavior aligned across servers.
+DEFAULT_VISION_FEATURE_CACHE_SIZE = 20
 
 
 class BaseVisionAddOn(ABC):

--- a/mlx_engine/model_kit/vision_add_ons/base.py
+++ b/mlx_engine/model_kit/vision_add_ons/base.py
@@ -1,19 +1,28 @@
-from abc import abstractmethod
+import hashlib
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
 
 import mlx.core as mx
 from mlx import nn
+from mlx_vlm.vision_cache import VisionFeatureCache
 
 
-class BaseVisionAddOn:
+DEFAULT_VISION_FEATURE_CACHE_SIZE = 8
+
+
+class BaseVisionAddOn(ABC):
     """
     Base class that defines the interface for a VisionAddOn.
     """
 
-    @abstractmethod
     def __init__(self):
         """
         Where load of vision model components is intended to occur.
         """
+        self._vision_feature_cache = VisionFeatureCache(
+            max_size=DEFAULT_VISION_FEATURE_CACHE_SIZE
+        )
 
     @abstractmethod
     def compute_embeddings(
@@ -39,3 +48,57 @@ class BaseVisionAddOn:
         previous request. Default is a no-op; override in add-ons that
         inject state into the text model (e.g., MRoPE positions).
         """
+
+    def get_cached_vision_features(
+        self,
+        images_b64: list[str],
+        max_size: tuple[int, int] | None,
+    ) -> Any | None:
+        """Return cached image features for an ordered image list, if present."""
+        return self._vision_feature_cache.get(
+            self._build_vision_cache_key(images_b64, max_size)
+        )
+
+    def store_cached_vision_features(
+        self,
+        images_b64: list[str],
+        max_size: tuple[int, int] | None,
+        features: Any,
+    ) -> None:
+        """Store image features for an ordered image list."""
+        self._vision_feature_cache.put(
+            self._build_vision_cache_key(images_b64, max_size),
+            features,
+        )
+
+    def get_or_compute_cached_vision_features(
+        self,
+        images_b64: list[str],
+        max_size: tuple[int, int] | None,
+        compute_features: Callable[[], Any],
+    ) -> Any:
+        """Return cached image features or compute, materialize, and cache them."""
+        features = self.get_cached_vision_features(images_b64, max_size)
+        if features is not None:
+            return features
+
+        features = compute_features()
+        mx.eval(features)
+        self.store_cached_vision_features(images_b64, max_size, features)
+        return features
+
+    def clear_feature_cache(self) -> None:
+        """Release cached image features."""
+        self._vision_feature_cache.clear()
+
+    def _build_vision_cache_key(
+        self,
+        images_b64: list[str],
+        max_size: tuple[int, int] | None,
+    ) -> str:
+        size_key = "orig" if max_size is None else f"{max_size[0]}x{max_size[1]}"
+        image_hashes = [
+            hashlib.sha256(image.encode("utf-8")).hexdigest()[:16]
+            for image in images_b64
+        ]
+        return f"{size_key}:{'|'.join(image_hashes)}"

--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -70,7 +70,7 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
             )
             return self.multi_modal_projector(hidden_state.astype(pixel_values.dtype))
 
-        image_features = self.vision_feature_cache.get_or_compute(
+        image_features = self._vision_feature_memoizer.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -70,7 +70,7 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
             )
             return self.multi_modal_projector(hidden_state.astype(pixel_values.dtype))
 
-        image_features = self.get_or_compute_cached_vision_features(
+        image_features = self.vision_feature_cache.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/gemma3.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3.py
@@ -63,15 +63,16 @@ class Gemma3VisionAddOn(BaseVisionAddOn):
         )
         input_embeddings = text_model.language_model.model.embed_tokens(input_ids)
 
-        # Process image through vision tower
-        hidden_state, _, _ = self.vision_tower(
-            pixel_values.transpose(0, 2, 3, 1).astype(input_embeddings.dtype),
-            output_hidden_states=True,
-        )
+        def compute_image_features() -> mx.array:
+            hidden_state, _, _ = self.vision_tower(
+                pixel_values.transpose(0, 2, 3, 1).astype(input_embeddings.dtype),
+                output_hidden_states=True,
+            )
+            return self.multi_modal_projector(hidden_state.astype(pixel_values.dtype))
 
-        # Format image features
-        image_features = hidden_state.astype(pixel_values.dtype)
-        image_features = self.multi_modal_projector(image_features)
+        image_features = self.get_or_compute_cached_vision_features(
+            images_b64, max_size, compute_image_features
+        )
 
         # Combine image and text embeddings
         final_inputs_embeds, _ = Gemma3CombinedModel.prepare_inputs_for_multimodal(

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -139,7 +139,7 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
                 self.embed_vision,
             )
 
-        image_features = self.vision_feature_cache.get_or_compute(
+        image_features = self._vision_feature_memoizer.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -139,7 +139,7 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
                 self.embed_vision,
             )
 
-        image_features = self.get_or_compute_cached_vision_features(
+        image_features = self.vision_feature_cache.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/gemma3n.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma3n.py
@@ -131,12 +131,16 @@ class Gemma3nVisionAddOn(BaseVisionAddOn):
             # Transpose the HW axes
             pixel_values = pixel_values.swapaxes(2, 3)
 
-        # Process image through vision tower, then embed into language model space
-        image_features = Gemma3nCombinedModel.get_image_features(
-            pixel_values,
-            self.vision_tower,
-            self.config,
-            self.embed_vision,
+        def compute_image_features() -> mx.array:
+            return Gemma3nCombinedModel.get_image_features(
+                pixel_values,
+                self.vision_tower,
+                self.config,
+                self.embed_vision,
+            )
+
+        image_features = self.get_or_compute_cached_vision_features(
+            images_b64, max_size, compute_image_features
         )
 
         # Construct mask that matches image embedding locations

--- a/mlx_engine/model_kit/vision_add_ons/gemma4.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma4.py
@@ -101,7 +101,7 @@ class Gemma4VisionAddOn(BaseVisionAddOn):
                 input_embeddings.dtype
             )
 
-        image_features = self.get_or_compute_cached_vision_features(
+        image_features = self.vision_feature_cache.get_or_compute(
             images_b64, max_size, compute_image_features
         ).astype(input_embeddings.dtype)
 

--- a/mlx_engine/model_kit/vision_add_ons/gemma4.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma4.py
@@ -101,7 +101,7 @@ class Gemma4VisionAddOn(BaseVisionAddOn):
                 input_embeddings.dtype
             )
 
-        image_features = self.vision_feature_cache.get_or_compute(
+        image_features = self._vision_feature_memoizer.get_or_compute(
             images_b64, max_size, compute_image_features
         ).astype(input_embeddings.dtype)
 

--- a/mlx_engine/model_kit/vision_add_ons/gemma4.py
+++ b/mlx_engine/model_kit/vision_add_ons/gemma4.py
@@ -96,10 +96,14 @@ class Gemma4VisionAddOn(BaseVisionAddOn):
         language_model = text_model.language_model.model
         input_embeddings = language_model.embed_tokens(input_ids)
 
-        image_features = self.vision_tower(pixel_values)
-        image_features = self.embed_vision(image_features).astype(
-            input_embeddings.dtype
-        )
+        def compute_image_features() -> mx.array:
+            return self.embed_vision(self.vision_tower(pixel_values)).astype(
+                input_embeddings.dtype
+            )
+
+        image_features = self.get_or_compute_cached_vision_features(
+            images_b64, max_size, compute_image_features
+        ).astype(input_embeddings.dtype)
 
         # Gemma4TextModel applies embed_scale even when input_embeddings are provided.
         scaled_image_features = image_features / language_model.embed_scale

--- a/mlx_engine/model_kit/vision_add_ons/lfm2_vl.py
+++ b/mlx_engine/model_kit/vision_add_ons/lfm2_vl.py
@@ -112,7 +112,7 @@ class LFM2VisionAddOn(BaseVisionAddOn):
 
             return mx.concatenate(image_features, axis=0)
 
-        image_features = self.get_or_compute_cached_vision_features(
+        image_features = self.vision_feature_cache.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/lfm2_vl.py
+++ b/mlx_engine/model_kit/vision_add_ons/lfm2_vl.py
@@ -112,7 +112,7 @@ class LFM2VisionAddOn(BaseVisionAddOn):
 
             return mx.concatenate(image_features, axis=0)
 
-        image_features = self.vision_feature_cache.get_or_compute(
+        image_features = self._vision_feature_memoizer.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/lfm2_vl.py
+++ b/mlx_engine/model_kit/vision_add_ons/lfm2_vl.py
@@ -88,29 +88,33 @@ class LFM2VisionAddOn(BaseVisionAddOn):
         spatial_shapes = other_model_inputs["spatial_shapes"]
         pixel_attention_mask = other_model_inputs["pixel_attention_mask"]
 
-        # Get the ouptut hidden states from the vision model
-        *_, hidden_states = self.vision_tower(
-            pixel_values, output_hidden_states=True, spatial_shapes=spatial_shapes
+        def compute_image_features() -> mx.array:
+            *_, hidden_states = self.vision_tower(
+                pixel_values, output_hidden_states=True, spatial_shapes=spatial_shapes
+            )
+
+            img_feature_lengths = pixel_attention_mask.sum(axis=1).tolist()
+            image_features = []
+
+            for img_idx in range(hidden_states.shape[0]):
+                feature = hidden_states[img_idx]
+
+                feature = feature[: img_feature_lengths[img_idx], :][None, ...]
+
+                feature_org_h, feature_org_w = spatial_shapes[img_idx]
+                feature = feature.reshape(1, feature_org_h, feature_org_w, -1)
+                feature = self.pixel_unshuffle(feature)
+
+                img_embedding = self.multi_modal_projector(feature)
+
+                img_embedding = img_embedding.reshape(-1, img_embedding.shape[-1])
+                image_features.append(img_embedding)
+
+            return mx.concatenate(image_features, axis=0)
+
+        image_features = self.get_or_compute_cached_vision_features(
+            images_b64, max_size, compute_image_features
         )
-
-        img_feature_lengths = pixel_attention_mask.sum(axis=1).tolist()
-        image_features = []
-
-        for img_idx in range(hidden_states.shape[0]):
-            feature = hidden_states[img_idx]
-
-            feature = feature[: img_feature_lengths[img_idx], :][None, ...]
-
-            feature_org_h, feature_org_w = spatial_shapes[img_idx]
-            feature = feature.reshape(1, feature_org_h, feature_org_w, -1)
-            feature = self.pixel_unshuffle(feature)
-
-            img_embedding = self.multi_modal_projector(feature)
-
-            img_embedding = img_embedding.reshape(-1, img_embedding.shape[-1])
-            image_features.append(img_embedding)
-
-        image_features = mx.concatenate(image_features, axis=0)
 
         final_inputs_embeds = LFM2VlModel.merge_input_ids_with_image_features(
             image_features, inputs_embeds, input_ids, self.config.image_token_index

--- a/mlx_engine/model_kit/vision_add_ons/mistral3.py
+++ b/mlx_engine/model_kit/vision_add_ons/mistral3.py
@@ -87,26 +87,31 @@ class Mistral3VisionAddOn(BaseVisionAddOn):
         # Get the input embeddings from the language model
         inputs_embeds = text_model.language_model.model.embed_tokens(input_ids)
 
-        # Get the output hidden states from the vision model
-        if isinstance(pixel_values, list):
-            pixel_values = mx.concatenate(
-                [mx.array(pv)[None, ...] for pv in pixel_values], axis=0
+        def compute_image_features() -> mx.array:
+            vision_pixel_values = pixel_values
+            if isinstance(vision_pixel_values, list):
+                vision_pixel_values = mx.concatenate(
+                    [mx.array(pv)[None, ...] for pv in vision_pixel_values], axis=0
+                )
+            if vision_pixel_values.ndim == 3:
+                vision_pixel_values = vision_pixel_values[None, ...]
+
+            # Pass pixel_values as list of images, as each image is individually run through conv2d and position encoding
+            # Reference code from transformers: https://github.com/huggingface/transformers/blob/main/src/transformers/models/pixtral/modeling_pixtral.py#L479C9-L479C21
+            # and mistral_inference: https://github.com/mistralai/mistral-inference/blob/main/src/mistral_inference/vision_encoder.py#L85
+            *_, hidden_states = self.vision_tower(
+                vision_pixel_values.transpose(0, 2, 3, 1),
+                output_hidden_states=True,
             )
-        if pixel_values.ndim == 3:
-            pixel_values = pixel_values[None, ...]
+            # Select the hidden states from the desired layer
+            selected_image_feature = hidden_states[self.config.vision_feature_layer]
 
-        # Pass pixel_values as list of images, as each image is individually run through conv2d and position encoding
-        # Reference code from transformers: https://github.com/huggingface/transformers/blob/main/src/transformers/models/pixtral/modeling_pixtral.py#L479C9-L479C21
-        # and mistral_inference: https://github.com/mistralai/mistral-inference/blob/main/src/mistral_inference/vision_encoder.py#L85
-        *_, hidden_states = self.vision_tower(
-            pixel_values.transpose(0, 2, 3, 1),
-            output_hidden_states=True,
+            # Pass image features through the multi-modal projector
+            return self.multi_modal_projector(selected_image_feature, image_sizes)
+
+        image_features = self.get_or_compute_cached_vision_features(
+            images_b64, max_size, compute_image_features
         )
-        # Select the hidden states from the desired layer
-        selected_image_feature = hidden_states[self.config.vision_feature_layer]
-
-        # Pass image features through the multi-modal projector
-        image_features = self.multi_modal_projector(selected_image_feature, image_sizes)
 
         # Insert special image tokens in the input_ids
         final_inputs_embeds = Mistral3CombinedModel.merge_input_ids_with_image_features(

--- a/mlx_engine/model_kit/vision_add_ons/mistral3.py
+++ b/mlx_engine/model_kit/vision_add_ons/mistral3.py
@@ -109,7 +109,7 @@ class Mistral3VisionAddOn(BaseVisionAddOn):
             # Pass image features through the multi-modal projector
             return self.multi_modal_projector(selected_image_feature, image_sizes)
 
-        image_features = self.get_or_compute_cached_vision_features(
+        image_features = self.vision_feature_cache.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/mistral3.py
+++ b/mlx_engine/model_kit/vision_add_ons/mistral3.py
@@ -109,7 +109,7 @@ class Mistral3VisionAddOn(BaseVisionAddOn):
             # Pass image features through the multi-modal projector
             return self.multi_modal_projector(selected_image_feature, image_sizes)
 
-        image_features = self.vision_feature_cache.get_or_compute(
+        image_features = self._vision_feature_memoizer.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/pixtral.py
+++ b/mlx_engine/model_kit/vision_add_ons/pixtral.py
@@ -83,7 +83,7 @@ class PixtralVisionAddOn(BaseVisionAddOn):
             # Pass image features through the multi-modal projector
             return self.multi_modal_projector(selected_image_feature)
 
-        image_features = self.get_or_compute_cached_vision_features(
+        image_features = self.vision_feature_cache.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/pixtral.py
+++ b/mlx_engine/model_kit/vision_add_ons/pixtral.py
@@ -72,16 +72,20 @@ class PixtralVisionAddOn(BaseVisionAddOn):
         if pixel_values.ndim == 3:
             pixel_values = pixel_values[None, ...]
 
-        # Process image through vision tower
-        *_, hidden_states = self.vision_tower(
-            pixel_values.transpose(0, 2, 3, 1),
-            output_hidden_states=True,
-        )
-        # Select the hidden states from the desired layer
-        selected_image_feature = hidden_states[self.config.vision_feature_layer]
+        def compute_image_features() -> mx.array:
+            *_, hidden_states = self.vision_tower(
+                pixel_values.transpose(0, 2, 3, 1),
+                output_hidden_states=True,
+            )
+            # Select the hidden states from the desired layer
+            selected_image_feature = hidden_states[self.config.vision_feature_layer]
 
-        # Pass image features through the multi-modal projector
-        image_features = self.multi_modal_projector(selected_image_feature)
+            # Pass image features through the multi-modal projector
+            return self.multi_modal_projector(selected_image_feature)
+
+        image_features = self.get_or_compute_cached_vision_features(
+            images_b64, max_size, compute_image_features
+        )
 
         # Insert special image tokens in the input_ids
         final_inputs_embeds = PixtralCombinedModel.merge_input_ids_with_image_features(

--- a/mlx_engine/model_kit/vision_add_ons/pixtral.py
+++ b/mlx_engine/model_kit/vision_add_ons/pixtral.py
@@ -83,7 +83,7 @@ class PixtralVisionAddOn(BaseVisionAddOn):
             # Pass image features through the multi-modal projector
             return self.multi_modal_projector(selected_image_feature)
 
-        image_features = self.vision_feature_cache.get_or_compute(
+        image_features = self._vision_feature_memoizer.get_or_compute(
             images_b64, max_size, compute_image_features
         )
 

--- a/mlx_engine/model_kit/vision_add_ons/qwen_vl_utils.py
+++ b/mlx_engine/model_kit/vision_add_ons/qwen_vl_utils.py
@@ -76,7 +76,7 @@ def compute_qwen_vl_embeddings(
 
     # Process image through vision tower and merge embeddings
     if qwen_vl_version == 2:
-        hidden_states = addon.get_or_compute_cached_vision_features(
+        hidden_states = addon.vision_feature_cache.get_or_compute(
             images_b64,
             max_size,
             lambda: addon.vision_tower(
@@ -92,7 +92,7 @@ def compute_qwen_vl_embeddings(
             input_ids,
         )
     elif qwen_vl_version == 3:
-        hidden_states = addon.get_or_compute_cached_vision_features(
+        hidden_states = addon.vision_feature_cache.get_or_compute(
             images_b64,
             max_size,
             lambda: addon.vision_tower(

--- a/mlx_engine/model_kit/vision_add_ons/qwen_vl_utils.py
+++ b/mlx_engine/model_kit/vision_add_ons/qwen_vl_utils.py
@@ -76,7 +76,7 @@ def compute_qwen_vl_embeddings(
 
     # Process image through vision tower and merge embeddings
     if qwen_vl_version == 2:
-        hidden_states = addon.vision_feature_cache.get_or_compute(
+        hidden_states = addon._vision_feature_memoizer.get_or_compute(
             images_b64,
             max_size,
             lambda: addon.vision_tower(
@@ -92,7 +92,7 @@ def compute_qwen_vl_embeddings(
             input_ids,
         )
     elif qwen_vl_version == 3:
-        hidden_states = addon.vision_feature_cache.get_or_compute(
+        hidden_states = addon._vision_feature_memoizer.get_or_compute(
             images_b64,
             max_size,
             lambda: addon.vision_tower(

--- a/mlx_engine/model_kit/vision_add_ons/qwen_vl_utils.py
+++ b/mlx_engine/model_kit/vision_add_ons/qwen_vl_utils.py
@@ -76,8 +76,12 @@ def compute_qwen_vl_embeddings(
 
     # Process image through vision tower and merge embeddings
     if qwen_vl_version == 2:
-        hidden_states = addon.vision_tower(
-            pixel_values, grid_thw, output_hidden_states=False
+        hidden_states = addon.get_or_compute_cached_vision_features(
+            images_b64,
+            max_size,
+            lambda: addon.vision_tower(
+                pixel_values, grid_thw, output_hidden_states=False
+            ),
         )
 
         final_inputs_embeds = addon.model_cls.merge_input_ids_with_image_features(
@@ -88,8 +92,12 @@ def compute_qwen_vl_embeddings(
             input_ids,
         )
     elif qwen_vl_version == 3:
-        hidden_states, _ = addon.vision_tower(
-            pixel_values, grid_thw, output_hidden_states=False
+        hidden_states = addon.get_or_compute_cached_vision_features(
+            images_b64,
+            max_size,
+            lambda: addon.vision_tower(
+                pixel_values, grid_thw, output_hidden_states=False
+            )[0],
         )
 
         final_inputs_embeds, _ = addon.model_cls.merge_input_ids_with_image_features(

--- a/mlx_engine/model_kit/vision_add_ons/vision_feature_memoizer.py
+++ b/mlx_engine/model_kit/vision_add_ons/vision_feature_memoizer.py
@@ -1,0 +1,43 @@
+import hashlib
+from collections.abc import Callable
+
+import mlx.core as mx
+from mlx_vlm.vision_cache import VisionFeatureCache
+
+
+# Match mlx-vlm's default cache size
+DEFAULT_VISION_FEATURE_CACHE_SIZE = 20
+
+
+class VisionFeatureMemoizer:
+    def __init__(self):
+        self._cache = VisionFeatureCache(max_size=DEFAULT_VISION_FEATURE_CACHE_SIZE)
+
+    def get_or_compute(
+        self,
+        images_b64: list[str],
+        max_size: tuple[int, int] | None,
+        compute_features: Callable[[], mx.array],
+    ) -> mx.array:
+        """Return cached image features or compute, materialize, and cache them."""
+        cache_key = self._build_key(images_b64, max_size)
+        features = self._cache.get(cache_key)
+        if features is not None:
+            return features
+
+        features = compute_features()
+        mx.eval(features)
+        self._cache.put(cache_key, features)
+        return features
+
+    def _build_key(
+        self,
+        images_b64: list[str],
+        max_size: tuple[int, int] | None,
+    ) -> str:
+        """Keep cache hits exact across image changes, reorderings, and resize settings."""
+        size_key = "orig" if max_size is None else f"{max_size[0]}x{max_size[1]}"
+        image_hashes = [
+            hashlib.sha256(image.encode("utf-8")).hexdigest() for image in images_b64
+        ]
+        return f"{size_key}:{'|'.join(image_hashes)}"

--- a/tests/test_vision_feature_cache.py
+++ b/tests/test_vision_feature_cache.py
@@ -1,28 +1,13 @@
-import threading
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import mlx.core as mx
 
-from mlx_engine.model_kit.model_kit import ModelKit
-from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
-from mlx_engine.model_kit.vision_add_ons.gemma4 import Gemma4VisionAddOn
-from mlx_engine.model_kit.vision_add_ons.qwen_vl_utils import (
-    compute_qwen_vl_embeddings,
+from mlx_engine.model_kit.vision_add_ons.base import (
+    BaseVisionAddOn,
+    VisionFeatureMemoizer,
 )
-
-
-def _token_embeddings(input_ids: mx.array) -> mx.array:
-    values = input_ids.astype(mx.float32)
-    return mx.stack([values, values + 0.5], axis=-1)
-
-
-class _FakeGemma4TextModel:
-    embed_scale = 1.0
-    hidden_size_per_layer_input = False
-
-    def embed_tokens(self, input_ids: mx.array) -> mx.array:
-        return _token_embeddings(input_ids)
+from mlx_engine.model_kit.vision_add_ons.gemma4 import Gemma4VisionAddOn
 
 
 class _CountingModule:
@@ -35,35 +20,24 @@ class _CountingModule:
         return self.result
 
 
-class _MinimalVisionAddOn(BaseVisionAddOn):
-    def compute_embeddings(self, *args, **kwargs):
-        raise NotImplementedError
-
-
-def test_base_helper_computes_once_and_reuses_cached_features():
-    add_on = _MinimalVisionAddOn()
+def test_feature_memoizer_computes_once_and_reuses_cached_features():
+    memoizer = VisionFeatureMemoizer()
     compute = _CountingModule(mx.array([[1.0, 2.0]], dtype=mx.float32))
 
-    first = add_on.get_or_compute_cached_vision_features(["img-a"], (512, 512), compute)
-    second = add_on.get_or_compute_cached_vision_features(
-        ["img-a"], (512, 512), compute
-    )
+    first = memoizer.get_or_compute(["img-a"], (512, 512), compute)
+    second = memoizer.get_or_compute(["img-a"], (512, 512), compute)
 
     assert compute.calls == 1
     assert mx.array_equal(first, second)
 
 
-def test_cache_key_distinguishes_image_order():
-    add_on = _MinimalVisionAddOn()
+def test_feature_memoizer_keys_image_order():
+    memoizer = VisionFeatureMemoizer()
     first_compute = _CountingModule(mx.array([[1.0, 2.0]], dtype=mx.float32))
     second_compute = _CountingModule(mx.array([[3.0, 4.0]], dtype=mx.float32))
 
-    first = add_on.get_or_compute_cached_vision_features(
-        ["img-a", "img-b"], (512, 512), first_compute
-    )
-    second = add_on.get_or_compute_cached_vision_features(
-        ["img-b", "img-a"], (512, 512), second_compute
-    )
+    first = memoizer.get_or_compute(["img-a", "img-b"], (512, 512), first_compute)
+    second = memoizer.get_or_compute(["img-b", "img-a"], (512, 512), second_compute)
 
     assert first_compute.calls == 1
     assert second_compute.calls == 1
@@ -71,21 +45,15 @@ def test_cache_key_distinguishes_image_order():
     assert mx.array_equal(second, mx.array([[3.0, 4.0]], dtype=mx.float32))
 
 
-def test_cache_key_distinguishes_max_size():
-    add_on = _MinimalVisionAddOn()
+def test_feature_memoizer_keys_max_size():
+    memoizer = VisionFeatureMemoizer()
     resized_compute = _CountingModule(mx.array([[1.0, 2.0]], dtype=mx.float32))
     larger_compute = _CountingModule(mx.array([[3.0, 4.0]], dtype=mx.float32))
     original_compute = _CountingModule(mx.array([[5.0, 6.0]], dtype=mx.float32))
 
-    resized = add_on.get_or_compute_cached_vision_features(
-        ["img-a"], (512, 512), resized_compute
-    )
-    larger = add_on.get_or_compute_cached_vision_features(
-        ["img-a"], (1024, 1024), larger_compute
-    )
-    original = add_on.get_or_compute_cached_vision_features(
-        ["img-a"], None, original_compute
-    )
+    resized = memoizer.get_or_compute(["img-a"], (512, 512), resized_compute)
+    larger = memoizer.get_or_compute(["img-a"], (1024, 1024), larger_compute)
+    original = memoizer.get_or_compute(["img-a"], None, original_compute)
 
     assert resized_compute.calls == 1
     assert larger_compute.calls == 1
@@ -108,7 +76,19 @@ def test_gemma4_add_on_reuses_cached_image_features():
     )
 
     text_model = SimpleNamespace(
-        language_model=SimpleNamespace(model=_FakeGemma4TextModel())
+        language_model=SimpleNamespace(
+            model=SimpleNamespace(
+                embed_scale=1.0,
+                hidden_size_per_layer_input=False,
+                embed_tokens=lambda input_ids: mx.stack(
+                    [
+                        input_ids.astype(mx.float32),
+                        input_ids.astype(mx.float32) + 0.5,
+                    ],
+                    axis=-1,
+                ),
+            )
+        )
     )
     input_ids = mx.array([[1, 7, 7, 2]], dtype=mx.int32)
     pixel_values = mx.ones((1, 3, 2, 2), dtype=mx.float32)
@@ -135,132 +115,3 @@ def test_gemma4_add_on_reuses_cached_image_features():
     assert mx.array_equal(first_input_ids, input_ids.squeeze(0))
     assert mx.array_equal(second_input_ids, input_ids.squeeze(0))
     assert mx.array_equal(first_embeddings, second_embeddings)
-
-
-class _FakeQwenModel:
-    @staticmethod
-    def merge_input_ids_with_image_features(
-        image_features: mx.array,
-        inputs_embeds: mx.array,
-        input_ids: mx.array,
-        image_token_id: int,
-        video_token_id: int,
-    ) -> tuple[mx.array, mx.array]:
-        merged_rows = []
-        feature_index = 0
-        token_ids = input_ids.squeeze(0).tolist()
-        text_rows = inputs_embeds.squeeze(0)
-
-        for index, token_id in enumerate(token_ids):
-            if token_id in (image_token_id, video_token_id):
-                merged_rows.append(image_features[feature_index])
-                feature_index += 1
-            else:
-                merged_rows.append(text_rows[index])
-
-        return mx.expand_dims(mx.stack(merged_rows), axis=0), None
-
-
-class _FakeQwenProcessor:
-    def decode(self, tokens: list[int]) -> str:
-        return f"prompt-{tokens[0]}"
-
-
-class _FakeQwenAddOn(BaseVisionAddOn):
-    def __init__(self, hidden_states: mx.array):
-        super().__init__()
-        self.processor = _FakeQwenProcessor()
-        self.config = SimpleNamespace(image_token_id=99, video_token_id=100)
-        self.model_cls = _FakeQwenModel
-        self.vision_tower = _CountingModule((hidden_states, None))
-
-    def compute_embeddings(self, *args, **kwargs):
-        raise NotImplementedError
-
-
-def test_qwen_helper_reuses_cached_image_features_across_prompt_changes():
-    add_on = _FakeQwenAddOn(mx.array([[10.0, 11.0], [12.0, 13.0]], dtype=mx.float32))
-    text_model = SimpleNamespace(
-        language_model=SimpleNamespace(
-            model=SimpleNamespace(embed_tokens=_token_embeddings)
-        )
-    )
-
-    def fake_prepare_inputs(*, prompts, **_kwargs):
-        prompt_to_ids = {
-            "prompt-1": mx.array([[1, 99, 99, 2]], dtype=mx.int32),
-            "prompt-2": mx.array([[5, 99, 99, 6]], dtype=mx.int32),
-        }
-        return {
-            "input_ids": prompt_to_ids[prompts],
-            "pixel_values": mx.ones((1, 2, 2), dtype=mx.float32),
-            "image_grid_thw": mx.array([1, 2, 2], dtype=mx.int32),
-        }
-
-    with (
-        patch(
-            "mlx_engine.model_kit.vision_add_ons.qwen_vl_utils.convert_to_pil",
-            return_value=["pil-image"],
-        ),
-        patch(
-            "mlx_engine.model_kit.vision_add_ons.qwen_vl_utils.custom_resize",
-            side_effect=lambda images, **_kwargs: images,
-        ),
-        patch(
-            "mlx_engine.model_kit.vision_add_ons.qwen_vl_utils.prepare_inputs",
-            side_effect=fake_prepare_inputs,
-        ),
-    ):
-        first = compute_qwen_vl_embeddings(
-            addon=add_on,
-            text_model=text_model,
-            prompt_tokens=mx.array([1], dtype=mx.int32),
-            images_b64=["img-a"],
-            qwen_vl_version=3,
-            max_size=(1024, 1024),
-        )
-        second = compute_qwen_vl_embeddings(
-            addon=add_on,
-            text_model=text_model,
-            prompt_tokens=mx.array([2], dtype=mx.int32),
-            images_b64=["img-a"],
-            qwen_vl_version=3,
-            max_size=(1024, 1024),
-        )
-
-    assert add_on.vision_tower.calls == 1
-    assert first.input_ids.tolist() == [1, 99, 99, 2]
-    assert second.input_ids.tolist() == [5, 99, 99, 6]
-
-    second_embeddings = second.embeddings.tolist()
-    assert second_embeddings[0] == [5.0, 5.5]
-    assert second_embeddings[1] == [10.0, 11.0]
-    assert second_embeddings[2] == [12.0, 13.0]
-    assert second_embeddings[3] == [6.0, 6.5]
-
-
-def test_model_kit_shutdown_clears_cached_image_features():
-    add_on = _MinimalVisionAddOn()
-    first_compute = _CountingModule(mx.ones((1, 2, 2)))
-    second_compute = _CountingModule(mx.zeros((1, 2, 2)))
-
-    add_on.get_or_compute_cached_vision_features(["img-a"], (256, 256), first_compute)
-
-    kit = ModelKit.__new__(ModelKit)
-    kit.vision_add_on = add_on
-    kit._shutdown = threading.Event()
-
-    with patch.object(
-        add_on, "clear_feature_cache", wraps=add_on.clear_feature_cache
-    ) as clear_feature_cache:
-        ModelKit.shutdown(kit)
-
-    result = add_on.get_or_compute_cached_vision_features(
-        ["img-a"], (256, 256), second_compute
-    )
-
-    assert clear_feature_cache.call_count == 1
-    assert kit.is_shutdown() is True
-    assert first_compute.calls == 1
-    assert second_compute.calls == 1
-    assert mx.array_equal(result, mx.zeros((1, 2, 2)))

--- a/tests/test_vision_feature_cache.py
+++ b/tests/test_vision_feature_cache.py
@@ -137,16 +137,6 @@ def test_gemma4_add_on_reuses_cached_image_features():
     assert mx.array_equal(first_embeddings, second_embeddings)
 
 
-class _FakeQwenVisionTower:
-    def __init__(self, hidden_states: mx.array):
-        self.hidden_states = hidden_states
-        self.calls = 0
-
-    def __call__(self, *_args, **_kwargs):
-        self.calls += 1
-        return self.hidden_states, None
-
-
 class _FakeQwenModel:
     @staticmethod
     def merge_input_ids_with_image_features(
@@ -156,17 +146,19 @@ class _FakeQwenModel:
         image_token_id: int,
         video_token_id: int,
     ) -> tuple[mx.array, mx.array]:
-        special_mask = (input_ids == image_token_id) | (input_ids == video_token_id)
-        expanded_mask = mx.broadcast_to(special_mask[..., None], inputs_embeds.shape)
-        flat_mask = expanded_mask.flatten()
-        flat_indices = mx.cumsum(flat_mask.astype(mx.int32)) - 1
-        aligned_features = image_features.flatten()[flat_indices % image_features.size]
-        merged = mx.where(
-            flat_mask,
-            aligned_features,
-            inputs_embeds.flatten(),
-        ).reshape(inputs_embeds.shape)
-        return merged, expanded_mask
+        merged_rows = []
+        feature_index = 0
+        token_ids = input_ids.squeeze(0).tolist()
+        text_rows = inputs_embeds.squeeze(0)
+
+        for index, token_id in enumerate(token_ids):
+            if token_id in (image_token_id, video_token_id):
+                merged_rows.append(image_features[feature_index])
+                feature_index += 1
+            else:
+                merged_rows.append(text_rows[index])
+
+        return mx.expand_dims(mx.stack(merged_rows), axis=0), None
 
 
 class _FakeQwenProcessor:
@@ -180,7 +172,7 @@ class _FakeQwenAddOn(BaseVisionAddOn):
         self.processor = _FakeQwenProcessor()
         self.config = SimpleNamespace(image_token_id=99, video_token_id=100)
         self.model_cls = _FakeQwenModel
-        self.vision_tower = _FakeQwenVisionTower(hidden_states)
+        self.vision_tower = _CountingModule((hidden_states, None))
 
     def compute_embeddings(self, *args, **kwargs):
         raise NotImplementedError
@@ -247,21 +239,8 @@ def test_qwen_helper_reuses_cached_image_features_across_prompt_changes():
     assert second_embeddings[3] == [6.0, 6.5]
 
 
-class _TrackingVisionAddOn(BaseVisionAddOn):
-    def __init__(self):
-        super().__init__()
-        self.cleared = 0
-
-    def compute_embeddings(self, *args, **kwargs):
-        raise NotImplementedError
-
-    def clear_feature_cache(self) -> None:
-        self.cleared += 1
-        super().clear_feature_cache()
-
-
 def test_model_kit_shutdown_clears_cached_image_features():
-    add_on = _TrackingVisionAddOn()
+    add_on = _MinimalVisionAddOn()
     first_compute = _CountingModule(mx.ones((1, 2, 2)))
     second_compute = _CountingModule(mx.zeros((1, 2, 2)))
 
@@ -271,13 +250,16 @@ def test_model_kit_shutdown_clears_cached_image_features():
     kit.vision_add_on = add_on
     kit._shutdown = threading.Event()
 
-    ModelKit.shutdown(kit)
+    with patch.object(
+        add_on, "clear_feature_cache", wraps=add_on.clear_feature_cache
+    ) as clear_feature_cache:
+        ModelKit.shutdown(kit)
 
     result = add_on.get_or_compute_cached_vision_features(
         ["img-a"], (256, 256), second_compute
     )
 
-    assert add_on.cleared == 1
+    assert clear_feature_cache.call_count == 1
     assert kit.is_shutdown() is True
     assert first_compute.calls == 1
     assert second_compute.calls == 1

--- a/tests/test_vision_feature_cache.py
+++ b/tests/test_vision_feature_cache.py
@@ -1,0 +1,252 @@
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import mlx.core as mx
+
+from mlx_engine.model_kit.model_kit import ModelKit
+from mlx_engine.model_kit.vision_add_ons.base import BaseVisionAddOn
+from mlx_engine.model_kit.vision_add_ons.gemma4 import Gemma4VisionAddOn
+from mlx_engine.model_kit.vision_add_ons.qwen_vl_utils import (
+    compute_qwen_vl_embeddings,
+)
+
+
+def _token_embeddings(input_ids: mx.array) -> mx.array:
+    values = input_ids.astype(mx.float32)
+    return mx.stack([values, values + 0.5], axis=-1)
+
+
+class _FakeGemma4TextModel:
+    embed_scale = 1.0
+    hidden_size_per_layer_input = False
+
+    def embed_tokens(self, input_ids: mx.array) -> mx.array:
+        return _token_embeddings(input_ids)
+
+
+class _CountingModule:
+    def __init__(self, result):
+        self.result = result
+        self.calls = 0
+
+    def __call__(self, *_args, **_kwargs):
+        self.calls += 1
+        return self.result
+
+
+class _MinimalVisionAddOn(BaseVisionAddOn):
+    def compute_embeddings(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def test_base_helper_computes_once_and_reuses_cached_features():
+    add_on = _MinimalVisionAddOn()
+    compute = _CountingModule(mx.array([[1.0, 2.0]], dtype=mx.float32))
+
+    first = add_on.get_or_compute_cached_vision_features(["img-a"], (512, 512), compute)
+    second = add_on.get_or_compute_cached_vision_features(
+        ["img-a"], (512, 512), compute
+    )
+
+    assert compute.calls == 1
+    assert mx.array_equal(first, second)
+
+
+def test_cache_key_distinguishes_image_order():
+    add_on = _MinimalVisionAddOn()
+    feature = mx.array([[1.0, 2.0]], dtype=mx.float32)
+
+    add_on.store_cached_vision_features(["img-a", "img-b"], (512, 512), feature)
+
+    assert add_on.get_cached_vision_features(["img-b", "img-a"], (512, 512)) is None
+
+
+def test_cache_key_distinguishes_max_size():
+    add_on = _MinimalVisionAddOn()
+    feature = mx.array([[1.0, 2.0]], dtype=mx.float32)
+
+    add_on.store_cached_vision_features(["img-a"], (512, 512), feature)
+
+    assert add_on.get_cached_vision_features(["img-a"], (1024, 1024)) is None
+    assert add_on.get_cached_vision_features(["img-a"], None) is None
+
+
+def test_gemma4_add_on_reuses_cached_image_features():
+    add_on = Gemma4VisionAddOn.__new__(Gemma4VisionAddOn)
+    BaseVisionAddOn.__init__(add_on)
+    add_on.config = SimpleNamespace(image_token_id=7, audio_token_id=8)
+    add_on.processor = object()
+    add_on.vision_tower = _CountingModule(
+        mx.array([[[10.0, 11.0], [12.0, 13.0]]], dtype=mx.float32)
+    )
+    add_on.embed_vision = _CountingModule(
+        mx.array([[[10.0, 11.0], [12.0, 13.0]]], dtype=mx.float32)
+    )
+
+    text_model = SimpleNamespace(
+        language_model=SimpleNamespace(model=_FakeGemma4TextModel())
+    )
+    input_ids = mx.array([[1, 7, 7, 2]], dtype=mx.int32)
+    pixel_values = mx.ones((1, 3, 2, 2), dtype=mx.float32)
+
+    with patch(
+        "mlx_engine.model_kit.vision_add_ons.gemma4.common_process_prompt_with_images",
+        return_value=(input_ids, pixel_values, None, None),
+    ):
+        first_input_ids, first_embeddings = add_on.compute_embeddings(
+            text_model,
+            prompt_tokens=mx.array([1, 2], dtype=mx.int32),
+            images_b64=["img-a"],
+            max_size=(512, 512),
+        )
+        second_input_ids, second_embeddings = add_on.compute_embeddings(
+            text_model,
+            prompt_tokens=mx.array([3, 4], dtype=mx.int32),
+            images_b64=["img-a"],
+            max_size=(512, 512),
+        )
+
+    assert add_on.vision_tower.calls == 1
+    assert add_on.embed_vision.calls == 1
+    assert mx.array_equal(first_input_ids, input_ids.squeeze(0))
+    assert mx.array_equal(second_input_ids, input_ids.squeeze(0))
+    assert mx.array_equal(first_embeddings, second_embeddings)
+
+
+class _FakeQwenVisionTower:
+    def __init__(self, hidden_states: mx.array):
+        self.hidden_states = hidden_states
+        self.calls = 0
+
+    def __call__(self, *_args, **_kwargs):
+        self.calls += 1
+        return self.hidden_states, None
+
+
+class _FakeQwenModel:
+    @staticmethod
+    def merge_input_ids_with_image_features(
+        image_features: mx.array,
+        inputs_embeds: mx.array,
+        input_ids: mx.array,
+        image_token_id: int,
+        video_token_id: int,
+    ) -> tuple[mx.array, mx.array]:
+        special_mask = (input_ids == image_token_id) | (input_ids == video_token_id)
+        expanded_mask = mx.broadcast_to(special_mask[..., None], inputs_embeds.shape)
+        flat_mask = expanded_mask.flatten()
+        flat_indices = mx.cumsum(flat_mask.astype(mx.int32)) - 1
+        aligned_features = image_features.flatten()[flat_indices % image_features.size]
+        merged = mx.where(
+            flat_mask,
+            aligned_features,
+            inputs_embeds.flatten(),
+        ).reshape(inputs_embeds.shape)
+        return merged, expanded_mask
+
+
+class _FakeQwenProcessor:
+    def decode(self, tokens: list[int]) -> str:
+        return f"prompt-{tokens[0]}"
+
+
+class _FakeQwenAddOn(BaseVisionAddOn):
+    def __init__(self, hidden_states: mx.array):
+        super().__init__()
+        self.processor = _FakeQwenProcessor()
+        self.config = SimpleNamespace(image_token_id=99, video_token_id=100)
+        self.model_cls = _FakeQwenModel
+        self.vision_tower = _FakeQwenVisionTower(hidden_states)
+
+    def compute_embeddings(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def test_qwen_helper_reuses_cached_image_features_across_prompt_changes():
+    add_on = _FakeQwenAddOn(mx.array([[10.0, 11.0], [12.0, 13.0]], dtype=mx.float32))
+    text_model = SimpleNamespace(
+        language_model=SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=_token_embeddings)
+        )
+    )
+
+    def fake_prepare_inputs(*, prompts, **_kwargs):
+        prompt_to_ids = {
+            "prompt-1": mx.array([[1, 99, 99, 2]], dtype=mx.int32),
+            "prompt-2": mx.array([[5, 99, 99, 6]], dtype=mx.int32),
+        }
+        return {
+            "input_ids": prompt_to_ids[prompts],
+            "pixel_values": mx.ones((1, 2, 2), dtype=mx.float32),
+            "image_grid_thw": mx.array([1, 2, 2], dtype=mx.int32),
+        }
+
+    with (
+        patch(
+            "mlx_engine.model_kit.vision_add_ons.qwen_vl_utils.convert_to_pil",
+            return_value=["pil-image"],
+        ),
+        patch(
+            "mlx_engine.model_kit.vision_add_ons.qwen_vl_utils.custom_resize",
+            side_effect=lambda images, **_kwargs: images,
+        ),
+        patch(
+            "mlx_engine.model_kit.vision_add_ons.qwen_vl_utils.prepare_inputs",
+            side_effect=fake_prepare_inputs,
+        ),
+    ):
+        first = compute_qwen_vl_embeddings(
+            addon=add_on,
+            text_model=text_model,
+            prompt_tokens=mx.array([1], dtype=mx.int32),
+            images_b64=["img-a"],
+            qwen_vl_version=3,
+            max_size=(1024, 1024),
+        )
+        second = compute_qwen_vl_embeddings(
+            addon=add_on,
+            text_model=text_model,
+            prompt_tokens=mx.array([2], dtype=mx.int32),
+            images_b64=["img-a"],
+            qwen_vl_version=3,
+            max_size=(1024, 1024),
+        )
+
+    assert add_on.vision_tower.calls == 1
+    assert first.input_ids.tolist() == [1, 99, 99, 2]
+    assert second.input_ids.tolist() == [5, 99, 99, 6]
+
+    second_embeddings = second.embeddings.tolist()
+    assert second_embeddings[0] == [5.0, 5.5]
+    assert second_embeddings[1] == [10.0, 11.0]
+    assert second_embeddings[2] == [12.0, 13.0]
+    assert second_embeddings[3] == [6.0, 6.5]
+
+
+class _TrackingVisionAddOn(BaseVisionAddOn):
+    def __init__(self):
+        super().__init__()
+        self.cleared = 0
+
+    def compute_embeddings(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def clear_feature_cache(self) -> None:
+        self.cleared += 1
+        super().clear_feature_cache()
+
+
+def test_model_kit_shutdown_clears_cached_image_features():
+    add_on = _TrackingVisionAddOn()
+    add_on.store_cached_vision_features(["img-a"], (256, 256), mx.ones((1, 2, 2)))
+
+    kit = ModelKit.__new__(ModelKit)
+    kit.vision_add_on = add_on
+    kit._shutdown = threading.Event()
+
+    ModelKit.shutdown(kit)
+
+    assert add_on.cleared == 1
+    assert kit.is_shutdown() is True
+    assert add_on.get_cached_vision_features(["img-a"], (256, 256)) is None

--- a/tests/test_vision_feature_cache.py
+++ b/tests/test_vision_feature_cache.py
@@ -5,6 +5,8 @@ import mlx.core as mx
 
 from mlx_engine.model_kit.vision_add_ons.base import (
     BaseVisionAddOn,
+)
+from mlx_engine.model_kit.vision_add_ons.vision_feature_memoizer import (
     VisionFeatureMemoizer,
 )
 from mlx_engine.model_kit.vision_add_ons.gemma4 import Gemma4VisionAddOn

--- a/tests/test_vision_feature_cache.py
+++ b/tests/test_vision_feature_cache.py
@@ -55,21 +55,44 @@ def test_base_helper_computes_once_and_reuses_cached_features():
 
 def test_cache_key_distinguishes_image_order():
     add_on = _MinimalVisionAddOn()
-    feature = mx.array([[1.0, 2.0]], dtype=mx.float32)
+    first_compute = _CountingModule(mx.array([[1.0, 2.0]], dtype=mx.float32))
+    second_compute = _CountingModule(mx.array([[3.0, 4.0]], dtype=mx.float32))
 
-    add_on.store_cached_vision_features(["img-a", "img-b"], (512, 512), feature)
+    first = add_on.get_or_compute_cached_vision_features(
+        ["img-a", "img-b"], (512, 512), first_compute
+    )
+    second = add_on.get_or_compute_cached_vision_features(
+        ["img-b", "img-a"], (512, 512), second_compute
+    )
 
-    assert add_on.get_cached_vision_features(["img-b", "img-a"], (512, 512)) is None
+    assert first_compute.calls == 1
+    assert second_compute.calls == 1
+    assert mx.array_equal(first, mx.array([[1.0, 2.0]], dtype=mx.float32))
+    assert mx.array_equal(second, mx.array([[3.0, 4.0]], dtype=mx.float32))
 
 
 def test_cache_key_distinguishes_max_size():
     add_on = _MinimalVisionAddOn()
-    feature = mx.array([[1.0, 2.0]], dtype=mx.float32)
+    resized_compute = _CountingModule(mx.array([[1.0, 2.0]], dtype=mx.float32))
+    larger_compute = _CountingModule(mx.array([[3.0, 4.0]], dtype=mx.float32))
+    original_compute = _CountingModule(mx.array([[5.0, 6.0]], dtype=mx.float32))
 
-    add_on.store_cached_vision_features(["img-a"], (512, 512), feature)
+    resized = add_on.get_or_compute_cached_vision_features(
+        ["img-a"], (512, 512), resized_compute
+    )
+    larger = add_on.get_or_compute_cached_vision_features(
+        ["img-a"], (1024, 1024), larger_compute
+    )
+    original = add_on.get_or_compute_cached_vision_features(
+        ["img-a"], None, original_compute
+    )
 
-    assert add_on.get_cached_vision_features(["img-a"], (1024, 1024)) is None
-    assert add_on.get_cached_vision_features(["img-a"], None) is None
+    assert resized_compute.calls == 1
+    assert larger_compute.calls == 1
+    assert original_compute.calls == 1
+    assert mx.array_equal(resized, mx.array([[1.0, 2.0]], dtype=mx.float32))
+    assert mx.array_equal(larger, mx.array([[3.0, 4.0]], dtype=mx.float32))
+    assert mx.array_equal(original, mx.array([[5.0, 6.0]], dtype=mx.float32))
 
 
 def test_gemma4_add_on_reuses_cached_image_features():
@@ -239,7 +262,10 @@ class _TrackingVisionAddOn(BaseVisionAddOn):
 
 def test_model_kit_shutdown_clears_cached_image_features():
     add_on = _TrackingVisionAddOn()
-    add_on.store_cached_vision_features(["img-a"], (256, 256), mx.ones((1, 2, 2)))
+    first_compute = _CountingModule(mx.ones((1, 2, 2)))
+    second_compute = _CountingModule(mx.zeros((1, 2, 2)))
+
+    add_on.get_or_compute_cached_vision_features(["img-a"], (256, 256), first_compute)
 
     kit = ModelKit.__new__(ModelKit)
     kit.vision_add_on = add_on
@@ -247,6 +273,12 @@ def test_model_kit_shutdown_clears_cached_image_features():
 
     ModelKit.shutdown(kit)
 
+    result = add_on.get_or_compute_cached_vision_features(
+        ["img-a"], (256, 256), second_compute
+    )
+
     assert add_on.cleared == 1
     assert kit.is_shutdown() is True
-    assert add_on.get_cached_vision_features(["img-a"], (256, 256)) is None
+    assert first_compute.calls == 1
+    assert second_compute.calls == 1
+    assert mx.array_equal(result, mx.zeros((1, 2, 2)))


### PR DESCRIPTION
Integrate mlx-vlm's `VisionFeatureCache`, which brings us to parity with the mlx_vlm server with regards to image caching.

Changes:
- Add `VisionFeatureMemoizer`, which caches image features, and restores them when there is a key match. This memoizer is only wired in with models that use the unified arch.
- Refactor the image feature generation in each addon into its own helper function. The actual ML is not changing. This refactor lets us have a nicer pattern of cache interaction
- Add unit tests for `VisionFeatureCache` and an integration test. The existing e2e tests ensure that the models are still working as intended.

Testing:
I tested token generation for the models that are a part of the unified arch on this branch, and on the current main, to ensure that the refactoring made in the vision add ons are correct. Click below to see the testing script, which was run on the feature branch and the main branch. The output jsons were identical, showing no regression in the vision add on ML implementation. Reviewers can run this script themselves. Reviewers should also be able to verify that the changes to image feature generation in this PR's diff are mostly whitespace changes.

<details>

<summary> THE SCRIPT </summary>

```py
import base64
import gc
import json
import sys
from pathlib import Path
from typing import Callable

from transformers import AutoProcessor


MAX_IMAGE_SIZE = (1024, 1024)
MAX_KV_SIZE = 2048
MAX_TOKENS = 30
SEED = 0
OUTPUT_FILENAME = "active_vision_outputs.json"


def _project_root() -> Path:
    script_path = Path(__file__).resolve()
    for candidate in (script_path.parent, *script_path.parents):
        if (candidate / "mlx_engine").is_dir() and (candidate / "demo-data").is_dir():
            return candidate
    raise FileNotFoundError(
        "Could not find the mlx-engine project root next to this script."
    )


PROJECT_ROOT = _project_root()
sys.path.insert(0, str(PROJECT_ROOT))


def _read_image_b64(path: Path) -> str:
    with open(path, "rb") as image_file:
        return base64.b64encode(image_file.read()).decode("utf-8")


def _resolve_model_path(model_name: str) -> Path:
    with open(Path("~/.lmstudio-home-pointer").expanduser().resolve(), "r") as handle:
        lmstudio_home = Path(handle.read().strip())
    model_path = lmstudio_home / "models" / model_name
    if not model_path.exists():
        raise FileNotFoundError(
            f"Model {model_name} not found at {model_path}. Download it before running this script."
        )
    return model_path


def _build_gemma4_prompt(model_path: Path, prompt: str, image_b64: str) -> str:
    processor = AutoProcessor.from_pretrained(model_path)
    conversation = [
        {
            "role": "user",
            "content": [
                {"type": "image", "base64": image_b64},
                {"type": "text", "text": prompt},
            ],
        }
    ]
    return processor.apply_chat_template(
        conversation,
        tokenize=False,
        add_generation_prompt=True,
    )


def _literal_prompt(prompt: str) -> Callable[[Path, str], str]:
    return lambda _model_path, _image_b64: prompt


PROMPT_TEXT = "What is this"
QWEN_PROMPT = (
    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
    "<|im_start|>user\n"
    f"<|vision_start|><|image_pad|><|vision_end|>{PROMPT_TEXT}<|im_end|>\n"
    "<|im_start|>assistant\n"
)

CASES: list[tuple[str, str, Callable[[Path, str], str]]] = [
    (
        "gemma3",
        "mlx-community/gemma-3-4b-it-4bit",
        _literal_prompt(
            "<bos><start_of_turn>user\n"
            f"{PROMPT_TEXT}<start_of_image><end_of_turn>\n"
            "<start_of_turn>model\n"
        ),
    ),
    (
        "gemma3n",
        "lmstudio-community/gemma-3n-E2B-it-MLX-4bit",
        _literal_prompt(
            "<bos><start_of_turn>user\n"
            f"<image_soft_token>{PROMPT_TEXT}<end_of_turn>\n"
            "<start_of_turn>model\n"
        ),
    ),
    (
        "gemma4",
        "lmstudio-community/gemma-4-E2B-it-MLX-4bit",
        lambda model_path, image_b64: _build_gemma4_prompt(
            model_path, PROMPT_TEXT, image_b64
        ),
    ),
    (
        "lfm2_vl",
        "mlx-community/LFM2-VL-450M-4bit",
        _literal_prompt(
            "<|startoftext|><|im_start|>user\n"
            f"<image>{PROMPT_TEXT}<|im_end|>\n"
            "<|im_start|>assistant"
        ),
    ),
    (
        "mistral3",
        "lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit",
        _literal_prompt(f"<s>[INST]{PROMPT_TEXT}[IMG][/INST]"),
    ),
    (
        "pixtral",
        "mlx-community/pixtral-12b-4bit",
        _literal_prompt(f"<s>[INST]{PROMPT_TEXT}[IMG][/INST]"),
    ),
    (
        "qwen3_5",
        "lmstudio-community/Qwen3.5-2B-MLX-4bit",
        _literal_prompt(QWEN_PROMPT),
    ),
    (
        "qwen3_5_moe",
        "lmstudio-community/Qwen3.5-35B-A3B-MLX-4bit",
        _literal_prompt(QWEN_PROMPT),
    ),
]


def _generate_case(
    *,
    case_name: str,
    model_name: str,
    prompt_builder: Callable[[Path, str], str],
    image_b64: str,
) -> dict:
    import mlx.core as mx

    from mlx_engine.generate import create_generator, load_model, tokenize

    model_path = _resolve_model_path(model_name)
    prompt = prompt_builder(model_path, image_b64)
    model_kit = None
    try:
        model_kit = load_model(
            model_path=model_path,
            max_kv_size=MAX_KV_SIZE,
            max_seq_nums=1,
            trust_remote_code=True,
        )
        prompt_tokens = tokenize(model_kit, prompt)
        generated_text = ""
        stop_reason = None
        for result in create_generator(
            model_kit=model_kit,
            prompt_tokens=prompt_tokens,
            images_b64=[image_b64],
            max_image_size=MAX_IMAGE_SIZE,
            seed=SEED,
            max_tokens=MAX_TOKENS,
            temp=0.0,
            repetition_penalty=1.01,
        ):
            generated_text += result.text
            if result.stop_condition:
                stop_reason = result.stop_condition.stop_reason
                break

        return {
            "case": case_name,
            "model_name": model_name,
            "prompt": prompt,
            "text": generated_text,
            "stop_reason": stop_reason,
        }
    finally:
        if model_kit is not None:
            model_kit.shutdown()
            del model_kit
        gc.collect()
        mx.clear_cache()


def main() -> None:
    image_path = PROJECT_ROOT / "demo-data" / "toucan.jpeg"
    image_b64 = _read_image_b64(image_path)
    results = {
        "image_path": str(image_path),
        "generation_params": {
            "seed": SEED,
            "temp": 0.0,
            "repetition_penalty": 1.01,
            "max_tokens": MAX_TOKENS,
            "max_kv_size": MAX_KV_SIZE,
            "max_image_size": list(MAX_IMAGE_SIZE),
        },
        "cases": {},
    }

    for case_name, model_name, prompt_builder in CASES:
        print(f"Running {case_name}: {model_name}")
        results["cases"][case_name] = _generate_case(
            case_name=case_name,
            model_name=model_name,
            prompt_builder=prompt_builder,
            image_b64=image_b64,
        )

    out_path = PROJECT_ROOT / OUTPUT_FILENAME
    out_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n")
    print(f"Wrote results to {out_path}")


if __name__ == "__main__":
    main()

```

</details>

I chose not to check this script into git, as it's better to actually write unit tests that set expectations on behavior; but introducing the unit tests as part of this PR would not show a regression from main.

Codex review:
<img width="469" height="153" alt="Screenshot 2026-04-10 at 2 59 05 PM" src="https://github.com/user-attachments/assets/700c8af1-381d-4b33-83fc-61337a671b02" />
