### PR TITLE
Handle Gemma4 bidirectional visual prefill

### DIFF
--- a/mlx_engine/model_kit/batched_vision/model_kit.py
+++ b/mlx_engine/model_kit/batched_vision/model_kit.py
@@ -65,6 +65,7 @@ from mlx_engine.model_kit.batched_vision.vision_feature_memoizer import (
     VisionFeatureMemoizer,
 )
 from mlx_engine.model_kit.patches.gemma4 import (
+    config_uses_bidirectional_visual_attention,
     is_unified_model_type as is_gemma4_unified_model_type,
     patch_loaded_model as patch_loaded_gemma4_model,
 )
@@ -73,12 +74,18 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_SEQ_NUMS = 4
 
 
-def _requires_global_no_chunked_prefill(model, model_type: str | None) -> bool:
+def _requires_global_no_chunked_prefill(
+    model,
+    model_type: str | None,
+    uses_bidirectional_visual_attention: bool = False,
+) -> bool:
     if not getattr(model, "no_chunked_prefill", False):
         return False
-    # Gemma4 unified visual prompts need a request-local policy because only
-    # visual token blocks require the bidirectional-mask prefill constraint.
-    return not is_gemma4_unified_model_type(model_type)
+    # Gemma4 bidirectional visual prompts need a request-local policy because
+    # only visual token blocks require the bidirectional-mask prefill constraint.
+    return not (
+        uses_bidirectional_visual_attention or is_gemma4_unified_model_type(model_type)
+    )
 
 
 def _restore_splits_gemma4_image_span(
@@ -86,9 +93,13 @@ def _restore_splits_gemma4_image_span(
     model_type: str | None,
     cached_prefix_len: int,
     image_spans,
+    uses_bidirectional_visual_attention: bool = False,
 ) -> bool:
     """Return true when a Gemma4 restore would split an image token span."""
-    if not is_gemma4_unified_model_type(model_type) or cached_prefix_len <= 0:
+    uses_visual_prefill_policy = uses_bidirectional_visual_attention or (
+        is_gemma4_unified_model_type(model_type)
+    )
+    if not uses_visual_prefill_policy or cached_prefix_len <= 0:
         return False
     return any(span.start < cached_prefix_len < span.end for span in image_spans)
 
@@ -142,6 +153,9 @@ class BatchedVisionModelKit:
             model_path, trust_remote_code=trust_remote_code
         )
         self.model_type = self.config.get("model_type")
+        self._uses_gemma4_bidirectional_visual_attention = (
+            config_uses_bidirectional_visual_attention(self.config)
+        )
         self._prompt_cache_store = VlmPromptCacheStore(max_kv_size=max_kv_size)
         self._cache_io_thread = PromptCacheIOThread(
             cache_store=self._prompt_cache_store,
@@ -374,7 +388,11 @@ class BatchedVisionModelKit:
             completion_batch_size=self._max_seq_nums,
             prefill_step_size=(
                 None
-                if _requires_global_no_chunked_prefill(self.model, self.model_type)
+                if _requires_global_no_chunked_prefill(
+                    self.model,
+                    self.model_type,
+                    self._uses_gemma4_bidirectional_visual_attention,
+                )
                 else self.prefill_step_size
             ),
         )
@@ -412,6 +430,9 @@ class BatchedVisionModelKit:
             model_type=self.model_type,
             cached_prefix_len=restored.cached_prefix_len,
             image_spans=prepared_prompt.image_spans,
+            uses_bidirectional_visual_attention=(
+                self._uses_gemma4_bidirectional_visual_attention
+            ),
         ):
             restored = None
 
@@ -444,7 +465,11 @@ class BatchedVisionModelKit:
             )
             inputs_embeds = prompt_kwargs.pop("inputs_embeds")
 
-        if _requires_global_no_chunked_prefill(self.model, self.model_type):
+        if _requires_global_no_chunked_prefill(
+            self.model,
+            self.model_type,
+            self._uses_gemma4_bidirectional_visual_attention,
+        ):
             # One-shot prefill skips exact intermediate prompt boundaries.
             prompt_progress_for_cache_chunks = prompt_token_count
         else:

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -1,4 +1,4 @@
-"""Gemma 4 unified compatibility helpers for batched vision generation."""
+"""Gemma 4 bidirectional-vision compatibility helpers for batched generation."""
 
 from types import MethodType
 from typing import Any
@@ -10,9 +10,43 @@ def is_unified_model_type(model_type: str | None) -> bool:
     return str(model_type or "").startswith("gemma4_unified")
 
 
+def is_gemma4_model_type(model_type: str | None) -> bool:
+    return str(model_type or "").startswith("gemma4")
+
+
+def _language_model(model: Any) -> Any:
+    return getattr(model, "language_model", model)
+
+
+def _model_type(model: Any) -> str | None:
+    return getattr(_language_model(model), "model_type", None)
+
+
 def is_unified_model(model: Any) -> bool:
-    language_model = getattr(model, "language_model", model)
-    return is_unified_model_type(getattr(language_model, "model_type", None))
+    return is_unified_model_type(_model_type(model))
+
+
+def uses_bidirectional_visual_attention(model: Any) -> bool:
+    """Return true for Gemma4-family language models with visual bidir masks."""
+    language_model = _language_model(model)
+    if not is_gemma4_model_type(getattr(language_model, "model_type", None)):
+        return False
+    config = getattr(language_model, "config", None)
+    return _get_config_value(config, "use_bidirectional_attention") == "vision"
+
+
+def _get_config_value(config: dict | Any, key: str) -> Any:
+    if isinstance(config, dict):
+        return config.get(key)
+    return getattr(config, key, None)
+
+
+def config_uses_bidirectional_visual_attention(config: dict | Any) -> bool:
+    """Config-level version used before the loaded model exists."""
+    model_type = _get_config_value(config, "model_type")
+    text_config = _get_config_value(config, "text_config") or config
+    attention_mode = _get_config_value(text_config, "use_bidirectional_attention")
+    return is_gemma4_model_type(model_type) and attention_mode == "vision"
 
 
 def visual_prefill_prefix_len(
@@ -21,14 +55,14 @@ def visual_prefill_prefix_len(
     image_spans: list[Any],
     cached_prefix_len: int,
 ) -> int | None:
-    """Return the remaining visual prefix Gemma4 unified must prefill together.
+    """Return the visual prefix Gemma4 bidir masks need in one model call.
 
-    Gemma4 unified derives its bidirectional visual attention overlay from the
-    token-type ids visible to one language-model call. Keep the first prefill
-    anchored at the current suffix start through the last visual token; text
-    after that point can go back to ordinary chunked prefill.
+    Gemma4 derives its bidirectional visual attention overlay from token-type ids
+    visible to the current language-model call. Keep the first prefill anchored
+    at the current suffix start through the last visual token; trailing text can
+    go back to ordinary chunked prefill.
     """
-    if not is_unified_model(model):
+    if not uses_bidirectional_visual_attention(model):
         return None
 
     token_types = prompt_kwargs.get("mm_token_type_ids")
@@ -64,9 +98,9 @@ def prepare_cached_suffix_prompt_kwargs(prompt_kwargs: dict, key_len: int) -> di
 
 
 def patch_loaded_model(model: Any) -> None:
-    """Patch a loaded mlx-vlm Gemma4 unified model for cached visual suffix masks."""
-    language_model = getattr(model, "language_model", model)
-    if not is_unified_model_type(getattr(language_model, "model_type", None)):
+    """Patch loaded Gemma4 bidir models for cached visual suffix masks."""
+    language_model = _language_model(model)
+    if not uses_bidirectional_visual_attention(language_model):
         return
     text_model = getattr(language_model, "model", language_model)
     if getattr(text_model, "_mlx_engine_suffix_visual_mask_patch", False):

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -145,6 +145,13 @@ def _gemma4_model():
     return model
 
 
+def _gemma4_non_bidir_model():
+    model = _FakeModel()
+    model.model_type = "gemma4"
+    model.config = SimpleNamespace(use_bidirectional_attention=None)
+    return model
+
+
 def test_generation_batch_applies_per_sequence_processors_and_top_logprobs():
     """Processors are per-row, and sampled token metadata follows decode-ahead."""
     model = _FakeModel()
@@ -492,7 +499,7 @@ def test_batch_generator_uses_image_spans_without_gemma4_token_types(monkeypatch
 def test_batch_generator_pads_gemma4_token_types_after_restore(monkeypatch):
     """A new-image suffix can build masks against restored cached prefix keys."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
-    model = _gemma4_unified_model()
+    model = _gemma4_model()
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
@@ -560,8 +567,8 @@ def test_batch_generator_pads_gemma4_token_types_for_final_prefill(monkeypatch):
     assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 0, 1, 1]]
 
 
-def test_batch_generator_does_not_apply_unified_visual_policy_to_gemma4(monkeypatch):
-    """Non-unified Gemma4 models keep their existing chunking behavior."""
+def test_batch_generator_applies_visual_policy_to_bidir_gemma4(monkeypatch):
+    """Non-unified Gemma4 bidirectional-vision models use visual-prefix prefill."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,
@@ -569,6 +576,47 @@ def test_batch_generator_does_not_apply_unified_visual_policy_to_gemma4(monkeypa
         lambda _model: [_FakeBatchCache()],
     )
     model = _gemma4_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=4,
+    )
+    prompt = list(range(10))
+    mm_token_type_ids = mx.array(
+        [[0, 0, 0, 0, 0, 1, 1, 1, 0, 0]],
+        dtype=mx.int32,
+    )
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[],
+        )
+
+        generator.next()
+        generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [8, 2]
+
+
+def test_batch_generator_chunks_non_bidir_gemma4_normally(monkeypatch):
+    """Gemma4 without bidirectional visual attention keeps normal chunking."""
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_non_bidir_model()
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,

--- a/tests/test_batched_vision_model_kit.py
+++ b/tests/test_batched_vision_model_kit.py
@@ -14,11 +14,16 @@ from mlx_engine.model_kit.batched_vision.prompt_cache.types import (
 )
 
 
-def test_global_no_chunked_prefill_exempts_only_gemma4_unified():
+def test_global_no_chunked_prefill_exempts_gemma4_visual_policy():
     model = SimpleNamespace(no_chunked_prefill=True)
 
     assert not _requires_global_no_chunked_prefill(model, "gemma4_unified")
     assert not _requires_global_no_chunked_prefill(model, "gemma4_unified_text")
+    assert not _requires_global_no_chunked_prefill(
+        model,
+        "gemma4",
+        uses_bidirectional_visual_attention=True,
+    )
     assert _requires_global_no_chunked_prefill(model, "gemma4")
     assert _requires_global_no_chunked_prefill(model, "gemma4_text")
 
@@ -46,6 +51,12 @@ def test_gemma4_restore_conflict_only_rejects_split_image_span():
         model_type="gemma4_unified",
         cached_prefix_len=201,
         image_spans=image_spans,
+    )
+    assert _restore_splits_gemma4_image_span(
+        model_type="gemma4",
+        cached_prefix_len=201,
+        image_spans=image_spans,
+        uses_bidirectional_visual_attention=True,
     )
     assert not _restore_splits_gemma4_image_span(
         model_type="gemma4",

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -4,12 +4,14 @@ import mlx.core as mx
 from mlx_lm.models.base import create_causal_mask
 
 from mlx_engine.model_kit.patches.gemma4 import (
+    config_uses_bidirectional_visual_attention,
     patch_loaded_model,
     prepare_cached_suffix_prompt_kwargs,
+    uses_bidirectional_visual_attention,
 )
 
 
-class _Gemma4UnifiedTextModel:
+class _Gemma4TextModel:
     def _block_sequence_ids_for_mask(self, mm_token_type_ids):
         is_vision = (mm_token_type_ids == 1) | (mm_token_type_ids == 2)
         prev = mx.concatenate(
@@ -50,9 +52,10 @@ def test_gemma4_cached_suffix_prompt_kwargs_keeps_text_only_token_types():
 
 
 def test_gemma4_suffix_visual_mask_patch_uses_query_rows_only():
-    text_model = _Gemma4UnifiedTextModel()
+    text_model = _Gemma4TextModel()
     language_model = SimpleNamespace(
-        model_type="gemma4_unified_text",
+        model_type="gemma4_text",
+        config=SimpleNamespace(use_bidirectional_attention="vision"),
         model=text_model,
     )
     model = SimpleNamespace(language_model=language_model)
@@ -78,3 +81,33 @@ def test_gemma4_suffix_visual_mask_patch_uses_query_rows_only():
         )
         is base_mask
     )
+
+
+def test_gemma4_bidirectional_visual_detection_accepts_top_and_text_config():
+    model = SimpleNamespace(
+        language_model=SimpleNamespace(
+            model_type="gemma4_text",
+            config=SimpleNamespace(use_bidirectional_attention="vision"),
+        )
+    )
+    config = {
+        "model_type": "gemma4",
+        "text_config": {"use_bidirectional_attention": "vision"},
+    }
+
+    assert uses_bidirectional_visual_attention(model)
+    assert config_uses_bidirectional_visual_attention(config)
+
+
+def test_gemma4_bidirectional_visual_detection_rejects_non_bidir_config():
+    model = SimpleNamespace(
+        model_type="gemma4_text",
+        config=SimpleNamespace(use_bidirectional_attention=None),
+    )
+    config = {
+        "model_type": "gemma4",
+        "text_config": {"use_bidirectional_attention": None},
+    }
+
+    assert not uses_bidirectional_visual_attention(model)
+    assert not config_uses_bidirectional_visual_attention(config)


### PR DESCRIPTION
Update the non-unified gemma models to ensure that chunked prefill does not chunk in the middle of an image block. This follows a recent upstream change, and also matches the transformers source of truth.