### PR TITLE
Disable Qwen ragged attention kernel

### DIFF
--- a/mlx_engine/model_kit/patches/qwen3_5.py
+++ b/mlx_engine/model_kit/patches/qwen3_5.py
@@ -57,6 +57,13 @@ OriginalVlmQwen3_5LanguageModelCall = VlmQwen3_5LanguageModel.__call__
 OriginalVlmQwen3_5IsSingleRowBatchCache = (
     vlm_qwen3_5_language._is_single_row_batch_cache
 )
+OriginalVlmQwen3_5RaggedDecodeAttention = (
+    vlm_qwen3_5_language._qwen3_5_ragged_decode_attention
+)
+
+
+def _patched_vlm_qwen3_5_ragged_decode_attention(*args, **kwargs):
+    return None
 
 
 def _vlm_qwen3_5_gated_delta_net_fast_path(
@@ -712,4 +719,7 @@ def apply_patches():
     VlmQwen3_5LanguageModel.__call__ = _patched_vlm_qwen3_5_language_model_call
     vlm_qwen3_5_language._is_single_row_batch_cache = (
         _patched_vlm_qwen3_5_is_single_row_batch_cache
+    )
+    vlm_qwen3_5_language._qwen3_5_ragged_decode_attention = (
+        _patched_vlm_qwen3_5_ragged_decode_attention
     )

--- a/tests/test_patched_qwen3_5.py
+++ b/tests/test_patched_qwen3_5.py
@@ -8,6 +8,7 @@ from mlx_lm.models.cache import ArraysCache, BatchKVCache, KVCache, make_prompt_
 from mlx_lm.models.qwen3_5 import Model, ModelArgs
 import mlx_lm.models.qwen3_5 as qwen3_5_module
 from mlx_lm.models.qwen3_next import Qwen3NextAttention
+from mlx_vlm.models.qwen3_5 import language as vlm_qwen3_5_language
 from transformers import AutoTokenizer
 
 from mlx_engine.model_kit.patches import qwen3_5 as qwen3_5_patches
@@ -133,6 +134,19 @@ def qwen3_5_chat_prompt_tokens(model_path) -> mx.array:
         add_generation_prompt=True,
     )
     return mx.array(tokenizer.encode(prompt, add_special_tokens=False))[None, :]
+
+
+def test_vlm_qwen3_5_ragged_decode_attention_kernel_is_disabled():
+    assert (
+        vlm_qwen3_5_language._qwen3_5_ragged_decode_attention
+        is qwen3_5_patches._patched_vlm_qwen3_5_ragged_decode_attention
+    )
+    assert (
+        vlm_qwen3_5_language._qwen3_5_ragged_decode_attention(
+            "queries", "keys", "values", "pads", "scale"
+        )
+        is None
+    )
 
 
 def test_vlm_qwen3_5_attention_text_fast_path_uses_qwen3_next(monkeypatch):


### PR DESCRIPTION
This disables the Qwen 3.5-family ragged decode attention fast path in `mlx-vlm` from the `mlx-engine` patch layer.

The v1.9.0 runtime can crash on M2 machines when Qwen 3.5 / 3.6 models enter the left-padded ragged decode attention path. That path uses a custom Metal kernel with a large threadgroup shape. Returning `None` from `_qwen3_5_ragged_decode_attention` makes upstream `mlx-vlm` fall back to its existing standard SDPA implementation instead of launching the custom kernel.

Normal single-sequence decode does not call this ragged helper, so the change has no measured throughput impact there.