### PR TITLE
Gemma4 tool calling grammar

### DIFF
--- a/mlx_engine/external/models/ernie4_5/tokenization_ernie4_5.py
+++ b/mlx_engine/external/models/ernie4_5/tokenization_ernie4_5.py
@@ -25,7 +25,6 @@ logger = logging.get_logger(__name__)
 
 
 class Ernie4_5_Tokenizer(PreTrainedTokenizer):
-
     vocab_files_names = {
         "vocab_file": "tokenizer.model",
     }
@@ -93,7 +92,7 @@ class Ernie4_5_Tokenizer(PreTrainedTokenizer):
             int: The number of tokens in the vocabulary.
         """
         return self.sp_model.vocab_size()
-    
+
     def get_vocab(self):
         """Get the vocabulary as a dictionary mapping tokens to their IDs.
 
@@ -211,4 +210,3 @@ class Ernie4_5_Tokenizer(PreTrainedTokenizer):
             clean_up_tokenization_spaces=False,
             spaces_between_special_tokens=False,
         )
-

--- a/mlx_engine/external/models/ernie4_5_moe/configuration_ernie4_5_moe.py
+++ b/mlx_engine/external/models/ernie4_5_moe/configuration_ernie4_5_moe.py
@@ -15,7 +15,6 @@
 from transformers import PretrainedConfig
 
 
-
 class Ernie4_5_MoeConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`Ernie4_5_Model`].
@@ -185,7 +184,7 @@ class Ernie4_5_MoeConfig(PretrainedConfig):
         # Set default for tied embeddings if not specified.
         if "tie_word_embeddings" not in kwargs:
             kwargs["tie_word_embeddings"] = False
-        
+
         super().__init__(
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,

--- a/mlx_engine/external/models/lfm2_vl/processing_lfm2_vl.py
+++ b/mlx_engine/external/models/lfm2_vl/processing_lfm2_vl.py
@@ -237,14 +237,10 @@ class Lfm2VlProcessor(ProcessorMixin):
 
         total_factor = encoder_patch_size * downsample_factor
         smart_resize_min_pixels = (
-            min_image_tokens
-            * encoder_patch_size ** 2
-            * downsample_factor ** 2
+            min_image_tokens * encoder_patch_size**2 * downsample_factor**2
         )
         smart_resize_max_pixels = (
-            max_image_tokens
-            * encoder_patch_size ** 2
-            * downsample_factor ** 2
+            max_image_tokens * encoder_patch_size**2 * downsample_factor**2
         )
 
         h_bar = max(total_factor, round_by_factor(height, total_factor))
@@ -286,8 +282,8 @@ class Lfm2VlProcessor(ProcessorMixin):
         return (
             h_bar * w_bar
             > max_image_tokens
-            * encoder_patch_size ** 2
-            * self.downsample_factor ** 2
+            * encoder_patch_size**2
+            * self.downsample_factor**2
             * max_pixels_tolerance
         )
 
@@ -457,7 +453,9 @@ class Lfm2VlProcessor(ProcessorMixin):
     def __call__(
         self,
         images: ImageInput | list[ImageInput] | list[list[ImageInput]] = None,
-        text: Union[TextInput, "PreTokenizedInput", list[TextInput], list["PreTokenizedInput"]] = None,
+        text: Union[
+            TextInput, "PreTokenizedInput", list[TextInput], list["PreTokenizedInput"]
+        ] = None,
         use_image_special_tokens: bool | None = None,
         downsample_factor: int | None = None,
         min_image_tokens: int | None = None,

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -733,11 +733,6 @@ def _batched_generation(
                     tokenizer=model_kit.tokenizer,
                     context=gemma4_tool_context,
                 )
-                logger.info(
-                    "[mlx-engine] tool runtime: protocol=gemma4 tools=%d "
-                    "mode=reasoning_guard+structure",
-                    len(gemma4_tool_context.tool_names),
-                )
                 logits_processors.append(gemma4_reasoning_guard)
 
         stream = model_kit.generate(

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -738,7 +738,7 @@ def _batched_generation(
                 if gemma4_reasoning_guard is not None:
                     logger.info(
                         "[mlx-engine] tool runtime: protocol=gemma4 tools=%d "
-                        "mode=reasoning_guard",
+                        "mode=reasoning_guard+structure",
                         len(gemma4_tool_context.tool_names),
                     )
                     logits_processors.append(gemma4_reasoning_guard)

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -729,19 +729,16 @@ def _batched_generation(
                 model_type=model_kit.model_type,
             )
             if gemma4_tool_context is not None:
-                gemma4_reasoning_guard = (
-                    create_gemma4_reasoning_guard_logits_processor(
-                        tokenizer=model_kit.tokenizer,
-                        context=gemma4_tool_context,
-                    )
+                gemma4_reasoning_guard = create_gemma4_reasoning_guard_logits_processor(
+                    tokenizer=model_kit.tokenizer,
+                    context=gemma4_tool_context,
                 )
-                if gemma4_reasoning_guard is not None:
-                    logger.info(
-                        "[mlx-engine] tool runtime: protocol=gemma4 tools=%d "
-                        "mode=reasoning_guard+structure",
-                        len(gemma4_tool_context.tool_names),
-                    )
-                    logits_processors.append(gemma4_reasoning_guard)
+                logger.info(
+                    "[mlx-engine] tool runtime: protocol=gemma4 tools=%d "
+                    "mode=reasoning_guard+structure",
+                    len(gemma4_tool_context.tool_names),
+                )
+                logits_processors.append(gemma4_reasoning_guard)
 
         stream = model_kit.generate(
             prompt_tokens=input_tokens,

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -43,6 +43,10 @@ from mlx_engine.utils.speculative_decoding import (
 )
 from outlines.processors.structured import JSONLogitsProcessor
 from mlx_engine.utils.outlines_transformer_tokenizer import OutlinesTransformerTokenizer
+from mlx_engine.tool_runtime import (
+    create_gemma4_reasoning_guard_logits_processor,
+    create_gemma4_tool_context_from_prompt,
+)
 from mlx_engine.cache_wrapper import validate_prefill_step_size
 from mlx_engine.utils.prompt_progress_reporter import (
     BatchedMlxLmReporterAdapter,
@@ -718,6 +722,26 @@ def _batched_generation(
                     json_schema,
                 )
             )
+        else:
+            gemma4_tool_context = create_gemma4_tool_context_from_prompt(
+                tokenizer=model_kit.tokenizer,
+                prompt_tokens=prompt_tokens,
+                model_type=model_kit.model_type,
+            )
+            if gemma4_tool_context is not None:
+                gemma4_reasoning_guard = (
+                    create_gemma4_reasoning_guard_logits_processor(
+                        tokenizer=model_kit.tokenizer,
+                        context=gemma4_tool_context,
+                    )
+                )
+                if gemma4_reasoning_guard is not None:
+                    logger.info(
+                        "[mlx-engine] tool runtime: protocol=gemma4 tools=%d "
+                        "mode=reasoning_guard",
+                        len(gemma4_tool_context.tool_names),
+                    )
+                    logits_processors.append(gemma4_reasoning_guard)
 
         stream = model_kit.generate(
             prompt_tokens=input_tokens,

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -225,8 +225,9 @@ def _apply_logits_processors(
         sample_logits = logits[i : i + 1]
         appended_last_token = False
         for processor in logits_processors[i]:
-            if last_tokens is not None and isinstance(
-                processor, RepetitionPenaltyProcessor
+            if last_tokens is not None and (
+                isinstance(processor, RepetitionPenaltyProcessor)
+                or getattr(processor, "uses_last_token_fast_path", False)
             ):
                 sample_logits = processor.process_last_token(
                     last_tokens[i : i + 1], sample_logits

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -235,8 +235,10 @@ def _apply_logits_processors(
             elif last_tokens is not None and isinstance(
                 processor, Gemma4ReasoningGuardLogitsProcessor
             ):
-                sample_logits = processor.process_last_token(
-                    last_tokens[i : i + 1], sample_logits
+                # Pass materialized history separately so Gemma4 structure
+                # tracking avoids last_tokens.tolist() on the decode path.
+                sample_logits = processor.process_last_token_with_context(
+                    tokens[i], last_tokens[i : i + 1], sample_logits
                 )
             else:
                 if last_tokens is not None and not appended_last_token:

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -38,6 +38,7 @@ from mlx_lm.models.cache import make_prompt_cache
 from mlx_engine.processors.repetition_penalty_processor import (
     RepetitionPenaltyProcessor,
 )
+from mlx_engine.tool_runtime import Gemma4ReasoningGuardLogitsProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -221,9 +222,6 @@ def _apply_logits_processors(
     last_tokens: mx.array | None = None,
 ) -> mx.array:
     processed_logits = []
-    changed_logits = False
-    # Lazily materialize once; per-row MLX slice.tolist() is measurable.
-    last_token_ids = None
     for i in range(logits.shape[0]):
         sample_logits = logits[i : i + 1]
         appended_last_token = False
@@ -234,26 +232,18 @@ def _apply_logits_processors(
                 sample_logits = processor.process_last_token(
                     last_tokens[i : i + 1], sample_logits
                 )
-            elif last_tokens is not None and getattr(
-                processor, "uses_last_token_fast_path", False
+            elif last_tokens is not None and isinstance(
+                processor, Gemma4ReasoningGuardLogitsProcessor
             ):
-                if last_token_ids is None:
-                    last_token_ids = last_tokens.tolist()
                 sample_logits = processor.process_last_token(
-                    last_token_ids[i], sample_logits
+                    last_tokens[i : i + 1], sample_logits
                 )
             else:
                 if last_tokens is not None and not appended_last_token:
                     tokens[i].append(last_tokens[i : i + 1].tolist()[0])
                     appended_last_token = True
                 sample_logits = processor(mx.array(tokens[i]), sample_logits)
-            changed_logits = changed_logits or getattr(
-                processor, "last_call_changed_logits", True
-            )
         processed_logits.append(sample_logits)
-    # State-only processors can watch tokens without forcing a logits rebuild.
-    if not changed_logits:
-        return logits
     return mx.concatenate(processed_logits, axis=0)
 
 

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -221,23 +221,39 @@ def _apply_logits_processors(
     last_tokens: mx.array | None = None,
 ) -> mx.array:
     processed_logits = []
+    changed_logits = False
+    # Lazily materialize once; per-row MLX slice.tolist() is measurable.
+    last_token_ids = None
     for i in range(logits.shape[0]):
         sample_logits = logits[i : i + 1]
         appended_last_token = False
         for processor in logits_processors[i]:
-            if last_tokens is not None and (
-                isinstance(processor, RepetitionPenaltyProcessor)
-                or getattr(processor, "uses_last_token_fast_path", False)
+            if last_tokens is not None and isinstance(
+                processor, RepetitionPenaltyProcessor
             ):
                 sample_logits = processor.process_last_token(
                     last_tokens[i : i + 1], sample_logits
+                )
+            elif last_tokens is not None and getattr(
+                processor, "uses_last_token_fast_path", False
+            ):
+                if last_token_ids is None:
+                    last_token_ids = last_tokens.tolist()
+                sample_logits = processor.process_last_token(
+                    last_token_ids[i], sample_logits
                 )
             else:
                 if last_tokens is not None and not appended_last_token:
                     tokens[i].append(last_tokens[i : i + 1].tolist()[0])
                     appended_last_token = True
                 sample_logits = processor(mx.array(tokens[i]), sample_logits)
+            changed_logits = changed_logits or getattr(
+                processor, "last_call_changed_logits", True
+            )
         processed_logits.append(sample_logits)
+    # State-only processors can watch tokens without forcing a logits rebuild.
+    if not changed_logits:
+        return logits
     return mx.concatenate(processed_logits, axis=0)
 
 

--- a/mlx_engine/tool_protocols.py
+++ b/mlx_engine/tool_protocols.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+GEMMA4_REASONING_START = "<|channel>thought"
+GEMMA4_CHANNEL_END = "<channel|>"
+GEMMA4_TOOL_DECLARATION_START = "<|tool>"
+GEMMA4_TOOL_DECLARATION_END = "<tool|>"
+GEMMA4_TOOL_CALL_START = "<|tool_call>"
+GEMMA4_TOOL_CALL_END = "<tool_call|>"
+GEMMA4_STRING_DELIMITER = '<|"|>'
+
+
+@dataclass(frozen=True)
+class Gemma4ToolContext:
+    tool_names: tuple[str, ...]
+    reasoning_open: bool
+
+
+def gemma4_reasoning_is_open(text: str) -> bool:
+    return text.rfind(GEMMA4_REASONING_START) > text.rfind(GEMMA4_CHANNEL_END)

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -1,0 +1,41 @@
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from mlx_engine.tool_protocols import (
+    GEMMA4_TOOL_DECLARATION_END,
+    GEMMA4_TOOL_DECLARATION_START,
+    Gemma4ToolContext,
+    gemma4_reasoning_is_open,
+)
+
+# Match Gemma4 declaration blocks like:
+#   <|tool>declaration:get_weather{ ... }<tool|>
+# and capture only the declared tool name (`get_weather`).
+_GEMMA4_TOOL_NAME_RE = re.compile(
+    rf"{re.escape(GEMMA4_TOOL_DECLARATION_START)}.*?"
+    r"declaration:\s*([A-Za-z_][A-Za-z0-9_.$/-]*)\s*{.*?"
+    rf"{re.escape(GEMMA4_TOOL_DECLARATION_END)}",
+    re.DOTALL,
+)
+
+
+def create_gemma4_tool_context_from_prompt(
+    *,
+    tokenizer: Any,
+    prompt_tokens: Iterable[int],
+    model_type: str | None,
+) -> Gemma4ToolContext | None:
+    """Return Gemma4 tool context only when the rendered prompt declares tools."""
+    if not str(model_type or "").startswith("gemma4"):
+        return None
+
+    prompt_text = tokenizer.decode(list(prompt_tokens))
+    tool_names = tuple(dict.fromkeys(_GEMMA4_TOOL_NAME_RE.findall(prompt_text)))
+    if len(tool_names) == 0:
+        return None
+
+    return Gemma4ToolContext(
+        tool_names=tool_names,
+        reasoning_open=gemma4_reasoning_is_open(prompt_text),
+    )

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from mlx_engine.tool_protocols import (
+    GEMMA4_TOOL_CALL_START,
     GEMMA4_TOOL_DECLARATION_END,
     GEMMA4_TOOL_DECLARATION_START,
     Gemma4ToolContext,
@@ -39,3 +40,66 @@ def create_gemma4_tool_context_from_prompt(
         tool_names=tool_names,
         reasoning_open=gemma4_reasoning_is_open(prompt_text),
     )
+
+
+class Gemma4ReasoningGuardLogitsProcessor:
+    """Block Gemma4 tool-call starts while visible reasoning is still open."""
+
+    def __init__(self, *, tokenizer: Any, tool_call_start_token_id: int):
+        self._tokenizer = tokenizer
+        self._tool_call_start_token_id = tool_call_start_token_id
+
+    def __call__(self, tokens: Any, logits: Any) -> Any:
+        token_ids = _token_ids_to_list(tokens)
+        if not gemma4_reasoning_is_open(self._tokenizer.decode(token_ids)):
+            return logits
+
+        if 0 <= self._tool_call_start_token_id < logits.shape[-1]:
+            logits[:, self._tool_call_start_token_id] = -float("inf")
+        return logits
+
+
+def create_gemma4_reasoning_guard_logits_processor(
+    *,
+    tokenizer: Any,
+    context: Gemma4ToolContext,
+) -> Gemma4ReasoningGuardLogitsProcessor | None:
+    if len(context.tool_names) == 0:
+        return None
+
+    tool_call_start_token_id = _gemma4_tool_call_start_token_id(tokenizer)
+    if tool_call_start_token_id is None:
+        return None
+
+    return Gemma4ReasoningGuardLogitsProcessor(
+        tokenizer=tokenizer,
+        tool_call_start_token_id=tool_call_start_token_id,
+    )
+
+
+def _token_ids_to_list(tokens: Any) -> list[int]:
+    if hasattr(tokens, "tolist"):
+        tokens = tokens.tolist()
+    if isinstance(tokens, int):
+        return [tokens]
+    return [int(token_id) for token_id in tokens]
+
+
+def _gemma4_tool_call_start_token_id(tokenizer: Any) -> int | None:
+    token_ids = getattr(tokenizer, "tool_call_start_tokens", None)
+    if token_ids is None and hasattr(tokenizer, "encode"):
+        token_ids = tokenizer.encode(GEMMA4_TOOL_CALL_START, add_special_tokens=False)
+
+    if isinstance(token_ids, int):
+        token_id = token_ids
+    elif isinstance(token_ids, (list, tuple)) and len(token_ids) == 1:
+        token_id = int(token_ids[0])
+    else:
+        return None
+
+    try:
+        if tokenizer.decode([token_id]) != GEMMA4_TOOL_CALL_START:
+            return None
+    except Exception:
+        return None
+    return token_id

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -3,6 +3,11 @@ import re
 from collections.abc import Iterable
 from typing import Any
 
+import llguidance
+import llguidance.hf
+import llguidance.mlx
+import llguidance.numpy
+
 import mlx.core as mx
 
 from mlx_engine.tool_protocols import (
@@ -71,14 +76,10 @@ class _Gemma4LLGuidanceToolGrammar:
     def _ensure_ready(self) -> None:
         if self._llg_tokenizer is not None:
             return
-        import llguidance.numpy
-
         self._llg_tokenizer = _get_llguidance_tokenizer(self._tokenizer)
         self._bitmask = llguidance.numpy.allocate_token_bitmask(1, self._vocab_size)
 
     def start_matcher(self) -> Any:
-        import llguidance
-
         self._ensure_ready()
         return llguidance.LLMatcher(self._llg_tokenizer, self._grammar)
 
@@ -89,9 +90,6 @@ class _Gemma4LLGuidanceToolGrammar:
         return matcher.is_stopped()
 
     def mask_logits(self, matcher: Any, logits: mx.array) -> mx.array:
-        import llguidance.mlx
-        import llguidance.numpy
-
         llguidance.numpy.fill_next_token_bitmask(matcher, self._bitmask, 0)
         return llguidance.mlx.apply_token_bitmask(logits, self._bitmask)
 
@@ -321,8 +319,6 @@ WS: /[ \t\n\r]*/
 
 
 def _get_llguidance_tokenizer(tokenizer: Any) -> Any:
-    import llguidance.hf
-
     hf_tokenizer = tokenizer._tokenizer
     cache_key = id(hf_tokenizer)
     llg_tokenizer = _LLG_TOKENIZER_CACHE.get(cache_key)

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -291,17 +291,22 @@ def create_gemma4_reasoning_guard_logits_processor(
 
 def _gemma4_llguidance_grammar(tool_names: tuple[str, ...]) -> str:
     tool_choice = " | ".join(json.dumps(tool_name) for tool_name in tool_names)
+    # Regex chars handle normal text; explicit special-token alternatives keep
+    # marker-looking text legal inside Gemma strings until the exact <|"|> delimiter.
     return rf'''%llguidance {{}}
 start: "call:" tool object <tool_call|>
 tool: {tool_choice}
 object: "{{" WS (member (WS "," WS member)*)? WS "}}"
 member: key WS ":" WS value
-key: IDENT | gemma_string
-IDENT: /[A-Za-z_]/ /[A-Za-z0-9_.$\/-]*/
-value: gemma_string | object | array | NUMBER | "true" | "false" | "null"
+key: BARE_KEY | gemma_string
+BARE_KEY: /[A-Za-z0-9_.$\/-]/+
+value: gemma_string | object | array | NUMBER | LITERAL
+LITERAL: "true" | "false" | "null" | "None" | "none"
 array: "[" WS (value (WS "," WS value)*)? WS "]"
-gemma_string: <|"|> STRING_CHAR* <|"|>
-STRING_CHAR: /[^<]/ | "<" /[^|]/
+gemma_string: <|"|> gemma_string_char* <|"|>
+gemma_string_char: STRING_CHAR | gemma_string_special
+STRING_CHAR: /[^<]/ | "<" /[^|]/ | "<|" /[^"]/ | "<|\"" /[^|]/ | "<|\"|" /[^>]/
+gemma_string_special: <|tool> | <tool|> | <|tool_call> | <tool_call|> | <|tool_response> | <tool_response|> | <|channel> | <channel|> | <|turn> | <turn|> | <|think|> | <|image> | <image|> | <|image|> | <|audio> | <audio|> | <|audio|> | <|video|>
 NUMBER: "-"? (/[0-9]/ | /[1-9]/ /[0-9]*/) ("." /[0-9]/+)? (/[eE]/ /[+-]/? /[0-9]/+)?
 WS: /[ \t\n\r]*/
 '''

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -212,8 +212,10 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._previous_token_mx = token_id
 
         if self._tool_state == self._STATE_NORMAL:
-            # If the sampled token was <|tool_call>, force the next token to
-            # start the native `call:` prefix. Otherwise leave logits alone.
+            # Bridge the first token after <|tool_call> without syncing token_id
+            # to Python. Starting llguidance here would require token_id.item()
+            # on every normal decode step; instead, use an MLX condition to force
+            # the native `call:` prefix only when <|tool_call> was sampled.
             logits = _boost_token_ids_mx(
                 logits,
                 token_id == self._tool_call_start_token_id,

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -58,6 +58,8 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._reasoning_start_token_ids = reasoning_start_token_ids
         self._reasoning_end_token_ids = reasoning_end_token_ids
         self._tool_call_start_token_id = tool_call_start_token_id
+        # Lets the VLM batcher skip logits work while the guard only observes state.
+        self.last_call_changed_logits = False
         self._tail_token_count = max(
             len(reasoning_start_token_ids),
             len(reasoning_end_token_ids),
@@ -83,6 +85,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
         return self._mask_if_needed(logits)
 
     def _mask_if_needed(self, logits: Any) -> Any:
+        self.last_call_changed_logits = self._reasoning_open
         if self._reasoning_open:
             # vLLM treats <|tool_call> as an implicit Gemma4 reasoning end, but
             # Electron currently suppresses tool parsing for reasoning fragments.
@@ -122,6 +125,8 @@ def create_gemma4_reasoning_guard_logits_processor(
 def _token_ids_to_list(tokens: Any) -> list[int]:
     if hasattr(tokens, "tolist"):
         tokens = tokens.tolist()
+    if isinstance(tokens, int):
+        return [tokens]
     return [int(token_id) for token_id in tokens]
 
 

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -176,8 +176,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
     def _process_last_token_mx(self, token_id: mx.array, logits: mx.array) -> mx.array:
         # Keep normal decode token handling in MLX: last_token.tolist() calls
         # eval()/wait and can create a per-token graph break. We only sync the
-        # sampled token while an llguidance tool grammar is active, where slower
-        # decoding is acceptable.
+        # sampled token while an llguidance tool grammar is active.
         reasoning_start = (
             self._previous_token_mx == self._reasoning_start_first_token_id
         ) & (token_id == self._reasoning_start_second_token_id)
@@ -197,10 +196,8 @@ class Gemma4ReasoningGuardLogitsProcessor:
 
     def _mask_if_needed_mx(self, logits: mx.array, token_id: mx.array) -> mx.array:
         logits = self._mask_tool_structure_mx(logits, token_id)
-        # vLLM treats <|tool_call> as an implicit Gemma4 reasoning end, but
-        # Electron currently suppresses tool parsing for reasoning fragments.
-        # This stricter mask forces the model to sample the real <channel|>
-        # close first, avoiding synthetic markers or an Electron parser change.
+        # Keep <|tool_call> blocked while visible reasoning is open. This forces
+        # the model to sample the real <channel|> close before starting a tool call.
         logits[:, self._tool_call_start_token_id] = mx.where(
             self._reasoning_open_mx,
             -float("inf"),
@@ -213,11 +210,9 @@ class Gemma4ReasoningGuardLogitsProcessor:
         logits: mx.array,
         token_id: mx.array,
     ) -> mx.array:
-        # KISS structural scope: once <|tool_call> is emitted, llguidance
-        # enforces one native Gemma4 call:
+        # Once <|tool_call> is emitted, llguidance enforces one native Gemma4 call:
         #   call:KNOWN_TOOL{...}<tool_call|>
-        # We still keep the cheap Python wrapper for lazy activation and the
-        # post-tool state that allows only EOS/whitespace/another adjacent call.
+        # The post-tool state allows only EOS/whitespace/another adjacent call.
         if self._tool_state == self._STATE_NORMAL:
             return _force_token_ids_mx(
                 logits,
@@ -254,10 +249,8 @@ class Gemma4ReasoningGuardLogitsProcessor:
 
     def _mask_if_needed(self, logits: Any) -> Any:
         if self._reasoning_open:
-            # vLLM treats <|tool_call> as an implicit Gemma4 reasoning end, but
-            # Electron currently suppresses tool parsing for reasoning fragments.
-            # This stricter mask forces the model to sample the real <channel|>
-            # close first, avoiding synthetic markers or an Electron parser change.
+            # Keep <|tool_call> blocked while visible reasoning is open. This forces
+            # the model to sample the real <channel|> close before starting a tool call.
             logits[:, self._tool_call_start_token_id] = -float("inf")
         return logits
 

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -2,6 +2,8 @@ import re
 from collections.abc import Iterable
 from typing import Any
 
+import mlx.core as mx
+
 from mlx_engine.tool_protocols import (
     GEMMA4_TOOL_DECLARATION_END,
     GEMMA4_TOOL_DECLARATION_START,
@@ -44,8 +46,6 @@ def create_gemma4_tool_context_from_prompt(
 class Gemma4ReasoningGuardLogitsProcessor:
     """Block Gemma4 tool-call starts while visible reasoning is still open."""
 
-    uses_last_token_fast_path = True
-
     def __init__(
         self,
         *,
@@ -55,26 +55,36 @@ class Gemma4ReasoningGuardLogitsProcessor:
         tool_call_start_token_id: int,
     ):
         self._reasoning_open = reasoning_open
+        self._reasoning_open_mx = mx.array(reasoning_open)
         self._reasoning_start_token_ids = reasoning_start_token_ids
+        self._reasoning_start_prefix_token_id = (
+            reasoning_start_token_ids[0]
+            if len(reasoning_start_token_ids) == 2
+            else None
+        )
+        self._reasoning_start_token_id = reasoning_start_token_ids[-1]
         self._reasoning_end_token_ids = reasoning_end_token_ids
+        self._reasoning_end_token_id = reasoning_end_token_ids[0]
         self._tool_call_start_token_id = tool_call_start_token_id
-        # Lets the VLM batcher skip logits work while the guard only observes state.
-        self.last_call_changed_logits = False
-        self._tail_token_count = max(
-            len(reasoning_start_token_ids),
-            len(reasoning_end_token_ids),
-            1,
-        ) - 1
+        self._tail_token_count = max(len(reasoning_start_token_ids), 1) - 1
         self._tail_tokens: list[int] = []
+        self._previous_token_mx: mx.array | None = None
 
     def __call__(self, tokens: Any, logits: Any) -> Any:
         # VLM calls this once on prompt prefill. Prompt reasoning state already
         # came from decoded prompt text, so keep only enough tail for markers
         # that may finish immediately after prefill.
         self._tail_tokens = _tail(_token_ids_to_list(tokens), self._tail_token_count)
+        self._previous_token_mx = (
+            mx.array(self._tail_tokens[-1]) if len(self._tail_tokens) > 0 else None
+        )
+        self._reasoning_open_mx = mx.array(self._reasoning_open)
         return self._mask_if_needed(logits)
 
     def process_last_token(self, last_token: Any, logits: Any) -> Any:
+        if isinstance(last_token, mx.array):
+            return self._process_last_token_mx(last_token.reshape(-1)[0], logits)
+
         for token_id in _token_ids_to_list(last_token):
             token_window = self._tail_tokens + [token_id]
             if _ends_with(token_window, self._reasoning_start_token_ids):
@@ -84,8 +94,42 @@ class Gemma4ReasoningGuardLogitsProcessor:
             self._tail_tokens = _tail(token_window, self._tail_token_count)
         return self._mask_if_needed(logits)
 
+    def _process_last_token_mx(self, token_id: mx.array, logits: mx.array) -> mx.array:
+        reasoning_start = token_id == self._reasoning_start_token_id
+        if self._reasoning_start_prefix_token_id is not None:
+            if self._previous_token_mx is None:
+                reasoning_start = mx.array(False)
+            else:
+                reasoning_start = reasoning_start & (
+                    self._previous_token_mx == self._reasoning_start_prefix_token_id
+                )
+        reasoning_end = token_id == self._reasoning_end_token_id
+        self._reasoning_open_mx = mx.where(
+            reasoning_start,
+            mx.array(True),
+            self._reasoning_open_mx,
+        )
+        self._reasoning_open_mx = mx.where(
+            reasoning_end,
+            mx.array(False),
+            self._reasoning_open_mx,
+        )
+        self._previous_token_mx = token_id
+        return self._mask_if_needed_mx(logits)
+
+    def _mask_if_needed_mx(self, logits: mx.array) -> mx.array:
+        # vLLM treats <|tool_call> as an implicit Gemma4 reasoning end, but
+        # Electron currently suppresses tool parsing for reasoning fragments.
+        # This stricter mask forces the model to sample the real <channel|>
+        # close first, avoiding synthetic markers or an Electron parser change.
+        logits[:, self._tool_call_start_token_id] = mx.where(
+            self._reasoning_open_mx,
+            -float("inf"),
+            logits[:, self._tool_call_start_token_id],
+        )
+        return logits
+
     def _mask_if_needed(self, logits: Any) -> Any:
-        self.last_call_changed_logits = self._reasoning_open
         if self._reasoning_open:
             # vLLM treats <|tool_call> as an implicit Gemma4 reasoning end, but
             # Electron currently suppresses tool parsing for reasoning fragments.
@@ -110,7 +154,9 @@ def create_gemma4_reasoning_guard_logits_processor(
         tool_call_start_token_ids is None
         or len(tool_call_start_token_ids) != 1
         or reasoning_start_token_ids is None
+        or not 1 <= len(reasoning_start_token_ids) <= 2
         or reasoning_end_token_ids is None
+        or len(reasoning_end_token_ids) != 1
     ):
         return None
 

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -3,9 +3,6 @@ from collections.abc import Iterable
 from typing import Any
 
 from mlx_engine.tool_protocols import (
-    GEMMA4_CHANNEL_END,
-    GEMMA4_REASONING_START,
-    GEMMA4_TOOL_CALL_START,
     GEMMA4_TOOL_DECLARATION_END,
     GEMMA4_TOOL_DECLARATION_START,
     Gemma4ToolContext,
@@ -103,21 +100,9 @@ def create_gemma4_reasoning_guard_logits_processor(
     if len(context.tool_names) == 0:
         return None
 
-    tool_call_start_token_ids = _token_sequence(
-        tokenizer,
-        attr_name="tool_call_start_tokens",
-        text=GEMMA4_TOOL_CALL_START,
-    )
-    reasoning_start_token_ids = _token_sequence(
-        tokenizer,
-        attr_name="think_start_tokens",
-        text=GEMMA4_REASONING_START,
-    )
-    reasoning_end_token_ids = _token_sequence(
-        tokenizer,
-        attr_name="think_end_tokens",
-        text=GEMMA4_CHANNEL_END,
-    )
+    tool_call_start_token_ids = tokenizer.tool_call_start_tokens
+    reasoning_start_token_ids = tokenizer.think_start_tokens
+    reasoning_end_token_ids = tokenizer.think_end_tokens
     if (
         tool_call_start_token_ids is None
         or len(tool_call_start_token_ids) != 1
@@ -134,30 +119,10 @@ def create_gemma4_reasoning_guard_logits_processor(
     )
 
 
-def _token_sequence(
-    tokenizer: Any,
-    *,
-    attr_name: str,
-    text: str,
-) -> tuple[int, ...] | None:
-    token_ids = getattr(tokenizer, attr_name, None)
-    if token_ids is None and hasattr(tokenizer, "encode"):
-        token_ids = tokenizer.encode(text, add_special_tokens=False)
-    if isinstance(token_ids, int):
-        return (token_ids,)
-    if isinstance(token_ids, (list, tuple)) and len(token_ids) > 0:
-        return tuple(int(token_id) for token_id in token_ids)
-    return None
-
-
 def _token_ids_to_list(tokens: Any) -> list[int]:
     if hasattr(tokens, "tolist"):
         tokens = tokens.tolist()
-    if isinstance(tokens, int):
-        return [tokens]
-    if isinstance(tokens, (list, tuple)):
-        return [int(token_id) for token_id in tokens]
-    return [int(tokens)]
+    return [int(token_id) for token_id in tokens]
 
 
 def _tail(token_ids: list[int], count: int) -> list[int]:
@@ -167,4 +132,4 @@ def _tail(token_ids: list[int], count: int) -> list[int]:
 
 
 def _ends_with(token_ids: list[int], suffix: tuple[int, ...]) -> bool:
-    return len(token_ids) >= len(suffix) and tuple(token_ids[-len(suffix) :]) == suffix
+    return token_ids[-len(suffix) :] == list(suffix)

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -57,16 +57,11 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._reasoning_open = reasoning_open
         self._reasoning_open_mx = mx.array(reasoning_open)
         self._reasoning_start_token_ids = reasoning_start_token_ids
-        self._reasoning_start_prefix_token_id = (
-            reasoning_start_token_ids[0]
-            if len(reasoning_start_token_ids) == 2
-            else None
-        )
-        self._reasoning_start_token_id = reasoning_start_token_ids[-1]
+        self._reasoning_start_first_token_id = reasoning_start_token_ids[0]
+        self._reasoning_start_second_token_id = reasoning_start_token_ids[1]
         self._reasoning_end_token_ids = reasoning_end_token_ids
         self._reasoning_end_token_id = reasoning_end_token_ids[0]
         self._tool_call_start_token_id = tool_call_start_token_id
-        self._tail_token_count = max(len(reasoning_start_token_ids), 1) - 1
         self._tail_tokens: list[int] = []
         self._previous_token_mx: mx.array | None = None
 
@@ -74,7 +69,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
         # VLM calls this once on prompt prefill. Prompt reasoning state already
         # came from decoded prompt text, so keep only enough tail for markers
         # that may finish immediately after prefill.
-        self._tail_tokens = _tail(_token_ids_to_list(tokens), self._tail_token_count)
+        self._tail_tokens = _tail(_token_ids_to_list(tokens), 1)
         self._previous_token_mx = (
             mx.array(self._tail_tokens[-1]) if len(self._tail_tokens) > 0 else None
         )
@@ -91,18 +86,18 @@ class Gemma4ReasoningGuardLogitsProcessor:
                 self._reasoning_open = True
             if _ends_with(token_window, self._reasoning_end_token_ids):
                 self._reasoning_open = False
-            self._tail_tokens = _tail(token_window, self._tail_token_count)
+            self._tail_tokens = _tail(token_window, 1)
         return self._mask_if_needed(logits)
 
     def _process_last_token_mx(self, token_id: mx.array, logits: mx.array) -> mx.array:
-        reasoning_start = token_id == self._reasoning_start_token_id
-        if self._reasoning_start_prefix_token_id is not None:
-            if self._previous_token_mx is None:
-                reasoning_start = mx.array(False)
-            else:
-                reasoning_start = reasoning_start & (
-                    self._previous_token_mx == self._reasoning_start_prefix_token_id
-                )
+        # Keep decode token handling in MLX: last_token.tolist() calls eval()/wait
+        # and can create a per-token graph break.
+        if self._previous_token_mx is None:
+            reasoning_start = mx.array(False)
+        else:
+            reasoning_start = (
+                self._previous_token_mx == self._reasoning_start_first_token_id
+            ) & (token_id == self._reasoning_start_second_token_id)
         reasoning_end = token_id == self._reasoning_end_token_id
         self._reasoning_open_mx = mx.where(
             reasoning_start,
@@ -154,7 +149,7 @@ def create_gemma4_reasoning_guard_logits_processor(
         tool_call_start_token_ids is None
         or len(tool_call_start_token_ids) != 1
         or reasoning_start_token_ids is None
-        or not 1 <= len(reasoning_start_token_ids) <= 2
+        or len(reasoning_start_token_ids) != 2
         or reasoning_end_token_ids is None
         or len(reasoning_end_token_ids) != 1
     ):

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -3,6 +3,8 @@ from collections.abc import Iterable
 from typing import Any
 
 from mlx_engine.tool_protocols import (
+    GEMMA4_CHANNEL_END,
+    GEMMA4_REASONING_START,
     GEMMA4_TOOL_CALL_START,
     GEMMA4_TOOL_DECLARATION_END,
     GEMMA4_TOOL_DECLARATION_START,
@@ -45,13 +47,78 @@ def create_gemma4_tool_context_from_prompt(
 class Gemma4ReasoningGuardLogitsProcessor:
     """Block Gemma4 tool-call starts while visible reasoning is still open."""
 
-    def __init__(self, *, tokenizer: Any, tool_call_start_token_id: int):
-        self._tokenizer = tokenizer
+    uses_last_token_fast_path = True
+
+    def __init__(
+        self,
+        *,
+        reasoning_open: bool,
+        reasoning_start_token_ids: tuple[int, ...],
+        reasoning_end_token_ids: tuple[int, ...],
+        tool_call_start_token_id: int,
+    ):
+        self._reasoning_open = reasoning_open
+        self._reasoning_start_token_ids = reasoning_start_token_ids
+        self._reasoning_end_token_ids = reasoning_end_token_ids
         self._tool_call_start_token_id = tool_call_start_token_id
+        self._processed_token_count = 0
+        self._tail_tokens: list[int] = []
+        self._tail_token_count = max(
+            len(reasoning_start_token_ids),
+            len(reasoning_end_token_ids),
+            1,
+        ) - 1
 
     def __call__(self, tokens: Any, logits: Any) -> Any:
-        token_ids = _token_ids_to_list(tokens)
-        if not gemma4_reasoning_is_open(self._tokenizer.decode(token_ids)):
+        self._sync_from_full_history(_token_ids_to_list(tokens))
+        return self._mask_if_needed(logits)
+
+    def process_last_token(self, last_token: Any, logits: Any) -> Any:
+        new_token_ids = _token_ids_to_list(last_token)
+        self._process_new_tokens(new_token_ids)
+        self._processed_token_count += len(new_token_ids)
+        return self._mask_if_needed(logits)
+
+    def _sync_from_full_history(self, token_ids: list[int]) -> None:
+        if self._processed_token_count == 0:
+            # First call is the prompt prefill. We already decoded the prompt once
+            # to establish this state, so do not decode or rescan it per token.
+            self._processed_token_count = len(token_ids)
+            self._tail_tokens = self._tail(token_ids)
+            return
+
+        if len(token_ids) < self._processed_token_count:
+            self._reasoning_open = _gemma4_reasoning_is_open_from_token_ids(
+                token_ids,
+                self._reasoning_start_token_ids,
+                self._reasoning_end_token_ids,
+            )
+            self._processed_token_count = len(token_ids)
+            self._tail_tokens = self._tail(token_ids)
+            return
+
+        self._process_new_tokens(token_ids[self._processed_token_count :])
+        self._processed_token_count = len(token_ids)
+
+    def _process_new_tokens(self, new_token_ids: list[int]) -> None:
+        if len(new_token_ids) == 0:
+            return
+        scan_token_ids = self._tail_tokens + new_token_ids
+        self._reasoning_open = _update_gemma4_reasoning_state_from_token_ids(
+            self._reasoning_open,
+            scan_token_ids,
+            self._reasoning_start_token_ids,
+            self._reasoning_end_token_ids,
+        )
+        self._tail_tokens = self._tail(scan_token_ids)
+
+    def _tail(self, token_ids: list[int]) -> list[int]:
+        if self._tail_token_count == 0:
+            return []
+        return token_ids[-self._tail_token_count :]
+
+    def _mask_if_needed(self, logits: Any) -> Any:
+        if not self._reasoning_open:
             return logits
 
         if 0 <= self._tool_call_start_token_id < logits.shape[-1]:
@@ -68,11 +135,27 @@ def create_gemma4_reasoning_guard_logits_processor(
         return None
 
     tool_call_start_token_id = _gemma4_tool_call_start_token_id(tokenizer)
-    if tool_call_start_token_id is None:
+    reasoning_start_token_ids = _token_sequence(
+        tokenizer,
+        attr_name="think_start_tokens",
+        text=GEMMA4_REASONING_START,
+    )
+    reasoning_end_token_ids = _token_sequence(
+        tokenizer,
+        attr_name="think_end_tokens",
+        text=GEMMA4_CHANNEL_END,
+    )
+    if (
+        tool_call_start_token_id is None
+        or reasoning_start_token_ids is None
+        or reasoning_end_token_ids is None
+    ):
         return None
 
     return Gemma4ReasoningGuardLogitsProcessor(
-        tokenizer=tokenizer,
+        reasoning_open=context.reasoning_open,
+        reasoning_start_token_ids=reasoning_start_token_ids,
+        reasoning_end_token_ids=reasoning_end_token_ids,
         tool_call_start_token_id=tool_call_start_token_id,
     )
 
@@ -82,24 +165,82 @@ def _token_ids_to_list(tokens: Any) -> list[int]:
         tokens = tokens.tolist()
     if isinstance(tokens, int):
         return [tokens]
-    return [int(token_id) for token_id in tokens]
+
+    token_ids = []
+    for token_id in tokens:
+        if isinstance(token_id, (list, tuple)):
+            token_ids.extend(_token_ids_to_list(token_id))
+        else:
+            token_ids.append(int(token_id))
+    return token_ids
 
 
 def _gemma4_tool_call_start_token_id(tokenizer: Any) -> int | None:
-    token_ids = getattr(tokenizer, "tool_call_start_tokens", None)
-    if token_ids is None and hasattr(tokenizer, "encode"):
-        token_ids = tokenizer.encode(GEMMA4_TOOL_CALL_START, add_special_tokens=False)
-
-    if isinstance(token_ids, int):
-        token_id = token_ids
-    elif isinstance(token_ids, (list, tuple)) and len(token_ids) == 1:
-        token_id = int(token_ids[0])
-    else:
+    token_ids = _token_sequence(
+        tokenizer,
+        attr_name="tool_call_start_tokens",
+        text=GEMMA4_TOOL_CALL_START,
+    )
+    if token_ids is None or len(token_ids) != 1:
         return None
 
+    token_id = token_ids[0]
     try:
         if tokenizer.decode([token_id]) != GEMMA4_TOOL_CALL_START:
             return None
     except Exception:
         return None
     return token_id
+
+
+def _token_sequence(
+    tokenizer: Any,
+    *,
+    attr_name: str,
+    text: str,
+) -> tuple[int, ...] | None:
+    token_ids = getattr(tokenizer, attr_name, None)
+    if token_ids is None and hasattr(tokenizer, "encode"):
+        token_ids = tokenizer.encode(text, add_special_tokens=False)
+
+    if isinstance(token_ids, int):
+        return (token_ids,)
+    if isinstance(token_ids, (list, tuple)) and len(token_ids) > 0:
+        return tuple(int(token_id) for token_id in token_ids)
+    return None
+
+
+def _gemma4_reasoning_is_open_from_token_ids(
+    token_ids: list[int],
+    reasoning_start_token_ids: tuple[int, ...],
+    reasoning_end_token_ids: tuple[int, ...],
+) -> bool:
+    return _update_gemma4_reasoning_state_from_token_ids(
+        False,
+        token_ids,
+        reasoning_start_token_ids,
+        reasoning_end_token_ids,
+    )
+
+
+def _update_gemma4_reasoning_state_from_token_ids(
+    reasoning_open: bool,
+    token_ids: list[int],
+    reasoning_start_token_ids: tuple[int, ...],
+    reasoning_end_token_ids: tuple[int, ...],
+) -> bool:
+    for token_index in range(len(token_ids)):
+        if _token_sequence_matches(token_ids, token_index, reasoning_start_token_ids):
+            reasoning_open = True
+        if _token_sequence_matches(token_ids, token_index, reasoning_end_token_ids):
+            reasoning_open = False
+    return reasoning_open
+
+
+def _token_sequence_matches(
+    token_ids: list[int],
+    start_index: int,
+    expected: tuple[int, ...],
+) -> bool:
+    end_index = start_index + len(expected)
+    return end_index <= len(token_ids) and tuple(token_ids[start_index:end_index]) == expected

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -87,6 +87,10 @@ class Gemma4ReasoningGuardLogitsProcessor:
 
     def _mask_if_needed(self, logits: Any) -> Any:
         if self._reasoning_open:
+            # vLLM treats <|tool_call> as an implicit Gemma4 reasoning end, but
+            # Electron currently suppresses tool parsing for reasoning fragments.
+            # This stricter mask forces the model to sample the real <channel|>
+            # close first, avoiding synthetic markers or an Electron parser change.
             logits[:, self._tool_call_start_token_id] = -float("inf")
         return logits
 

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -139,7 +139,12 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._reasoning_open_mx = mx.array(self._reasoning_open)
         self._context_token_count = len(token_ids)
         self._reset_tool_state()
-        return self._apply_prefill_reasoning_mask(logits)
+
+        if self._reasoning_open:
+            # The prompt already ended inside visible reasoning, so prevent the
+            # first generated token from starting a tool call before <channel|>.
+            logits[:, self._tool_call_start_token_id] = -float("inf")
+        return logits
 
     def process_last_token_with_context(
         self,
@@ -148,31 +153,24 @@ class Gemma4ReasoningGuardLogitsProcessor:
         logits: mx.array,
     ) -> mx.array:
         """Catch up from materialized context, then mask next-token logits."""
-        self._catch_up_tool_context(token_context)
+        for token_id in token_context[self._context_token_count :]:
+            if self._tool_state == self._STATE_TOOL:
+                # This token was already materialized by the batcher; feed it
+                # into llguidance so the grammar is caught up before masking.
+                self._consume_tool_grammar_token(token_id)
+            elif token_id == self._tool_call_start_token_id:
+                # A materialized <|tool_call> starts grammar tracking. The
+                # grammar itself begins after that marker, at the `call:` text.
+                self._tool_state = self._STATE_TOOL
+                self._tool_matcher = self._tool_grammar.start_matcher()
+        self._context_token_count = len(token_context)
+
         return self._process_last_token_mx(last_token.reshape(-1)[0], logits)
 
     def _reset_tool_state(self) -> None:
         """Return tool-grammar tracking to ordinary non-tool generation."""
         self._tool_state = self._STATE_NORMAL
         self._tool_matcher = None
-
-    def _start_tool_call(self) -> None:
-        """Enter grammar-tracked mode after sampled <|tool_call>."""
-        self._tool_state = self._STATE_TOOL
-        self._tool_matcher = self._tool_grammar.start_matcher()
-
-    def _catch_up_tool_context(self, token_context: list[int]) -> None:
-        """Consume context tokens not yet seen by the tool grammar."""
-        for token_id in token_context[self._context_token_count :]:
-            self._advance_tool_state_from_token(token_id)
-        self._context_token_count = len(token_context)
-
-    def _advance_tool_state_from_token(self, token_id: int) -> None:
-        """Start or advance tool grammar state from a materialized token."""
-        if self._tool_state == self._STATE_TOOL:
-            self._consume_tool_grammar_token(token_id)
-        elif token_id == self._tool_call_start_token_id:
-            self._start_tool_call()
 
     def _consume_tool_grammar_token(self, token_id: int) -> None:
         """Feed one generated tool token into llguidance and mark completion."""
@@ -213,16 +211,50 @@ class Gemma4ReasoningGuardLogitsProcessor:
         # Remember this token so the next step can detect the two-token opener.
         self._previous_token_mx = token_id
 
-        # Apply reasoning/tool-call constraints to the logits for the next token.
-        return self._apply_next_token_masks_mx(logits, token_id)
+        if self._tool_state == self._STATE_NORMAL:
+            # If the sampled token was <|tool_call>, force the next token to
+            # start the native `call:` prefix. Otherwise leave logits alone.
+            logits = _boost_token_ids_mx(
+                logits,
+                token_id == self._tool_call_start_token_id,
+                self._initial_tool_token_ids,
+            )
 
-    def _apply_next_token_masks_mx(
-        self,
-        logits: mx.array,
-        token_id: mx.array,
-    ) -> mx.array:
-        """Apply tool-structure and reasoning-boundary masks in MLX."""
-        logits = self._apply_tool_structure_mask_mx(logits, token_id)
+        elif self._tool_state == self._STATE_TOOL:
+            # We are inside `call:KNOWN_TOOL{...}<tool_call|>`. This is the one
+            # place we sync token_id to Python so llguidance can advance.
+            self._consume_tool_grammar_token(int(token_id.item()))
+            # The consumed sampled token will be appended to token_context after
+            # this step. Skip it there so llguidance does not see it twice.
+            self._context_token_count += 1
+            if self._tool_state == self._STATE_POST_TOOL:
+                # The call just closed. Only allow EOS, whitespace, or another
+                # adjacent <|tool_call> from here.
+                logits = _boost_token_ids_mx(
+                    logits,
+                    mx.array(True),
+                    self._post_tool_token_ids,
+                )
+            else:
+                # The call is still open. Let llguidance choose the valid next
+                # tokens for the Gemma4 native call grammar.
+                logits = self._tool_grammar.mask_logits(self._tool_matcher, logits)
+
+        elif self._tool_state == self._STATE_POST_TOOL:
+            # If another <|tool_call> was sampled, force its `call:` prefix.
+            logits = _boost_token_ids_mx(
+                logits,
+                token_id == self._tool_call_start_token_id,
+                self._initial_tool_token_ids,
+            )
+            # Otherwise stay in the post-tool lane: EOS, whitespace, or another
+            # adjacent <|tool_call>. This blocks prose after a completed call.
+            logits = _boost_token_ids_mx(
+                logits,
+                token_id != self._tool_call_start_token_id,
+                self._post_tool_token_ids,
+            )
+
         # Keep <|tool_call> blocked while visible reasoning is open. This forces
         # the model to sample the real <channel|> close before starting a tool call.
         logits[:, self._tool_call_start_token_id] = mx.where(
@@ -230,57 +262,6 @@ class Gemma4ReasoningGuardLogitsProcessor:
             -float("inf"),
             logits[:, self._tool_call_start_token_id],
         )
-        return logits
-
-    def _apply_tool_structure_mask_mx(
-        self,
-        logits: mx.array,
-        token_id: mx.array,
-    ) -> mx.array:
-        """Constrain generated tokens once Gemma4 tool-call mode starts."""
-        # Once <|tool_call> is emitted, llguidance enforces one native Gemma4 call:
-        #   call:KNOWN_TOOL{...}<tool_call|>
-        # The post-tool state allows only EOS/whitespace/another adjacent call.
-        if self._tool_state == self._STATE_NORMAL:
-            return _boost_token_ids_mx(
-                logits,
-                token_id == self._tool_call_start_token_id,
-                self._initial_tool_token_ids,
-            )
-
-        if self._tool_state == self._STATE_TOOL:
-            self._consume_tool_grammar_token(int(token_id.item()))
-            # The consumed sampled token will be appended to token_context after
-            # this step. Skip it there so llguidance does not see it twice.
-            self._context_token_count += 1
-            if self._tool_state == self._STATE_POST_TOOL:
-                return _boost_token_ids_mx(
-                    logits,
-                    mx.array(True),
-                    self._post_tool_token_ids,
-                )
-            return self._tool_grammar.mask_logits(self._tool_matcher, logits)
-
-        if self._tool_state == self._STATE_POST_TOOL:
-            logits = _boost_token_ids_mx(
-                logits,
-                token_id == self._tool_call_start_token_id,
-                self._initial_tool_token_ids,
-            )
-            return _boost_token_ids_mx(
-                logits,
-                token_id != self._tool_call_start_token_id,
-                self._post_tool_token_ids,
-            )
-
-        return logits
-
-    def _apply_prefill_reasoning_mask(self, logits: Any) -> Any:
-        """Apply the initial prompt-derived reasoning guard after prefill."""
-        if self._reasoning_open:
-            # Keep <|tool_call> blocked while visible reasoning is open. This forces
-            # the model to sample the real <channel|> close before starting a tool call.
-            logits[:, self._tool_call_start_token_id] = -float("inf")
         return logits
 
 

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -1,3 +1,4 @@
+import json
 import re
 from collections.abc import Iterable
 from typing import Any
@@ -26,6 +27,7 @@ _GEMMA4_WHITESPACE = (" ", "\n", "\t", "\r")
 # Keep normal generation cheap: for small structural states, boost allowed
 # tokens instead of applying a full-vocabulary mask every decode step.
 _FORCED_TOOL_LOGIT = 1e9
+_LLG_TOKENIZER_CACHE: dict[int, Any] = {}
 
 
 def create_gemma4_tool_context_from_prompt(
@@ -49,11 +51,62 @@ def create_gemma4_tool_context_from_prompt(
     )
 
 
+class _Gemma4LLGuidanceToolGrammar:
+    """llguidance-backed grammar for one Gemma4 native tool call."""
+
+    def __init__(
+        self,
+        *,
+        tokenizer: Any,
+        tool_names: tuple[str, ...],
+        call_prefix_token_ids: tuple[int, ...],
+        vocab_size: int,
+    ):
+        self.initial_token_ids = (call_prefix_token_ids[0],)
+        self._tokenizer = tokenizer
+        self._grammar = _gemma4_llguidance_grammar(tool_names)
+        self._vocab_size = vocab_size
+        self._llguidance = None
+        self._llguidance_mlx = None
+        self._llguidance_numpy = None
+        self._llg_tokenizer = None
+        self._bitmask = None
+
+    def _ensure_ready(self) -> None:
+        if self._llguidance is not None:
+            return
+        import llguidance
+        import llguidance.mlx
+        import llguidance.numpy
+
+        self._llguidance = llguidance
+        self._llguidance_mlx = llguidance.mlx
+        self._llguidance_numpy = llguidance.numpy
+        self._llg_tokenizer = _get_llguidance_tokenizer(self._tokenizer)
+        self._bitmask = llguidance.numpy.allocate_token_bitmask(1, self._vocab_size)
+
+    def start_matcher(self) -> Any:
+        self._ensure_ready()
+        return self._llguidance.LLMatcher(self._llg_tokenizer, self._grammar)
+
+    def consume_token(self, matcher: Any, token_id: int) -> bool:
+        matcher.consume_token(token_id)
+        error = matcher.get_error()
+        if error:
+            raise ValueError(f"Gemma4 tool grammar rejected token {token_id}: {error}")
+        return bool(matcher.is_stopped())
+
+    def mask_logits(self, matcher: Any, logits: mx.array) -> mx.array:
+        self._llguidance_numpy.fill_next_token_bitmask(matcher, self._bitmask, 0)
+        return self._llguidance_mlx.apply_token_bitmask(logits, self._bitmask)
+
+
 class Gemma4ReasoningGuardLogitsProcessor:
     """Guard reasoning boundaries and Gemma4 tool-call structure."""
 
     _STATE_NORMAL = 0
-    _STATE_HEADER_ROOT = 1
+    _STATE_TOOL = 1
+    _STATE_POST_TOOL = 2
 
     def __init__(
         self,
@@ -62,12 +115,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
         reasoning_start_token_ids: tuple[int, ...],
         reasoning_end_token_ids: tuple[int, ...],
         tool_call_start_token_id: int,
-        tool_call_end_token_id: int,
-        call_prefix_token_ids: tuple[int, ...],
-        tool_name_token_ids: tuple[tuple[int, ...], ...],
-        open_brace_token_id: int,
-        close_brace_token_id: int,
-        string_delimiter_token_id: int,
+        tool_grammar: Any,
         eos_token_ids: tuple[int, ...],
         whitespace_token_ids: tuple[int, ...],
         vocab_size: int,
@@ -80,37 +128,14 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._reasoning_end_token_ids = reasoning_end_token_ids
         self._reasoning_end_token_id = reasoning_end_token_ids[0]
         self._tool_call_start_token_id = tool_call_start_token_id
-        self._tool_call_end_token_id = tool_call_end_token_id
-        self._open_brace_token_id = open_brace_token_id
-        self._close_brace_token_id = close_brace_token_id
-        self._string_delimiter_token_id = string_delimiter_token_id
-        self._tail_tokens: list[int] = []
-        self._previous_token_mx: mx.array | None = None
-
-        (
-            header_edges,
-            self._header_allowed_token_ids_by_state,
-            self._args_state,
-            self._need_tool_end_state,
-            self._post_tool_state,
-        ) = _build_gemma4_header_states(
-            call_prefix_token_ids=call_prefix_token_ids,
-            tool_name_token_ids=tool_name_token_ids,
-            open_brace_token_id=open_brace_token_id,
-        )
-        self._header_transitions = _header_transitions(header_edges)
-        self._blocked_args_token_ids = _in_vocab(
-            (tool_call_start_token_id, tool_call_end_token_id, *eos_token_ids),
-            vocab_size,
-        )
-        self._blocked_string_token_ids = _in_vocab(
-            (tool_call_start_token_id, tool_call_end_token_id, *eos_token_ids),
-            vocab_size,
-        )
+        self._tool_grammar = tool_grammar
+        self._initial_tool_token_ids = tuple(tool_grammar.initial_token_ids)
         self._post_tool_token_ids = _in_vocab(
             (*eos_token_ids, *whitespace_token_ids, tool_call_start_token_id),
             vocab_size,
         )
+        self._tail_tokens: list[int] = []
+        self._previous_token_mx: mx.array | None = None
         self._context_token_count = 0
         self._reset_tool_state()
 
@@ -154,58 +179,39 @@ class Gemma4ReasoningGuardLogitsProcessor:
 
     def _reset_tool_state(self) -> None:
         self._tool_state = self._STATE_NORMAL
-        self._brace_depth = 0
-        self._in_string = False
+        self._tool_matcher = None
+
+    def _start_tool_call(self) -> None:
+        self._tool_state = self._STATE_TOOL
+        self._tool_matcher = self._tool_grammar.start_matcher()
 
     def _process_tool_context_tokens(self, token_context: list[int]) -> None:
+        if len(token_context) < self._context_token_count:
+            self._context_token_count = len(token_context)
         for token_id in token_context[self._context_token_count :]:
             self._process_tool_context_token(int(token_id))
         self._context_token_count = len(token_context)
 
     def _process_tool_context_token(self, token_id: int) -> None:
-        if self._tool_state == self._STATE_NORMAL:
+        if self._tool_state in (self._STATE_NORMAL, self._STATE_POST_TOOL):
             if token_id == self._tool_call_start_token_id:
-                self._tool_state = self._STATE_HEADER_ROOT
+                self._start_tool_call()
             return
 
-        if self._tool_state in self._header_transitions:
-            next_state = self._header_transitions[self._tool_state].get(token_id)
-            if next_state is not None:
-                self._tool_state = next_state
-                if next_state == self._args_state:
-                    self._brace_depth = 1
-                    self._in_string = False
-            return
+        if self._tool_state == self._STATE_TOOL:
+            self._consume_tool_token(token_id)
 
-        if self._tool_state == self._args_state:
-            if token_id == self._string_delimiter_token_id:
-                self._in_string = not self._in_string
-                return
-            if self._in_string:
-                return
-            if token_id == self._open_brace_token_id:
-                self._brace_depth += 1
-                return
-            if token_id == self._close_brace_token_id:
-                self._brace_depth -= 1
-                if self._brace_depth <= 0:
-                    self._tool_state = self._need_tool_end_state
-                return
-
-        if self._tool_state == self._need_tool_end_state:
-            if token_id == self._tool_call_end_token_id:
-                self._tool_state = self._post_tool_state
-            return
-
-        if self._tool_state == self._post_tool_state:
-            if token_id == self._tool_call_start_token_id:
-                self._tool_state = self._STATE_HEADER_ROOT
-                self._brace_depth = 0
-                self._in_string = False
+    def _consume_tool_token(self, token_id: int) -> None:
+        complete = self._tool_grammar.consume_token(self._tool_matcher, token_id)
+        if complete:
+            self._tool_state = self._STATE_POST_TOOL
+            self._tool_matcher = None
 
     def _process_last_token_mx(self, token_id: mx.array, logits: mx.array) -> mx.array:
-        # Keep decode token handling in MLX: last_token.tolist() calls eval()/wait
-        # and can create a per-token graph break.
+        # Keep normal decode token handling in MLX: last_token.tolist() calls
+        # eval()/wait and can create a per-token graph break. We only sync the
+        # sampled token while an llguidance tool grammar is active, where slower
+        # decoding is acceptable.
         if self._previous_token_mx is None:
             reasoning_start = mx.array(False)
         else:
@@ -244,50 +250,36 @@ class Gemma4ReasoningGuardLogitsProcessor:
         logits: mx.array,
         token_id: mx.array,
     ) -> mx.array:
-        # KISS structural scope: after <|tool_call>, enforce only
-        #   call:KNOWN_TOOL{ balanced top-level args }<tool_call|>
-        # Argument contents remain intentionally loose; strings use Gemma's
-        # <|"|> delimiter so braces inside strings do not affect balance.
+        # KISS structural scope: once <|tool_call> is emitted, llguidance
+        # enforces one native Gemma4 call:
+        #   call:KNOWN_TOOL{...}<tool_call|>
+        # We still keep the cheap Python wrapper for lazy activation and the
+        # post-tool state that allows only EOS/whitespace/another adjacent call.
         if self._tool_state == self._STATE_NORMAL:
             return _force_token_ids_mx(
                 logits,
                 token_id == self._tool_call_start_token_id,
-                self._header_allowed_token_ids_by_state[self._STATE_HEADER_ROOT],
+                self._initial_tool_token_ids,
             )
 
-        if self._tool_state in self._header_transitions:
-            for edge_token_id, next_state in self._header_transitions[
-                self._tool_state
-            ].items():
-                if next_state == self._args_state:
-                    logits = self._mask_args_after_current_token(
-                        logits,
-                        token_id,
-                        token_id == edge_token_id,
-                    )
-                else:
-                    logits = _force_token_ids_mx(
-                        logits,
-                        token_id == edge_token_id,
-                        self._header_allowed_token_ids_by_state[next_state],
-                    )
-            return logits
+        if self._tool_state == self._STATE_TOOL:
+            self._consume_tool_token(_mx_scalar_to_int(token_id))
+            # The consumed sampled token will be appended to token_context after
+            # this step. Skip it there so llguidance does not see it twice.
+            self._context_token_count += 1
+            if self._tool_state == self._STATE_POST_TOOL:
+                return _force_token_ids_mx(
+                    logits,
+                    mx.array(True),
+                    self._post_tool_token_ids,
+                )
+            return self._tool_grammar.mask_logits(self._tool_matcher, logits)
 
-        if self._tool_state == self._args_state:
-            return self._mask_args_after_current_token(logits, token_id, mx.array(True))
-
-        if self._tool_state == self._need_tool_end_state:
-            return _force_token_ids_mx(
-                logits,
-                token_id == self._tool_call_end_token_id,
-                self._post_tool_token_ids,
-            )
-
-        if self._tool_state == self._post_tool_state:
+        if self._tool_state == self._STATE_POST_TOOL:
             logits = _force_token_ids_mx(
                 logits,
                 token_id == self._tool_call_start_token_id,
-                self._header_allowed_token_ids_by_state[self._STATE_HEADER_ROOT],
+                self._initial_tool_token_ids,
             )
             return _force_token_ids_mx(
                 logits,
@@ -296,26 +288,6 @@ class Gemma4ReasoningGuardLogitsProcessor:
             )
 
         return logits
-
-    def _mask_args_after_current_token(
-        self,
-        logits: mx.array,
-        token_id: mx.array,
-        condition: mx.array,
-    ) -> mx.array:
-        blocked_token_ids = (
-            self._blocked_string_token_ids
-            if self._in_string
-            else self._blocked_args_token_ids
-        )
-        logits = _mask_token_ids_mx(logits, condition, blocked_token_ids)
-        if self._in_string or self._brace_depth != 1:
-            return logits
-        return _force_token_ids_mx(
-            logits,
-            condition & (token_id == self._close_brace_token_id),
-            (self._tool_call_end_token_id,),
-        )
 
     def _mask_if_needed(self, logits: Any) -> Any:
         if self._reasoning_open:
@@ -352,33 +324,26 @@ def create_gemma4_reasoning_guard_logits_processor(
         return None
 
     call_prefix_token_ids = _encode_token_ids(tokenizer, _GEMMA4_CALL_PREFIX)
-    tool_name_token_ids = tuple(
-        _encode_token_ids(tokenizer, tool_name) for tool_name in context.tool_names
-    )
-    open_brace_token_id = _single_token_id(tokenizer, "{")
-    close_brace_token_id = _single_token_id(tokenizer, "}")
-    string_delimiter_token_id = _single_token_id(tokenizer, GEMMA4_STRING_DELIMITER)
     if (
         len(call_prefix_token_ids) == 0
-        or any(len(token_ids) == 0 for token_ids in tool_name_token_ids)
-        or open_brace_token_id is None
-        or close_brace_token_id is None
-        or string_delimiter_token_id is None
+        or _single_token_id(tokenizer, GEMMA4_STRING_DELIMITER) is None
     ):
         return None
 
     vocab_size = int(tokenizer.vocab_size)
+    tool_grammar = _Gemma4LLGuidanceToolGrammar(
+        tokenizer=tokenizer,
+        tool_names=context.tool_names,
+        call_prefix_token_ids=call_prefix_token_ids,
+        vocab_size=vocab_size,
+    )
+
     return Gemma4ReasoningGuardLogitsProcessor(
         reasoning_open=context.reasoning_open,
         reasoning_start_token_ids=reasoning_start_token_ids,
         reasoning_end_token_ids=reasoning_end_token_ids,
         tool_call_start_token_id=tool_call_start_token_ids[0],
-        tool_call_end_token_id=tool_call_end_token_ids[0],
-        call_prefix_token_ids=call_prefix_token_ids,
-        tool_name_token_ids=tool_name_token_ids,
-        open_brace_token_id=open_brace_token_id,
-        close_brace_token_id=close_brace_token_id,
-        string_delimiter_token_id=string_delimiter_token_id,
+        tool_grammar=tool_grammar,
         eos_token_ids=tuple(int(token_id) for token_id in tokenizer.eos_token_ids),
         whitespace_token_ids=tuple(
             token_id
@@ -389,60 +354,41 @@ def create_gemma4_reasoning_guard_logits_processor(
     )
 
 
-def _build_gemma4_header_states(
-    *,
-    call_prefix_token_ids: tuple[int, ...],
-    tool_name_token_ids: tuple[tuple[int, ...], ...],
-    open_brace_token_id: int,
-) -> tuple[
-    tuple[tuple[int, int, int], ...],
-    dict[int, tuple[int, ...]],
-    int,
-    int,
-    int,
-]:
-    transitions: dict[int, dict[int, int | None]] = {}
-    next_state = Gemma4ReasoningGuardLogitsProcessor._STATE_HEADER_ROOT + 1
-
-    for name_token_ids in tool_name_token_ids:
-        state = Gemma4ReasoningGuardLogitsProcessor._STATE_HEADER_ROOT
-        for token_id in call_prefix_token_ids + name_token_ids:
-            state_transitions = transitions.setdefault(state, {})
-            if token_id not in state_transitions:
-                state_transitions[token_id] = next_state
-                next_state += 1
-            state = int(state_transitions[token_id])
-        transitions.setdefault(state, {})[open_brace_token_id] = None
-
-    args_state = next_state
-    need_tool_end_state = args_state + 1
-    post_tool_state = args_state + 2
-
-    header_edges = []
-    header_allowed_token_ids_by_state = {}
-    for from_state, state_transitions in transitions.items():
-        header_allowed_token_ids_by_state[from_state] = tuple(state_transitions.keys())
-        for token_id, to_state in state_transitions.items():
-            header_edges.append(
-                (from_state, token_id, args_state if to_state is None else to_state)
-            )
-
-    return (
-        tuple(header_edges),
-        header_allowed_token_ids_by_state,
-        args_state,
-        need_tool_end_state,
-        post_tool_state,
-    )
+def _gemma4_llguidance_grammar(tool_names: tuple[str, ...]) -> str:
+    tool_choice = " | ".join(json.dumps(tool_name) for tool_name in tool_names)
+    return "\n".join(
+        [
+            "%llguidance {}",
+            'start: "call:" tool object <tool_call|>',
+            f"tool: {tool_choice}",
+            'object: "{" WS (member (WS "," WS member)*)? WS "}"',
+            'member: key WS ":" WS value',
+            "key: IDENT | gemma_string",
+            r"IDENT: /[A-Za-z_]/ /[A-Za-z0-9_.$\/-]*/",
+            'value: gemma_string | object | array | NUMBER | "true" | "false" | "null" | "None" | "none"',
+            'array: "[" WS (value (WS "," WS value)*)? WS "]"',
+            'gemma_string: <|"|> STRING_CHAR* <|"|>',
+            'STRING_CHAR: /[^<]/ | "<" /[^|]/',
+            r'NUMBER: "-"? (/[0-9]/ | /[1-9]/ /[0-9]*/) ("." /[0-9]/+)? (/[eE]/ /[+-]/? /[0-9]/+)?',
+            r"WS: /[ \t\n\r]*/",
+        ]
+    ) + "\n"
 
 
-def _header_transitions(
-    header_edges: tuple[tuple[int, int, int], ...],
-) -> dict[int, dict[int, int]]:
-    transitions: dict[int, dict[int, int]] = {}
-    for from_state, token_id, to_state in header_edges:
-        transitions.setdefault(from_state, {})[token_id] = to_state
-    return transitions
+def _get_llguidance_tokenizer(tokenizer: Any) -> Any:
+    import llguidance.hf
+
+    hf_tokenizer = getattr(tokenizer, "_tokenizer", tokenizer)
+    cache_key = id(hf_tokenizer)
+    llg_tokenizer = _LLG_TOKENIZER_CACHE.get(cache_key)
+    if llg_tokenizer is None:
+        llg_tokenizer = llguidance.hf.from_tokenizer(
+            hf_tokenizer,
+            n_vocab=int(tokenizer.vocab_size),
+            eos_token=list(tokenizer.eos_token_ids),
+        )
+        _LLG_TOKENIZER_CACHE[cache_key] = llg_tokenizer
+    return llg_tokenizer
 
 
 def _force_token_ids_mx(
@@ -455,21 +401,6 @@ def _force_token_ids_mx(
     logits[:, list(token_ids)] = mx.where(
         condition,
         _FORCED_TOOL_LOGIT,
-        logits[:, list(token_ids)],
-    )
-    return logits
-
-
-def _mask_token_ids_mx(
-    logits: mx.array,
-    condition: mx.array,
-    token_ids: tuple[int, ...] | list[int],
-) -> mx.array:
-    if len(token_ids) == 0:
-        return logits
-    logits[:, list(token_ids)] = mx.where(
-        condition,
-        -float("inf"),
         logits[:, list(token_ids)],
     )
     return logits
@@ -491,6 +422,10 @@ def _single_token_id(tokenizer: Any, text: str) -> int | None:
 
 def _in_vocab(token_ids: Iterable[int], vocab_size: int) -> list[int]:
     return [int(token_id) for token_id in token_ids if 0 <= int(token_id) < vocab_size]
+
+
+def _mx_scalar_to_int(token_id: mx.array) -> int:
+    return int(token_id.item())
 
 
 def _token_ids_to_list(tokens: Any) -> list[int]:

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -6,7 +6,6 @@ from typing import Any
 import mlx.core as mx
 
 from mlx_engine.tool_protocols import (
-    GEMMA4_STRING_DELIMITER,
     GEMMA4_TOOL_DECLARATION_END,
     GEMMA4_TOOL_DECLARATION_START,
     Gemma4ToolContext,
@@ -66,39 +65,35 @@ class _Gemma4LLGuidanceToolGrammar:
         self._tokenizer = tokenizer
         self._grammar = _gemma4_llguidance_grammar(tool_names)
         self._vocab_size = vocab_size
-        self._llguidance = None
-        self._llguidance_mlx = None
-        self._llguidance_numpy = None
         self._llg_tokenizer = None
         self._bitmask = None
 
     def _ensure_ready(self) -> None:
-        if self._llguidance is not None:
+        if self._llg_tokenizer is not None:
             return
-        import llguidance
-        import llguidance.mlx
         import llguidance.numpy
 
-        self._llguidance = llguidance
-        self._llguidance_mlx = llguidance.mlx
-        self._llguidance_numpy = llguidance.numpy
         self._llg_tokenizer = _get_llguidance_tokenizer(self._tokenizer)
         self._bitmask = llguidance.numpy.allocate_token_bitmask(1, self._vocab_size)
 
     def start_matcher(self) -> Any:
+        import llguidance
+
         self._ensure_ready()
-        return self._llguidance.LLMatcher(self._llg_tokenizer, self._grammar)
+        return llguidance.LLMatcher(self._llg_tokenizer, self._grammar)
 
     def consume_token(self, matcher: Any, token_id: int) -> bool:
         matcher.consume_token(token_id)
-        error = matcher.get_error()
-        if error:
-            raise ValueError(f"Gemma4 tool grammar rejected token {token_id}: {error}")
-        return bool(matcher.is_stopped())
+        if error := matcher.get_error():
+            raise ValueError(error)
+        return matcher.is_stopped()
 
     def mask_logits(self, matcher: Any, logits: mx.array) -> mx.array:
-        self._llguidance_numpy.fill_next_token_bitmask(matcher, self._bitmask, 0)
-        return self._llguidance_mlx.apply_token_bitmask(logits, self._bitmask)
+        import llguidance.mlx
+        import llguidance.numpy
+
+        llguidance.numpy.fill_next_token_bitmask(matcher, self._bitmask, 0)
+        return llguidance.mlx.apply_token_bitmask(logits, self._bitmask)
 
 
 class Gemma4ReasoningGuardLogitsProcessor:
@@ -118,38 +113,30 @@ class Gemma4ReasoningGuardLogitsProcessor:
         tool_grammar: Any,
         eos_token_ids: tuple[int, ...],
         whitespace_token_ids: tuple[int, ...],
-        vocab_size: int,
     ):
         self._reasoning_open = reasoning_open
         self._reasoning_open_mx = mx.array(reasoning_open)
-        self._reasoning_start_token_ids = reasoning_start_token_ids
         self._reasoning_start_first_token_id = reasoning_start_token_ids[0]
         self._reasoning_start_second_token_id = reasoning_start_token_ids[1]
-        self._reasoning_end_token_ids = reasoning_end_token_ids
         self._reasoning_end_token_id = reasoning_end_token_ids[0]
         self._tool_call_start_token_id = tool_call_start_token_id
         self._tool_grammar = tool_grammar
         self._initial_tool_token_ids = tuple(tool_grammar.initial_token_ids)
-        self._post_tool_token_ids = _in_vocab(
-            (*eos_token_ids, *whitespace_token_ids, tool_call_start_token_id),
-            vocab_size,
+        self._post_tool_token_ids = (
+            *eos_token_ids,
+            *whitespace_token_ids,
+            tool_call_start_token_id,
         )
-        self._tail_tokens: list[int] = []
-        self._previous_token_mx: mx.array | None = None
+        self._previous_token_mx = mx.array(0)
         self._context_token_count = 0
         self._reset_tool_state()
 
     def __call__(self, tokens: Any, logits: Any) -> Any:
         # VLM calls this once on prompt prefill. Prompt reasoning state already
-        # came from decoded prompt text, so keep only enough tail for markers
-        # that may finish immediately after prefill. Historical prompt tool
-        # calls are ignored; the structural grammar starts on generated
-        # <|tool_call> only.
+        # came from decoded prompt text. Historical prompt tool calls are
+        # ignored; the structural grammar starts on generated <|tool_call> only.
         token_ids = _token_ids_to_list(tokens)
-        self._tail_tokens = _tail(token_ids, 1)
-        self._previous_token_mx = (
-            mx.array(self._tail_tokens[-1]) if len(self._tail_tokens) > 0 else None
-        )
+        self._previous_token_mx = mx.array(token_ids[-1])
         self._reasoning_open_mx = mx.array(self._reasoning_open)
         self._context_token_count = len(token_ids)
         self._reset_tool_state()
@@ -164,19 +151,6 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._process_tool_context_tokens(token_context)
         return self._process_last_token_mx(last_token.reshape(-1)[0], logits)
 
-    def process_last_token(self, last_token: Any, logits: Any) -> Any:
-        if isinstance(last_token, mx.array):
-            return self._process_last_token_mx(last_token.reshape(-1)[0], logits)
-
-        for token_id in _token_ids_to_list(last_token):
-            token_window = self._tail_tokens + [token_id]
-            if _ends_with(token_window, self._reasoning_start_token_ids):
-                self._reasoning_open = True
-            if _ends_with(token_window, self._reasoning_end_token_ids):
-                self._reasoning_open = False
-            self._tail_tokens = _tail(token_window, 1)
-        return self._mask_if_needed(logits)
-
     def _reset_tool_state(self) -> None:
         self._tool_state = self._STATE_NORMAL
         self._tool_matcher = None
@@ -186,8 +160,6 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._tool_matcher = self._tool_grammar.start_matcher()
 
     def _process_tool_context_tokens(self, token_context: list[int]) -> None:
-        if len(token_context) < self._context_token_count:
-            self._context_token_count = len(token_context)
         for token_id in token_context[self._context_token_count :]:
             self._process_tool_context_token(int(token_id))
         self._context_token_count = len(token_context)
@@ -212,12 +184,9 @@ class Gemma4ReasoningGuardLogitsProcessor:
         # eval()/wait and can create a per-token graph break. We only sync the
         # sampled token while an llguidance tool grammar is active, where slower
         # decoding is acceptable.
-        if self._previous_token_mx is None:
-            reasoning_start = mx.array(False)
-        else:
-            reasoning_start = (
-                self._previous_token_mx == self._reasoning_start_first_token_id
-            ) & (token_id == self._reasoning_start_second_token_id)
+        reasoning_start = (
+            self._previous_token_mx == self._reasoning_start_first_token_id
+        ) & (token_id == self._reasoning_start_second_token_id)
         reasoning_end = token_id == self._reasoning_end_token_id
         self._reasoning_open_mx = mx.where(
             reasoning_start,
@@ -307,29 +276,10 @@ def create_gemma4_reasoning_guard_logits_processor(
     if len(context.tool_names) == 0:
         return None
 
-    tool_call_start_token_ids = tokenizer.tool_call_start_tokens
-    tool_call_end_token_ids = tokenizer.tool_call_end_tokens
+    tool_call_start_token_id = tokenizer.tool_call_start_tokens[0]
     reasoning_start_token_ids = tokenizer.think_start_tokens
     reasoning_end_token_ids = tokenizer.think_end_tokens
-    if (
-        tool_call_start_token_ids is None
-        or len(tool_call_start_token_ids) != 1
-        or tool_call_end_token_ids is None
-        or len(tool_call_end_token_ids) != 1
-        or reasoning_start_token_ids is None
-        or len(reasoning_start_token_ids) != 2
-        or reasoning_end_token_ids is None
-        or len(reasoning_end_token_ids) != 1
-    ):
-        return None
-
     call_prefix_token_ids = _encode_token_ids(tokenizer, _GEMMA4_CALL_PREFIX)
-    if (
-        len(call_prefix_token_ids) == 0
-        or _single_token_id(tokenizer, GEMMA4_STRING_DELIMITER) is None
-    ):
-        return None
-
     vocab_size = int(tokenizer.vocab_size)
     tool_grammar = _Gemma4LLGuidanceToolGrammar(
         tokenizer=tokenizer,
@@ -342,43 +292,38 @@ def create_gemma4_reasoning_guard_logits_processor(
         reasoning_open=context.reasoning_open,
         reasoning_start_token_ids=reasoning_start_token_ids,
         reasoning_end_token_ids=reasoning_end_token_ids,
-        tool_call_start_token_id=tool_call_start_token_ids[0],
+        tool_call_start_token_id=tool_call_start_token_id,
         tool_grammar=tool_grammar,
         eos_token_ids=tuple(int(token_id) for token_id in tokenizer.eos_token_ids),
         whitespace_token_ids=tuple(
-            token_id
+            _encode_token_ids(tokenizer, whitespace)[0]
             for whitespace in _GEMMA4_WHITESPACE
-            if (token_id := _single_token_id(tokenizer, whitespace)) is not None
         ),
-        vocab_size=vocab_size,
     )
 
 
 def _gemma4_llguidance_grammar(tool_names: tuple[str, ...]) -> str:
     tool_choice = " | ".join(json.dumps(tool_name) for tool_name in tool_names)
-    return "\n".join(
-        [
-            "%llguidance {}",
-            'start: "call:" tool object <tool_call|>',
-            f"tool: {tool_choice}",
-            'object: "{" WS (member (WS "," WS member)*)? WS "}"',
-            'member: key WS ":" WS value',
-            "key: IDENT | gemma_string",
-            r"IDENT: /[A-Za-z_]/ /[A-Za-z0-9_.$\/-]*/",
-            'value: gemma_string | object | array | NUMBER | "true" | "false" | "null" | "None" | "none"',
-            'array: "[" WS (value (WS "," WS value)*)? WS "]"',
-            'gemma_string: <|"|> STRING_CHAR* <|"|>',
-            'STRING_CHAR: /[^<]/ | "<" /[^|]/',
-            r'NUMBER: "-"? (/[0-9]/ | /[1-9]/ /[0-9]*/) ("." /[0-9]/+)? (/[eE]/ /[+-]/? /[0-9]/+)?',
-            r"WS: /[ \t\n\r]*/",
-        ]
-    ) + "\n"
+    return rf'''%llguidance {{}}
+start: "call:" tool object <tool_call|>
+tool: {tool_choice}
+object: "{{" WS (member (WS "," WS member)*)? WS "}}"
+member: key WS ":" WS value
+key: IDENT | gemma_string
+IDENT: /[A-Za-z_]/ /[A-Za-z0-9_.$\/-]*/
+value: gemma_string | object | array | NUMBER | "true" | "false" | "null" | "None" | "none"
+array: "[" WS (value (WS "," WS value)*)? WS "]"
+gemma_string: <|"|> STRING_CHAR* <|"|>
+STRING_CHAR: /[^<]/ | "<" /[^|]/
+NUMBER: "-"? (/[0-9]/ | /[1-9]/ /[0-9]*/) ("." /[0-9]/+)? (/[eE]/ /[+-]/? /[0-9]/+)?
+WS: /[ \t\n\r]*/
+'''
 
 
 def _get_llguidance_tokenizer(tokenizer: Any) -> Any:
     import llguidance.hf
 
-    hf_tokenizer = getattr(tokenizer, "_tokenizer", tokenizer)
+    hf_tokenizer = tokenizer._tokenizer
     cache_key = id(hf_tokenizer)
     llg_tokenizer = _LLG_TOKENIZER_CACHE.get(cache_key)
     if llg_tokenizer is None:
@@ -413,34 +358,11 @@ def _encode_token_ids(tokenizer: Any, text: str) -> tuple[int, ...]:
     )
 
 
-def _single_token_id(tokenizer: Any, text: str) -> int | None:
-    token_ids = _encode_token_ids(tokenizer, text)
-    if len(token_ids) != 1:
-        return None
-    return token_ids[0]
-
-
-def _in_vocab(token_ids: Iterable[int], vocab_size: int) -> list[int]:
-    return [int(token_id) for token_id in token_ids if 0 <= int(token_id) < vocab_size]
-
-
 def _mx_scalar_to_int(token_id: mx.array) -> int:
     return int(token_id.item())
 
 
 def _token_ids_to_list(tokens: Any) -> list[int]:
     if hasattr(tokens, "tolist"):
-        tokens = tokens.tolist()
-    if isinstance(tokens, int):
-        return [tokens]
+        return [int(token_id) for token_id in tokens.tolist()]
     return [int(token_id) for token_id in tokens]
-
-
-def _tail(token_ids: list[int], count: int) -> list[int]:
-    if count == 0:
-        return []
-    return token_ids[-count:]
-
-
-def _ends_with(token_ids: list[int], suffix: tuple[int, ...]) -> bool:
-    return token_ids[-len(suffix) :] == list(suffix)

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -5,6 +5,7 @@ from typing import Any
 import mlx.core as mx
 
 from mlx_engine.tool_protocols import (
+    GEMMA4_STRING_DELIMITER,
     GEMMA4_TOOL_DECLARATION_END,
     GEMMA4_TOOL_DECLARATION_START,
     Gemma4ToolContext,
@@ -20,6 +21,11 @@ _GEMMA4_TOOL_NAME_RE = re.compile(
     rf"{re.escape(GEMMA4_TOOL_DECLARATION_END)}",
     re.DOTALL,
 )
+_GEMMA4_CALL_PREFIX = "call:"
+_GEMMA4_WHITESPACE = (" ", "\n", "\t", "\r")
+# Keep normal generation cheap: for small structural states, boost allowed
+# tokens instead of applying a full-vocabulary mask every decode step.
+_FORCED_TOOL_LOGIT = 1e9
 
 
 def create_gemma4_tool_context_from_prompt(
@@ -44,7 +50,10 @@ def create_gemma4_tool_context_from_prompt(
 
 
 class Gemma4ReasoningGuardLogitsProcessor:
-    """Block Gemma4 tool-call starts while visible reasoning is still open."""
+    """Guard reasoning boundaries and Gemma4 tool-call structure."""
+
+    _STATE_NORMAL = 0
+    _STATE_HEADER_ROOT = 1
 
     def __init__(
         self,
@@ -53,6 +62,15 @@ class Gemma4ReasoningGuardLogitsProcessor:
         reasoning_start_token_ids: tuple[int, ...],
         reasoning_end_token_ids: tuple[int, ...],
         tool_call_start_token_id: int,
+        tool_call_end_token_id: int,
+        call_prefix_token_ids: tuple[int, ...],
+        tool_name_token_ids: tuple[tuple[int, ...], ...],
+        open_brace_token_id: int,
+        close_brace_token_id: int,
+        string_delimiter_token_id: int,
+        eos_token_ids: tuple[int, ...],
+        whitespace_token_ids: tuple[int, ...],
+        vocab_size: int,
     ):
         self._reasoning_open = reasoning_open
         self._reasoning_open_mx = mx.array(reasoning_open)
@@ -62,19 +80,64 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._reasoning_end_token_ids = reasoning_end_token_ids
         self._reasoning_end_token_id = reasoning_end_token_ids[0]
         self._tool_call_start_token_id = tool_call_start_token_id
+        self._tool_call_end_token_id = tool_call_end_token_id
+        self._open_brace_token_id = open_brace_token_id
+        self._close_brace_token_id = close_brace_token_id
+        self._string_delimiter_token_id = string_delimiter_token_id
         self._tail_tokens: list[int] = []
         self._previous_token_mx: mx.array | None = None
+
+        (
+            header_edges,
+            self._header_allowed_token_ids_by_state,
+            self._args_state,
+            self._need_tool_end_state,
+            self._post_tool_state,
+        ) = _build_gemma4_header_states(
+            call_prefix_token_ids=call_prefix_token_ids,
+            tool_name_token_ids=tool_name_token_ids,
+            open_brace_token_id=open_brace_token_id,
+        )
+        self._header_transitions = _header_transitions(header_edges)
+        self._blocked_args_token_ids = _in_vocab(
+            (tool_call_start_token_id, tool_call_end_token_id, *eos_token_ids),
+            vocab_size,
+        )
+        self._blocked_string_token_ids = _in_vocab(
+            (tool_call_start_token_id, tool_call_end_token_id, *eos_token_ids),
+            vocab_size,
+        )
+        self._post_tool_token_ids = _in_vocab(
+            (*eos_token_ids, *whitespace_token_ids, tool_call_start_token_id),
+            vocab_size,
+        )
+        self._context_token_count = 0
+        self._reset_tool_state()
 
     def __call__(self, tokens: Any, logits: Any) -> Any:
         # VLM calls this once on prompt prefill. Prompt reasoning state already
         # came from decoded prompt text, so keep only enough tail for markers
-        # that may finish immediately after prefill.
-        self._tail_tokens = _tail(_token_ids_to_list(tokens), 1)
+        # that may finish immediately after prefill. Historical prompt tool
+        # calls are ignored; the structural grammar starts on generated
+        # <|tool_call> only.
+        token_ids = _token_ids_to_list(tokens)
+        self._tail_tokens = _tail(token_ids, 1)
         self._previous_token_mx = (
             mx.array(self._tail_tokens[-1]) if len(self._tail_tokens) > 0 else None
         )
         self._reasoning_open_mx = mx.array(self._reasoning_open)
+        self._context_token_count = len(token_ids)
+        self._reset_tool_state()
         return self._mask_if_needed(logits)
+
+    def process_last_token_with_context(
+        self,
+        token_context: list[int],
+        last_token: mx.array,
+        logits: mx.array,
+    ) -> mx.array:
+        self._process_tool_context_tokens(token_context)
+        return self._process_last_token_mx(last_token.reshape(-1)[0], logits)
 
     def process_last_token(self, last_token: Any, logits: Any) -> Any:
         if isinstance(last_token, mx.array):
@@ -88,6 +151,57 @@ class Gemma4ReasoningGuardLogitsProcessor:
                 self._reasoning_open = False
             self._tail_tokens = _tail(token_window, 1)
         return self._mask_if_needed(logits)
+
+    def _reset_tool_state(self) -> None:
+        self._tool_state = self._STATE_NORMAL
+        self._brace_depth = 0
+        self._in_string = False
+
+    def _process_tool_context_tokens(self, token_context: list[int]) -> None:
+        for token_id in token_context[self._context_token_count :]:
+            self._process_tool_context_token(int(token_id))
+        self._context_token_count = len(token_context)
+
+    def _process_tool_context_token(self, token_id: int) -> None:
+        if self._tool_state == self._STATE_NORMAL:
+            if token_id == self._tool_call_start_token_id:
+                self._tool_state = self._STATE_HEADER_ROOT
+            return
+
+        if self._tool_state in self._header_transitions:
+            next_state = self._header_transitions[self._tool_state].get(token_id)
+            if next_state is not None:
+                self._tool_state = next_state
+                if next_state == self._args_state:
+                    self._brace_depth = 1
+                    self._in_string = False
+            return
+
+        if self._tool_state == self._args_state:
+            if token_id == self._string_delimiter_token_id:
+                self._in_string = not self._in_string
+                return
+            if self._in_string:
+                return
+            if token_id == self._open_brace_token_id:
+                self._brace_depth += 1
+                return
+            if token_id == self._close_brace_token_id:
+                self._brace_depth -= 1
+                if self._brace_depth <= 0:
+                    self._tool_state = self._need_tool_end_state
+                return
+
+        if self._tool_state == self._need_tool_end_state:
+            if token_id == self._tool_call_end_token_id:
+                self._tool_state = self._post_tool_state
+            return
+
+        if self._tool_state == self._post_tool_state:
+            if token_id == self._tool_call_start_token_id:
+                self._tool_state = self._STATE_HEADER_ROOT
+                self._brace_depth = 0
+                self._in_string = False
 
     def _process_last_token_mx(self, token_id: mx.array, logits: mx.array) -> mx.array:
         # Keep decode token handling in MLX: last_token.tolist() calls eval()/wait
@@ -110,9 +224,10 @@ class Gemma4ReasoningGuardLogitsProcessor:
             self._reasoning_open_mx,
         )
         self._previous_token_mx = token_id
-        return self._mask_if_needed_mx(logits)
+        return self._mask_if_needed_mx(logits, token_id)
 
-    def _mask_if_needed_mx(self, logits: mx.array) -> mx.array:
+    def _mask_if_needed_mx(self, logits: mx.array, token_id: mx.array) -> mx.array:
+        logits = self._mask_tool_structure_mx(logits, token_id)
         # vLLM treats <|tool_call> as an implicit Gemma4 reasoning end, but
         # Electron currently suppresses tool parsing for reasoning fragments.
         # This stricter mask forces the model to sample the real <channel|>
@@ -123,6 +238,84 @@ class Gemma4ReasoningGuardLogitsProcessor:
             logits[:, self._tool_call_start_token_id],
         )
         return logits
+
+    def _mask_tool_structure_mx(
+        self,
+        logits: mx.array,
+        token_id: mx.array,
+    ) -> mx.array:
+        # KISS structural scope: after <|tool_call>, enforce only
+        #   call:KNOWN_TOOL{ balanced top-level args }<tool_call|>
+        # Argument contents remain intentionally loose; strings use Gemma's
+        # <|"|> delimiter so braces inside strings do not affect balance.
+        if self._tool_state == self._STATE_NORMAL:
+            return _force_token_ids_mx(
+                logits,
+                token_id == self._tool_call_start_token_id,
+                self._header_allowed_token_ids_by_state[self._STATE_HEADER_ROOT],
+            )
+
+        if self._tool_state in self._header_transitions:
+            for edge_token_id, next_state in self._header_transitions[
+                self._tool_state
+            ].items():
+                if next_state == self._args_state:
+                    logits = self._mask_args_after_current_token(
+                        logits,
+                        token_id,
+                        token_id == edge_token_id,
+                    )
+                else:
+                    logits = _force_token_ids_mx(
+                        logits,
+                        token_id == edge_token_id,
+                        self._header_allowed_token_ids_by_state[next_state],
+                    )
+            return logits
+
+        if self._tool_state == self._args_state:
+            return self._mask_args_after_current_token(logits, token_id, mx.array(True))
+
+        if self._tool_state == self._need_tool_end_state:
+            return _force_token_ids_mx(
+                logits,
+                token_id == self._tool_call_end_token_id,
+                self._post_tool_token_ids,
+            )
+
+        if self._tool_state == self._post_tool_state:
+            logits = _force_token_ids_mx(
+                logits,
+                token_id == self._tool_call_start_token_id,
+                self._header_allowed_token_ids_by_state[self._STATE_HEADER_ROOT],
+            )
+            return _force_token_ids_mx(
+                logits,
+                token_id != self._tool_call_start_token_id,
+                self._post_tool_token_ids,
+            )
+
+        return logits
+
+    def _mask_args_after_current_token(
+        self,
+        logits: mx.array,
+        token_id: mx.array,
+        condition: mx.array,
+    ) -> mx.array:
+        blocked_token_ids = (
+            self._blocked_string_token_ids
+            if self._in_string
+            else self._blocked_args_token_ids
+        )
+        logits = _mask_token_ids_mx(logits, condition, blocked_token_ids)
+        if self._in_string or self._brace_depth != 1:
+            return logits
+        return _force_token_ids_mx(
+            logits,
+            condition & (token_id == self._close_brace_token_id),
+            (self._tool_call_end_token_id,),
+        )
 
     def _mask_if_needed(self, logits: Any) -> Any:
         if self._reasoning_open:
@@ -143,11 +336,14 @@ def create_gemma4_reasoning_guard_logits_processor(
         return None
 
     tool_call_start_token_ids = tokenizer.tool_call_start_tokens
+    tool_call_end_token_ids = tokenizer.tool_call_end_tokens
     reasoning_start_token_ids = tokenizer.think_start_tokens
     reasoning_end_token_ids = tokenizer.think_end_tokens
     if (
         tool_call_start_token_ids is None
         or len(tool_call_start_token_ids) != 1
+        or tool_call_end_token_ids is None
+        or len(tool_call_end_token_ids) != 1
         or reasoning_start_token_ids is None
         or len(reasoning_start_token_ids) != 2
         or reasoning_end_token_ids is None
@@ -155,12 +351,146 @@ def create_gemma4_reasoning_guard_logits_processor(
     ):
         return None
 
+    call_prefix_token_ids = _encode_token_ids(tokenizer, _GEMMA4_CALL_PREFIX)
+    tool_name_token_ids = tuple(
+        _encode_token_ids(tokenizer, tool_name) for tool_name in context.tool_names
+    )
+    open_brace_token_id = _single_token_id(tokenizer, "{")
+    close_brace_token_id = _single_token_id(tokenizer, "}")
+    string_delimiter_token_id = _single_token_id(tokenizer, GEMMA4_STRING_DELIMITER)
+    if (
+        len(call_prefix_token_ids) == 0
+        or any(len(token_ids) == 0 for token_ids in tool_name_token_ids)
+        or open_brace_token_id is None
+        or close_brace_token_id is None
+        or string_delimiter_token_id is None
+    ):
+        return None
+
+    vocab_size = int(tokenizer.vocab_size)
     return Gemma4ReasoningGuardLogitsProcessor(
         reasoning_open=context.reasoning_open,
         reasoning_start_token_ids=reasoning_start_token_ids,
         reasoning_end_token_ids=reasoning_end_token_ids,
         tool_call_start_token_id=tool_call_start_token_ids[0],
+        tool_call_end_token_id=tool_call_end_token_ids[0],
+        call_prefix_token_ids=call_prefix_token_ids,
+        tool_name_token_ids=tool_name_token_ids,
+        open_brace_token_id=open_brace_token_id,
+        close_brace_token_id=close_brace_token_id,
+        string_delimiter_token_id=string_delimiter_token_id,
+        eos_token_ids=tuple(int(token_id) for token_id in tokenizer.eos_token_ids),
+        whitespace_token_ids=tuple(
+            token_id
+            for whitespace in _GEMMA4_WHITESPACE
+            if (token_id := _single_token_id(tokenizer, whitespace)) is not None
+        ),
+        vocab_size=vocab_size,
     )
+
+
+def _build_gemma4_header_states(
+    *,
+    call_prefix_token_ids: tuple[int, ...],
+    tool_name_token_ids: tuple[tuple[int, ...], ...],
+    open_brace_token_id: int,
+) -> tuple[
+    tuple[tuple[int, int, int], ...],
+    dict[int, tuple[int, ...]],
+    int,
+    int,
+    int,
+]:
+    transitions: dict[int, dict[int, int | None]] = {}
+    next_state = Gemma4ReasoningGuardLogitsProcessor._STATE_HEADER_ROOT + 1
+
+    for name_token_ids in tool_name_token_ids:
+        state = Gemma4ReasoningGuardLogitsProcessor._STATE_HEADER_ROOT
+        for token_id in call_prefix_token_ids + name_token_ids:
+            state_transitions = transitions.setdefault(state, {})
+            if token_id not in state_transitions:
+                state_transitions[token_id] = next_state
+                next_state += 1
+            state = int(state_transitions[token_id])
+        transitions.setdefault(state, {})[open_brace_token_id] = None
+
+    args_state = next_state
+    need_tool_end_state = args_state + 1
+    post_tool_state = args_state + 2
+
+    header_edges = []
+    header_allowed_token_ids_by_state = {}
+    for from_state, state_transitions in transitions.items():
+        header_allowed_token_ids_by_state[from_state] = tuple(state_transitions.keys())
+        for token_id, to_state in state_transitions.items():
+            header_edges.append(
+                (from_state, token_id, args_state if to_state is None else to_state)
+            )
+
+    return (
+        tuple(header_edges),
+        header_allowed_token_ids_by_state,
+        args_state,
+        need_tool_end_state,
+        post_tool_state,
+    )
+
+
+def _header_transitions(
+    header_edges: tuple[tuple[int, int, int], ...],
+) -> dict[int, dict[int, int]]:
+    transitions: dict[int, dict[int, int]] = {}
+    for from_state, token_id, to_state in header_edges:
+        transitions.setdefault(from_state, {})[token_id] = to_state
+    return transitions
+
+
+def _force_token_ids_mx(
+    logits: mx.array,
+    condition: mx.array,
+    token_ids: tuple[int, ...] | list[int],
+) -> mx.array:
+    if len(token_ids) == 0:
+        return logits
+    logits[:, list(token_ids)] = mx.where(
+        condition,
+        _FORCED_TOOL_LOGIT,
+        logits[:, list(token_ids)],
+    )
+    return logits
+
+
+def _mask_token_ids_mx(
+    logits: mx.array,
+    condition: mx.array,
+    token_ids: tuple[int, ...] | list[int],
+) -> mx.array:
+    if len(token_ids) == 0:
+        return logits
+    logits[:, list(token_ids)] = mx.where(
+        condition,
+        -float("inf"),
+        logits[:, list(token_ids)],
+    )
+    return logits
+
+
+def _encode_token_ids(tokenizer: Any, text: str) -> tuple[int, ...]:
+    return tuple(
+        int(token_id)
+        for token_id in tokenizer.encode(text, add_special_tokens=False)
+    )
+
+
+def _single_token_id(tokenizer: Any, text: str) -> int | None:
+    token_ids = _encode_token_ids(tokenizer, text)
+    if len(token_ids) != 1:
+        return None
+    return token_ids[0]
+
+
+def _in_vocab(token_ids: Iterable[int], vocab_size: int) -> list[int]:
+    return [int(token_id) for token_id in token_ids if 0 <= int(token_id) < vocab_size]
 
 
 def _token_ids_to_list(tokens: Any) -> list[int]:

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -1,6 +1,5 @@
 import json
 import re
-from collections.abc import Iterable
 from typing import Any
 
 import llguidance
@@ -28,8 +27,8 @@ _GEMMA4_TOOL_NAME_RE = re.compile(
 )
 _GEMMA4_CALL_PREFIX = "call:"
 _GEMMA4_WHITESPACE = (" ", "\n", "\t", "\r")
-# Keep normal generation cheap: for small structural states, boost allowed
-# tokens instead of applying a full-vocabulary mask every decode step.
+# For tiny forced-token states, update only the allowed token ids instead of
+# adding an unnecessary full-vocabulary mask.
 _FORCED_TOOL_LOGIT = 1e9
 _LLG_TOKENIZER_CACHE: dict[int, Any] = {}
 
@@ -37,14 +36,14 @@ _LLG_TOKENIZER_CACHE: dict[int, Any] = {}
 def create_gemma4_tool_context_from_prompt(
     *,
     tokenizer: Any,
-    prompt_tokens: Iterable[int],
+    prompt_tokens: list[int],
     model_type: str | None,
 ) -> Gemma4ToolContext | None:
     """Return Gemma4 tool context only when the rendered prompt declares tools."""
     if not str(model_type or "").startswith("gemma4"):
         return None
 
-    prompt_text = tokenizer.decode(list(prompt_tokens))
+    prompt_text = tokenizer.decode(prompt_tokens)
     tool_names = tuple(dict.fromkeys(_GEMMA4_TOOL_NAME_RE.findall(prompt_text)))
     if len(tool_names) == 0:
         return None
@@ -133,7 +132,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
         # VLM calls this once on prompt prefill. Prompt reasoning state already
         # came from decoded prompt text. Historical prompt tool calls are
         # ignored; the structural grammar starts on generated <|tool_call> only.
-        token_ids = _token_ids_to_list(tokens)
+        token_ids = tokens.tolist()
         self._previous_token_mx = mx.array(token_ids[-1])
         self._reasoning_open_mx = mx.array(self._reasoning_open)
         self._context_token_count = len(token_ids)
@@ -159,17 +158,14 @@ class Gemma4ReasoningGuardLogitsProcessor:
 
     def _process_tool_context_tokens(self, token_context: list[int]) -> None:
         for token_id in token_context[self._context_token_count :]:
-            self._process_tool_context_token(int(token_id))
+            self._process_tool_context_token(token_id)
         self._context_token_count = len(token_context)
 
     def _process_tool_context_token(self, token_id: int) -> None:
-        if self._tool_state in (self._STATE_NORMAL, self._STATE_POST_TOOL):
-            if token_id == self._tool_call_start_token_id:
-                self._start_tool_call()
-            return
-
         if self._tool_state == self._STATE_TOOL:
             self._consume_tool_token(token_id)
+        elif token_id == self._tool_call_start_token_id:
+            self._start_tool_call()
 
     def _consume_tool_token(self, token_id: int) -> None:
         complete = self._tool_grammar.consume_token(self._tool_matcher, token_id)
@@ -230,7 +226,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
             )
 
         if self._tool_state == self._STATE_TOOL:
-            self._consume_tool_token(_mx_scalar_to_int(token_id))
+            self._consume_tool_token(int(token_id.item()))
             # The consumed sampled token will be appended to token_context after
             # this step. Skip it there so llguidance does not see it twice.
             self._context_token_count += 1
@@ -270,26 +266,19 @@ def create_gemma4_reasoning_guard_logits_processor(
     *,
     tokenizer: Any,
     context: Gemma4ToolContext,
-) -> Gemma4ReasoningGuardLogitsProcessor | None:
-    if len(context.tool_names) == 0:
-        return None
-
+) -> Gemma4ReasoningGuardLogitsProcessor:
     tool_call_start_token_id = tokenizer.tool_call_start_tokens[0]
-    reasoning_start_token_ids = tokenizer.think_start_tokens
-    reasoning_end_token_ids = tokenizer.think_end_tokens
-    call_prefix_token_ids = _encode_token_ids(tokenizer, _GEMMA4_CALL_PREFIX)
-    vocab_size = int(tokenizer.vocab_size)
     tool_grammar = _Gemma4LLGuidanceToolGrammar(
         tokenizer=tokenizer,
         tool_names=context.tool_names,
-        call_prefix_token_ids=call_prefix_token_ids,
-        vocab_size=vocab_size,
+        call_prefix_token_ids=_encode_token_ids(tokenizer, _GEMMA4_CALL_PREFIX),
+        vocab_size=int(tokenizer.vocab_size),
     )
 
     return Gemma4ReasoningGuardLogitsProcessor(
         reasoning_open=context.reasoning_open,
-        reasoning_start_token_ids=reasoning_start_token_ids,
-        reasoning_end_token_ids=reasoning_end_token_ids,
+        reasoning_start_token_ids=tokenizer.think_start_tokens,
+        reasoning_end_token_ids=tokenizer.think_end_tokens,
         tool_call_start_token_id=tool_call_start_token_id,
         tool_grammar=tool_grammar,
         eos_token_ids=tuple(int(token_id) for token_id in tokenizer.eos_token_ids),
@@ -309,7 +298,7 @@ object: "{{" WS (member (WS "," WS member)*)? WS "}}"
 member: key WS ":" WS value
 key: IDENT | gemma_string
 IDENT: /[A-Za-z_]/ /[A-Za-z0-9_.$\/-]*/
-value: gemma_string | object | array | NUMBER | "true" | "false" | "null" | "None" | "none"
+value: gemma_string | object | array | NUMBER | "true" | "false" | "null"
 array: "[" WS (value (WS "," WS value)*)? WS "]"
 gemma_string: <|"|> STRING_CHAR* <|"|>
 STRING_CHAR: /[^<]/ | "<" /[^|]/
@@ -335,14 +324,13 @@ def _get_llguidance_tokenizer(tokenizer: Any) -> Any:
 def _force_token_ids_mx(
     logits: mx.array,
     condition: mx.array,
-    token_ids: tuple[int, ...] | list[int],
+    token_ids: tuple[int, ...],
 ) -> mx.array:
-    if len(token_ids) == 0:
-        return logits
-    logits[:, list(token_ids)] = mx.where(
+    token_id_list = list(token_ids)
+    logits[:, token_id_list] = mx.where(
         condition,
         _FORCED_TOOL_LOGIT,
-        logits[:, list(token_ids)],
+        logits[:, token_id_list],
     )
     return logits
 
@@ -352,13 +340,3 @@ def _encode_token_ids(tokenizer: Any, text: str) -> tuple[int, ...]:
         int(token_id)
         for token_id in tokenizer.encode(text, add_special_tokens=False)
     )
-
-
-def _mx_scalar_to_int(token_id: mx.array) -> int:
-    return int(token_id.item())
-
-
-def _token_ids_to_list(tokens: Any) -> list[int]:
-    if hasattr(tokens, "tolist"):
-        return [int(token_id) for token_id in tokens.tolist()]
-    return [int(token_id) for token_id in tokens]

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -21,7 +21,7 @@ from mlx_engine.tool_protocols import (
 # and capture only the declared tool name (`get_weather`).
 _GEMMA4_TOOL_NAME_RE = re.compile(
     rf"{re.escape(GEMMA4_TOOL_DECLARATION_START)}.*?"
-    r"declaration:\s*([A-Za-z_][A-Za-z0-9_.$/-]*)\s*{.*?"
+    r"declaration:\s*([A-Za-z_][A-Za-z0-9_.$/:-]*)\s*{.*?"
     rf"{re.escape(GEMMA4_TOOL_DECLARATION_END)}",
     re.DOTALL,
 )

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -230,9 +230,9 @@ class Gemma4ReasoningGuardLogitsProcessor:
             # this step. Skip it there so llguidance does not see it twice.
             self._context_token_count += 1
             if self._tool_state == self._STATE_POST_TOOL:
-                # The call just closed. Only allow EOS, whitespace, or another
-                # adjacent <|tool_call> from here.
-                logits = _boost_token_ids_mx(
+                # The call just closed. Allow only EOS, whitespace, or another
+                # adjacent <|tool_call>, preserving the model's scores among them.
+                logits = _mask_except_token_ids_mx(
                     logits,
                     mx.array(True),
                     self._post_tool_token_ids,
@@ -250,8 +250,8 @@ class Gemma4ReasoningGuardLogitsProcessor:
                 self._initial_tool_token_ids,
             )
             # Otherwise stay in the post-tool lane: EOS, whitespace, or another
-            # adjacent <|tool_call>. This blocks prose after a completed call.
-            logits = _boost_token_ids_mx(
+            # adjacent <|tool_call>. Preserve scores among those continuations.
+            logits = _mask_except_token_ids_mx(
                 logits,
                 token_id != self._tool_call_start_token_id,
                 self._post_tool_token_ids,
@@ -298,7 +298,7 @@ def _gemma4_llguidance_grammar(tool_names: tuple[str, ...]) -> str:
     tool_choice = " | ".join(json.dumps(tool_name) for tool_name in tool_names)
     # Regex chars handle normal text; explicit special-token alternatives keep
     # marker-looking text legal inside Gemma strings until the exact <|"|> delimiter.
-    return rf'''%llguidance {{}}
+    return rf"""%llguidance {{}}
 start: "call:" tool object <tool_call|>
 tool: {tool_choice}
 object: "{{" WS (member (WS "," WS member)*)? WS "}}"
@@ -314,7 +314,7 @@ STRING_CHAR: /[^<]/ | "<" /[^|]/ | "<|" /[^"]/ | "<|\"" /[^|]/ | "<|\"|" /[^>]/
 gemma_string_special: <|tool> | <tool|> | <|tool_call> | <tool_call|> | <|tool_response> | <tool_response|> | <|channel> | <channel|> | <|turn> | <turn|> | <|think|> | <|image> | <image|> | <|image|> | <|audio> | <audio|> | <|audio|> | <|video|>
 NUMBER: "-"? (/[0-9]/ | /[1-9]/ /[0-9]*/) ("." /[0-9]/+)? (/[eE]/ /[+-]/? /[0-9]/+)?
 WS: /[ \t\n\r]*/
-'''
+"""
 
 
 def _get_llguidance_tokenizer(tokenizer: Any) -> Any:
@@ -345,8 +345,18 @@ def _boost_token_ids_mx(
     return logits
 
 
+def _mask_except_token_ids_mx(
+    logits: mx.array,
+    condition: mx.array,
+    token_ids: tuple[int, ...],
+) -> mx.array:
+    allowed_logits = mx.full(logits.shape, -float("inf"), dtype=logits.dtype)
+    token_id_list = list(token_ids)
+    allowed_logits[:, token_id_list] = logits[:, token_id_list]
+    return mx.where(condition, allowed_logits, logits)
+
+
 def _encode_token_ids(tokenizer: Any, text: str) -> tuple[int, ...]:
     return tuple(
-        int(token_id)
-        for token_id in tokenizer.encode(text, add_special_tokens=False)
+        int(token_id) for token_id in tokenizer.encode(text, add_special_tokens=False)
     )

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -111,6 +111,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
         eos_token_ids: tuple[int, ...],
         whitespace_token_ids: tuple[int, ...],
     ):
+        """Initialize Gemma4 marker ids, tool grammar, and reasoning state."""
         self._reasoning_open = reasoning_open
         self._reasoning_open_mx = mx.array(reasoning_open)
         self._reasoning_start_first_token_id = reasoning_start_token_ids[0]
@@ -129,6 +130,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._reset_tool_state()
 
     def __call__(self, tokens: Any, logits: Any) -> Any:
+        """Initialize from VLM prefill tokens and apply prompt-time masks."""
         # VLM calls this once on prompt prefill. Prompt reasoning state already
         # came from decoded prompt text. Historical prompt tool calls are
         # ignored; the structural grammar starts on generated <|tool_call> only.
@@ -137,7 +139,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._reasoning_open_mx = mx.array(self._reasoning_open)
         self._context_token_count = len(token_ids)
         self._reset_tool_state()
-        return self._mask_if_needed(logits)
+        return self._apply_prefill_reasoning_mask(logits)
 
     def process_last_token_with_context(
         self,
@@ -145,57 +147,82 @@ class Gemma4ReasoningGuardLogitsProcessor:
         last_token: mx.array,
         logits: mx.array,
     ) -> mx.array:
-        self._process_tool_context_tokens(token_context)
+        """Catch up from materialized context, then mask next-token logits."""
+        self._catch_up_tool_context(token_context)
         return self._process_last_token_mx(last_token.reshape(-1)[0], logits)
 
     def _reset_tool_state(self) -> None:
+        """Return tool-grammar tracking to ordinary non-tool generation."""
         self._tool_state = self._STATE_NORMAL
         self._tool_matcher = None
 
     def _start_tool_call(self) -> None:
+        """Enter grammar-tracked mode after sampled <|tool_call>."""
         self._tool_state = self._STATE_TOOL
         self._tool_matcher = self._tool_grammar.start_matcher()
 
-    def _process_tool_context_tokens(self, token_context: list[int]) -> None:
+    def _catch_up_tool_context(self, token_context: list[int]) -> None:
+        """Consume context tokens not yet seen by the tool grammar."""
         for token_id in token_context[self._context_token_count :]:
-            self._process_tool_context_token(token_id)
+            self._advance_tool_state_from_token(token_id)
         self._context_token_count = len(token_context)
 
-    def _process_tool_context_token(self, token_id: int) -> None:
+    def _advance_tool_state_from_token(self, token_id: int) -> None:
+        """Start or advance tool grammar state from a materialized token."""
         if self._tool_state == self._STATE_TOOL:
-            self._consume_tool_token(token_id)
+            self._consume_tool_grammar_token(token_id)
         elif token_id == self._tool_call_start_token_id:
             self._start_tool_call()
 
-    def _consume_tool_token(self, token_id: int) -> None:
+    def _consume_tool_grammar_token(self, token_id: int) -> None:
+        """Feed one generated tool token into llguidance and mark completion."""
         complete = self._tool_grammar.consume_token(self._tool_matcher, token_id)
         if complete:
             self._tool_state = self._STATE_POST_TOOL
             self._tool_matcher = None
 
     def _process_last_token_mx(self, token_id: mx.array, logits: mx.array) -> mx.array:
+        """Track reasoning state in MLX and apply next-token masks."""
         # Keep normal decode token handling in MLX: last_token.tolist() calls
         # eval()/wait and can create a per-token graph break. We only sync the
         # sampled token while an llguidance tool grammar is active.
+
+        # Gemma4 opens visible reasoning with a two-token sequence:
+        # <|channel> followed by thought.
         reasoning_start = (
             self._previous_token_mx == self._reasoning_start_first_token_id
         ) & (token_id == self._reasoning_start_second_token_id)
+
+        # Gemma4 closes visible reasoning with the single <channel|> token.
         reasoning_end = token_id == self._reasoning_end_token_id
+
+        # If the opening sequence just completed, mark reasoning as open.
         self._reasoning_open_mx = mx.where(
             reasoning_start,
             mx.array(True),
             self._reasoning_open_mx,
         )
+
+        # If the close marker was sampled, mark reasoning as closed.
         self._reasoning_open_mx = mx.where(
             reasoning_end,
             mx.array(False),
             self._reasoning_open_mx,
         )
-        self._previous_token_mx = token_id
-        return self._mask_if_needed_mx(logits, token_id)
 
-    def _mask_if_needed_mx(self, logits: mx.array, token_id: mx.array) -> mx.array:
-        logits = self._mask_tool_structure_mx(logits, token_id)
+        # Remember this token so the next step can detect the two-token opener.
+        self._previous_token_mx = token_id
+
+        # Apply reasoning/tool-call constraints to the logits for the next token.
+        return self._apply_next_token_masks_mx(logits, token_id)
+
+    def _apply_next_token_masks_mx(
+        self,
+        logits: mx.array,
+        token_id: mx.array,
+    ) -> mx.array:
+        """Apply tool-structure and reasoning-boundary masks in MLX."""
+        logits = self._apply_tool_structure_mask_mx(logits, token_id)
         # Keep <|tool_call> blocked while visible reasoning is open. This forces
         # the model to sample the real <channel|> close before starting a tool call.
         logits[:, self._tool_call_start_token_id] = mx.where(
@@ -205,11 +232,12 @@ class Gemma4ReasoningGuardLogitsProcessor:
         )
         return logits
 
-    def _mask_tool_structure_mx(
+    def _apply_tool_structure_mask_mx(
         self,
         logits: mx.array,
         token_id: mx.array,
     ) -> mx.array:
+        """Constrain generated tokens once Gemma4 tool-call mode starts."""
         # Once <|tool_call> is emitted, llguidance enforces one native Gemma4 call:
         #   call:KNOWN_TOOL{...}<tool_call|>
         # The post-tool state allows only EOS/whitespace/another adjacent call.
@@ -221,7 +249,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
             )
 
         if self._tool_state == self._STATE_TOOL:
-            self._consume_tool_token(int(token_id.item()))
+            self._consume_tool_grammar_token(int(token_id.item()))
             # The consumed sampled token will be appended to token_context after
             # this step. Skip it there so llguidance does not see it twice.
             self._context_token_count += 1
@@ -247,7 +275,8 @@ class Gemma4ReasoningGuardLogitsProcessor:
 
         return logits
 
-    def _mask_if_needed(self, logits: Any) -> Any:
+    def _apply_prefill_reasoning_mask(self, logits: Any) -> Any:
+        """Apply the initial prompt-derived reasoning guard after prefill."""
         if self._reasoning_open:
             # Keep <|tool_call> blocked while visible reasoning is open. This forces
             # the model to sample the real <channel|> close before starting a tool call.

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -61,67 +61,32 @@ class Gemma4ReasoningGuardLogitsProcessor:
         self._reasoning_start_token_ids = reasoning_start_token_ids
         self._reasoning_end_token_ids = reasoning_end_token_ids
         self._tool_call_start_token_id = tool_call_start_token_id
-        self._processed_token_count = 0
-        self._tail_tokens: list[int] = []
         self._tail_token_count = max(
             len(reasoning_start_token_ids),
             len(reasoning_end_token_ids),
             1,
         ) - 1
+        self._tail_tokens: list[int] = []
 
     def __call__(self, tokens: Any, logits: Any) -> Any:
-        self._sync_from_full_history(_token_ids_to_list(tokens))
+        # VLM calls this once on prompt prefill. Prompt reasoning state already
+        # came from decoded prompt text, so keep only enough tail for markers
+        # that may finish immediately after prefill.
+        self._tail_tokens = _tail(_token_ids_to_list(tokens), self._tail_token_count)
         return self._mask_if_needed(logits)
 
     def process_last_token(self, last_token: Any, logits: Any) -> Any:
-        new_token_ids = _token_ids_to_list(last_token)
-        self._process_new_tokens(new_token_ids)
-        self._processed_token_count += len(new_token_ids)
+        for token_id in _token_ids_to_list(last_token):
+            token_window = self._tail_tokens + [token_id]
+            if _ends_with(token_window, self._reasoning_start_token_ids):
+                self._reasoning_open = True
+            if _ends_with(token_window, self._reasoning_end_token_ids):
+                self._reasoning_open = False
+            self._tail_tokens = _tail(token_window, self._tail_token_count)
         return self._mask_if_needed(logits)
 
-    def _sync_from_full_history(self, token_ids: list[int]) -> None:
-        if self._processed_token_count == 0:
-            # First call is the prompt prefill. We already decoded the prompt once
-            # to establish this state, so do not decode or rescan it per token.
-            self._processed_token_count = len(token_ids)
-            self._tail_tokens = self._tail(token_ids)
-            return
-
-        if len(token_ids) < self._processed_token_count:
-            self._reasoning_open = _gemma4_reasoning_is_open_from_token_ids(
-                token_ids,
-                self._reasoning_start_token_ids,
-                self._reasoning_end_token_ids,
-            )
-            self._processed_token_count = len(token_ids)
-            self._tail_tokens = self._tail(token_ids)
-            return
-
-        self._process_new_tokens(token_ids[self._processed_token_count :])
-        self._processed_token_count = len(token_ids)
-
-    def _process_new_tokens(self, new_token_ids: list[int]) -> None:
-        if len(new_token_ids) == 0:
-            return
-        scan_token_ids = self._tail_tokens + new_token_ids
-        self._reasoning_open = _update_gemma4_reasoning_state_from_token_ids(
-            self._reasoning_open,
-            scan_token_ids,
-            self._reasoning_start_token_ids,
-            self._reasoning_end_token_ids,
-        )
-        self._tail_tokens = self._tail(scan_token_ids)
-
-    def _tail(self, token_ids: list[int]) -> list[int]:
-        if self._tail_token_count == 0:
-            return []
-        return token_ids[-self._tail_token_count :]
-
     def _mask_if_needed(self, logits: Any) -> Any:
-        if not self._reasoning_open:
-            return logits
-
-        if 0 <= self._tool_call_start_token_id < logits.shape[-1]:
+        if self._reasoning_open:
             logits[:, self._tool_call_start_token_id] = -float("inf")
         return logits
 
@@ -134,7 +99,11 @@ def create_gemma4_reasoning_guard_logits_processor(
     if len(context.tool_names) == 0:
         return None
 
-    tool_call_start_token_id = _gemma4_tool_call_start_token_id(tokenizer)
+    tool_call_start_token_ids = _token_sequence(
+        tokenizer,
+        attr_name="tool_call_start_tokens",
+        text=GEMMA4_TOOL_CALL_START,
+    )
     reasoning_start_token_ids = _token_sequence(
         tokenizer,
         attr_name="think_start_tokens",
@@ -146,7 +115,8 @@ def create_gemma4_reasoning_guard_logits_processor(
         text=GEMMA4_CHANNEL_END,
     )
     if (
-        tool_call_start_token_id is None
+        tool_call_start_token_ids is None
+        or len(tool_call_start_token_ids) != 1
         or reasoning_start_token_ids is None
         or reasoning_end_token_ids is None
     ):
@@ -156,41 +126,8 @@ def create_gemma4_reasoning_guard_logits_processor(
         reasoning_open=context.reasoning_open,
         reasoning_start_token_ids=reasoning_start_token_ids,
         reasoning_end_token_ids=reasoning_end_token_ids,
-        tool_call_start_token_id=tool_call_start_token_id,
+        tool_call_start_token_id=tool_call_start_token_ids[0],
     )
-
-
-def _token_ids_to_list(tokens: Any) -> list[int]:
-    if hasattr(tokens, "tolist"):
-        tokens = tokens.tolist()
-    if isinstance(tokens, int):
-        return [tokens]
-
-    token_ids = []
-    for token_id in tokens:
-        if isinstance(token_id, (list, tuple)):
-            token_ids.extend(_token_ids_to_list(token_id))
-        else:
-            token_ids.append(int(token_id))
-    return token_ids
-
-
-def _gemma4_tool_call_start_token_id(tokenizer: Any) -> int | None:
-    token_ids = _token_sequence(
-        tokenizer,
-        attr_name="tool_call_start_tokens",
-        text=GEMMA4_TOOL_CALL_START,
-    )
-    if token_ids is None or len(token_ids) != 1:
-        return None
-
-    token_id = token_ids[0]
-    try:
-        if tokenizer.decode([token_id]) != GEMMA4_TOOL_CALL_START:
-            return None
-    except Exception:
-        return None
-    return token_id
 
 
 def _token_sequence(
@@ -202,7 +139,6 @@ def _token_sequence(
     token_ids = getattr(tokenizer, attr_name, None)
     if token_ids is None and hasattr(tokenizer, "encode"):
         token_ids = tokenizer.encode(text, add_special_tokens=False)
-
     if isinstance(token_ids, int):
         return (token_ids,)
     if isinstance(token_ids, (list, tuple)) and len(token_ids) > 0:
@@ -210,37 +146,21 @@ def _token_sequence(
     return None
 
 
-def _gemma4_reasoning_is_open_from_token_ids(
-    token_ids: list[int],
-    reasoning_start_token_ids: tuple[int, ...],
-    reasoning_end_token_ids: tuple[int, ...],
-) -> bool:
-    return _update_gemma4_reasoning_state_from_token_ids(
-        False,
-        token_ids,
-        reasoning_start_token_ids,
-        reasoning_end_token_ids,
-    )
+def _token_ids_to_list(tokens: Any) -> list[int]:
+    if hasattr(tokens, "tolist"):
+        tokens = tokens.tolist()
+    if isinstance(tokens, int):
+        return [tokens]
+    if isinstance(tokens, (list, tuple)):
+        return [int(token_id) for token_id in tokens]
+    return [int(tokens)]
 
 
-def _update_gemma4_reasoning_state_from_token_ids(
-    reasoning_open: bool,
-    token_ids: list[int],
-    reasoning_start_token_ids: tuple[int, ...],
-    reasoning_end_token_ids: tuple[int, ...],
-) -> bool:
-    for token_index in range(len(token_ids)):
-        if _token_sequence_matches(token_ids, token_index, reasoning_start_token_ids):
-            reasoning_open = True
-        if _token_sequence_matches(token_ids, token_index, reasoning_end_token_ids):
-            reasoning_open = False
-    return reasoning_open
+def _tail(token_ids: list[int], count: int) -> list[int]:
+    if count == 0:
+        return []
+    return token_ids[-count:]
 
 
-def _token_sequence_matches(
-    token_ids: list[int],
-    start_index: int,
-    expected: tuple[int, ...],
-) -> bool:
-    end_index = start_index + len(expected)
-    return end_index <= len(token_ids) and tuple(token_ids[start_index:end_index]) == expected
+def _ends_with(token_ids: list[int], suffix: tuple[int, ...]) -> bool:
+    return len(token_ids) >= len(suffix) and tuple(token_ids[-len(suffix) :]) == suffix

--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -242,7 +242,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
         #   call:KNOWN_TOOL{...}<tool_call|>
         # The post-tool state allows only EOS/whitespace/another adjacent call.
         if self._tool_state == self._STATE_NORMAL:
-            return _force_token_ids_mx(
+            return _boost_token_ids_mx(
                 logits,
                 token_id == self._tool_call_start_token_id,
                 self._initial_tool_token_ids,
@@ -254,7 +254,7 @@ class Gemma4ReasoningGuardLogitsProcessor:
             # this step. Skip it there so llguidance does not see it twice.
             self._context_token_count += 1
             if self._tool_state == self._STATE_POST_TOOL:
-                return _force_token_ids_mx(
+                return _boost_token_ids_mx(
                     logits,
                     mx.array(True),
                     self._post_tool_token_ids,
@@ -262,12 +262,12 @@ class Gemma4ReasoningGuardLogitsProcessor:
             return self._tool_grammar.mask_logits(self._tool_matcher, logits)
 
         if self._tool_state == self._STATE_POST_TOOL:
-            logits = _force_token_ids_mx(
+            logits = _boost_token_ids_mx(
                 logits,
                 token_id == self._tool_call_start_token_id,
                 self._initial_tool_token_ids,
             )
-            return _force_token_ids_mx(
+            return _boost_token_ids_mx(
                 logits,
                 token_id != self._tool_call_start_token_id,
                 self._post_tool_token_ids,
@@ -348,7 +348,7 @@ def _get_llguidance_tokenizer(tokenizer: Any) -> Any:
     return llg_tokenizer
 
 
-def _force_token_ids_mx(
+def _boost_token_ids_mx(
     logits: mx.array,
     condition: mx.array,
     token_ids: tuple[int, ...],

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -60,6 +60,14 @@ class _IntLastTokenProcessor:
         return _bump(logits, self.token)
 
 
+class _OptInLastTokenProcessor(_IntLastTokenProcessor):
+    uses_last_token_fast_path = True
+
+    def process_last_token(self, last_token, logits):
+        self.last_token_calls.append(last_token.tolist())
+        return _bump(logits, self.token)
+
+
 class _FakeBatchCache:
     keys = True
 
@@ -194,6 +202,23 @@ def test_int_last_token_processor_uses_full_context_call():
 
     assert processor.calls == [[100, 2]]
     assert processor.last_token_calls == []
+    assert mx.argmax(logits, axis=-1).tolist() == [5]
+
+
+def test_opt_in_last_token_processor_uses_fast_path_without_mutating_context():
+    processor = _OptInLastTokenProcessor(token=5)
+    token_context = [[100]]
+
+    logits = batcher._apply_logits_processors(
+        mx.zeros((1, 8), dtype=mx.float32),
+        token_context,
+        [[processor]],
+        last_tokens=mx.array([2], dtype=mx.int32),
+    )
+
+    assert processor.calls == []
+    assert processor.last_token_calls == [[2]]
+    assert token_context == [[100]]
     assert mx.argmax(logits, axis=-1).tolist() == [5]
 
 

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -214,7 +214,6 @@ def test_gemma4_reasoning_guard_uses_mlx_last_token_without_mutating_context():
         tool_grammar=_NoopToolGrammar(),
         eos_token_ids=(0,),
         whitespace_token_ids=(13,),
-        vocab_size=16,
     )
     processor([1], mx.zeros((1, 16), dtype=mx.float32))
     token_context = [[100]]

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -201,10 +201,11 @@ def test_int_last_token_processor_uses_full_context_call():
 def test_gemma4_reasoning_guard_uses_mlx_last_token_without_mutating_context():
     processor = Gemma4ReasoningGuardLogitsProcessor(
         reasoning_open=False,
-        reasoning_start_token_ids=(2,),
+        reasoning_start_token_ids=(1, 2),
         reasoning_end_token_ids=(3,),
         tool_call_start_token_id=5,
     )
+    processor([1], mx.zeros((1, 8), dtype=mx.float32))
     token_context = [[100]]
 
     logits = batcher._apply_logits_processors(

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -61,6 +61,13 @@ class _IntLastTokenProcessor:
         return _bump(logits, self.token)
 
 
+class _NoopToolGrammar:
+    initial_token_ids = (7,)
+
+    def start_matcher(self):
+        raise AssertionError("tool grammar should not activate in this test")
+
+
 class _FakeBatchCache:
     keys = True
 
@@ -204,12 +211,7 @@ def test_gemma4_reasoning_guard_uses_mlx_last_token_without_mutating_context():
         reasoning_start_token_ids=(1, 2),
         reasoning_end_token_ids=(3,),
         tool_call_start_token_id=5,
-        tool_call_end_token_id=6,
-        call_prefix_token_ids=(7, 8),
-        tool_name_token_ids=((9,),),
-        open_brace_token_id=10,
-        close_brace_token_id=11,
-        string_delimiter_token_id=12,
+        tool_grammar=_NoopToolGrammar(),
         eos_token_ids=(0,),
         whitespace_token_ids=(13,),
         vocab_size=16,

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -64,8 +64,20 @@ class _OptInLastTokenProcessor(_IntLastTokenProcessor):
     uses_last_token_fast_path = True
 
     def process_last_token(self, last_token, logits):
-        self.last_token_calls.append(last_token.tolist())
+        self.last_token_calls.append(last_token)
         return _bump(logits, self.token)
+
+
+class _UnchangedFastPathProcessor:
+    uses_last_token_fast_path = True
+    last_call_changed_logits = False
+
+    def __init__(self):
+        self.calls = []
+
+    def process_last_token(self, last_token, logits):
+        self.calls.append(last_token)
+        return logits
 
 
 class _FakeBatchCache:
@@ -217,9 +229,26 @@ def test_opt_in_last_token_processor_uses_fast_path_without_mutating_context():
     )
 
     assert processor.calls == []
-    assert processor.last_token_calls == [[2]]
+    assert processor.last_token_calls == [2]
     assert token_context == [[100]]
     assert mx.argmax(logits, axis=-1).tolist() == [5]
+
+
+def test_unchanged_fast_path_processor_returns_original_logits():
+    processor = _UnchangedFastPathProcessor()
+    token_context = [[100]]
+    logits = mx.zeros((1, 8), dtype=mx.float32)
+
+    result = batcher._apply_logits_processors(
+        logits,
+        token_context,
+        [[processor]],
+        last_tokens=mx.array([2], dtype=mx.int32),
+    )
+
+    assert processor.calls == [2]
+    assert token_context == [[100]]
+    assert result is logits
 
 
 def test_generation_batch_finish_returns_cache_tokens_and_rope_delta():

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -215,7 +215,7 @@ def test_gemma4_reasoning_guard_uses_mlx_last_token_without_mutating_context():
         eos_token_ids=(0,),
         whitespace_token_ids=(13,),
     )
-    processor([1], mx.zeros((1, 16), dtype=mx.float32))
+    processor(mx.array([1], dtype=mx.int32), mx.zeros((1, 16), dtype=mx.float32))
     token_context = [[100]]
 
     logits = batcher._apply_logits_processors(

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -13,6 +13,7 @@ from mlx_engine.model_kit.batched_vision.prompt_cache.chunks import (
     build_prefix_cache_chunks,
 )
 from mlx_engine.model_kit.batched_vision.prompt_cache.types import PromptImageSpan
+from mlx_engine.tool_runtime import Gemma4ReasoningGuardLogitsProcessor
 
 
 def _argmax_sampler(logprobs):
@@ -58,26 +59,6 @@ class _IntLastTokenProcessor:
     def __call__(self, tokens, logits):
         self.calls.append(tokens.tolist())
         return _bump(logits, self.token)
-
-
-class _OptInLastTokenProcessor(_IntLastTokenProcessor):
-    uses_last_token_fast_path = True
-
-    def process_last_token(self, last_token, logits):
-        self.last_token_calls.append(last_token)
-        return _bump(logits, self.token)
-
-
-class _UnchangedFastPathProcessor:
-    uses_last_token_fast_path = True
-    last_call_changed_logits = False
-
-    def __init__(self):
-        self.calls = []
-
-    def process_last_token(self, last_token, logits):
-        self.calls.append(last_token)
-        return logits
 
 
 class _FakeBatchCache:
@@ -217,8 +198,13 @@ def test_int_last_token_processor_uses_full_context_call():
     assert mx.argmax(logits, axis=-1).tolist() == [5]
 
 
-def test_opt_in_last_token_processor_uses_fast_path_without_mutating_context():
-    processor = _OptInLastTokenProcessor(token=5)
+def test_gemma4_reasoning_guard_uses_mlx_last_token_without_mutating_context():
+    processor = Gemma4ReasoningGuardLogitsProcessor(
+        reasoning_open=False,
+        reasoning_start_token_ids=(2,),
+        reasoning_end_token_ids=(3,),
+        tool_call_start_token_id=5,
+    )
     token_context = [[100]]
 
     logits = batcher._apply_logits_processors(
@@ -228,27 +214,8 @@ def test_opt_in_last_token_processor_uses_fast_path_without_mutating_context():
         last_tokens=mx.array([2], dtype=mx.int32),
     )
 
-    assert processor.calls == []
-    assert processor.last_token_calls == [2]
     assert token_context == [[100]]
-    assert mx.argmax(logits, axis=-1).tolist() == [5]
-
-
-def test_unchanged_fast_path_processor_returns_original_logits():
-    processor = _UnchangedFastPathProcessor()
-    token_context = [[100]]
-    logits = mx.zeros((1, 8), dtype=mx.float32)
-
-    result = batcher._apply_logits_processors(
-        logits,
-        token_context,
-        [[processor]],
-        last_tokens=mx.array([2], dtype=mx.int32),
-    )
-
-    assert processor.calls == [2]
-    assert token_context == [[100]]
-    assert result is logits
+    assert logits[:, 5].tolist() == [-float("inf")]
 
 
 def test_generation_batch_finish_returns_cache_tokens_and_rope_delta():

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -204,12 +204,21 @@ def test_gemma4_reasoning_guard_uses_mlx_last_token_without_mutating_context():
         reasoning_start_token_ids=(1, 2),
         reasoning_end_token_ids=(3,),
         tool_call_start_token_id=5,
+        tool_call_end_token_id=6,
+        call_prefix_token_ids=(7, 8),
+        tool_name_token_ids=((9,),),
+        open_brace_token_id=10,
+        close_brace_token_id=11,
+        string_delimiter_token_id=12,
+        eos_token_ids=(0,),
+        whitespace_token_ids=(13,),
+        vocab_size=16,
     )
-    processor([1], mx.zeros((1, 8), dtype=mx.float32))
+    processor([1], mx.zeros((1, 16), dtype=mx.float32))
     token_context = [[100]]
 
     logits = batcher._apply_logits_processors(
-        mx.zeros((1, 8), dtype=mx.float32),
+        mx.zeros((1, 16), dtype=mx.float32),
         token_context,
         [[processor]],
         last_tokens=mx.array([2], dtype=mx.int32),

--- a/tests/test_tool_runtime_detection.py
+++ b/tests/test_tool_runtime_detection.py
@@ -27,6 +27,17 @@ def test_gemma4_context_extracts_declared_tool_names():
     assert not context.reasoning_open
 
 
+def test_gemma4_context_extracts_colon_namespaced_tool_name():
+    context = create_gemma4_tool_context_from_prompt(
+        tokenizer=_Tokenizer("<|tool>declaration:mcp:search{}<tool|>"),
+        prompt_tokens=[1, 2, 3],
+        model_type="gemma4",
+    )
+
+    assert context is not None
+    assert context.tool_names == ("mcp:search",)
+
+
 def test_gemma4_context_requires_gemma4_model_type():
     context = create_gemma4_tool_context_from_prompt(
         tokenizer=_Tokenizer(GEMMA4_TOOL_PROMPT),

--- a/tests/test_tool_runtime_detection.py
+++ b/tests/test_tool_runtime_detection.py
@@ -1,10 +1,10 @@
 from mlx_engine.tool_runtime import create_gemma4_tool_context_from_prompt
 
 
-GEMMA4_TOOL_PROMPT = '''<bos><|turn>system
+GEMMA4_TOOL_PROMPT = """<bos><|turn>system
 <|tool>declaration:get_weather{description:<|"|>Get weather<|"|>,parameters:{properties:{location:{type:<|"|>STRING<|"|>}},type:<|"|>OBJECT<|"|>}}<tool|><|tool>declaration:search{description:<|"|>Search<|"|>,parameters:{properties:{query:{type:<|"|>STRING<|"|>}},type:<|"|>OBJECT<|"|>}}<tool|><turn|>
 <|turn>user
-What is the weather in Paris?'''
+What is the weather in Paris?"""
 
 
 class _Tokenizer:

--- a/tests/test_tool_runtime_detection.py
+++ b/tests/test_tool_runtime_detection.py
@@ -1,0 +1,58 @@
+from mlx_engine.tool_runtime import create_gemma4_tool_context_from_prompt
+
+
+GEMMA4_TOOL_PROMPT = '''<bos><|turn>system
+<|tool>declaration:get_weather{description:<|"|>Get weather<|"|>,parameters:{properties:{location:{type:<|"|>STRING<|"|>}},type:<|"|>OBJECT<|"|>}}<tool|><|tool>declaration:search{description:<|"|>Search<|"|>,parameters:{properties:{query:{type:<|"|>STRING<|"|>}},type:<|"|>OBJECT<|"|>}}<tool|><turn|>
+<|turn>user
+What is the weather in Paris?'''
+
+
+class _Tokenizer:
+    def __init__(self, text: str):
+        self.text = text
+
+    def decode(self, _token_ids):
+        return self.text
+
+
+def test_gemma4_context_extracts_declared_tool_names():
+    context = create_gemma4_tool_context_from_prompt(
+        tokenizer=_Tokenizer(GEMMA4_TOOL_PROMPT),
+        prompt_tokens=[1, 2, 3],
+        model_type="gemma4",
+    )
+
+    assert context is not None
+    assert context.tool_names == ("get_weather", "search")
+    assert not context.reasoning_open
+
+
+def test_gemma4_context_requires_gemma4_model_type():
+    context = create_gemma4_tool_context_from_prompt(
+        tokenizer=_Tokenizer(GEMMA4_TOOL_PROMPT),
+        prompt_tokens=[1, 2, 3],
+        model_type="qwen3_5_vl",
+    )
+
+    assert context is None
+
+
+def test_gemma4_context_requires_tool_declarations():
+    context = create_gemma4_tool_context_from_prompt(
+        tokenizer=_Tokenizer("<|turn>user\nHello<turn|>"),
+        prompt_tokens=[1, 2, 3],
+        model_type="gemma4",
+    )
+
+    assert context is None
+
+
+def test_gemma4_context_tracks_open_reasoning_from_prompt_tail():
+    context = create_gemma4_tool_context_from_prompt(
+        tokenizer=_Tokenizer(GEMMA4_TOOL_PROMPT + "<|channel>thought\nNeed a tool."),
+        prompt_tokens=[1, 2, 3],
+        model_type="gemma4",
+    )
+
+    assert context is not None
+    assert context.reasoning_open

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -324,3 +324,71 @@ def test_gemma4_llguidance_grammar_uses_native_special_tokens():
     assert '"search-tool"' in grammar
     assert "<tool_call|>" in grammar
     assert '<|"|>' in grammar
+
+
+def test_gemma4_llguidance_grammar_accepts_electron_parser_edge_cases():
+    import llguidance
+    import llguidance.hf
+    from tokenizers import Tokenizer, decoders, models, pre_tokenizers, trainers
+    from transformers import PreTrainedTokenizerFast
+
+    special_tokens = [
+        "<eos>",
+        '<|"|>',
+        "<|tool>",
+        "<tool|>",
+        "<|tool_call>",
+        "<tool_call|>",
+        "<|tool_response>",
+        "<tool_response|>",
+        "<|channel>",
+        "<channel|>",
+        "<|turn>",
+        "<turn|>",
+        "<|think|>",
+        "<|image>",
+        "<image|>",
+        "<|image|>",
+        "<|audio>",
+        "<audio|>",
+        "<|audio|>",
+        "<|video|>",
+    ]
+    tokenizer = Tokenizer(models.BPE(unk_token="<unk>"))
+    tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    tokenizer.decoder = decoders.ByteLevel()
+    tokenizer.train_from_iterator(
+        [
+            'call:lookup{2fa_code:<|"|>what is <|tool_call>?<|"|>}<tool_call|>',
+            "call:lookup{optional:None}<tool_call|>",
+            "call:lookup{optional:none}<tool_call|>",
+        ],
+        trainers.BpeTrainer(
+            vocab_size=300,
+            special_tokens=["<unk>", *special_tokens],
+            initial_alphabet=pre_tokenizers.ByteLevel.alphabet(),
+        ),
+    )
+    hf_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        unk_token="<unk>",
+        eos_token="<eos>",
+        additional_special_tokens=special_tokens[1:],
+    )
+    llg_tokenizer = llguidance.hf.from_tokenizer(
+        hf_tokenizer,
+        n_vocab=len(hf_tokenizer.get_vocab()),
+        eos_token=[hf_tokenizer.eos_token_id],
+    )
+    grammar = _gemma4_llguidance_grammar(("lookup",))
+
+    for text in [
+        'call:lookup{2fa_code:<|"|>what is <|tool_call>?<|"|>}<tool_call|>',
+        "call:lookup{optional:None}<tool_call|>",
+        "call:lookup{optional:none}<tool_call|>",
+    ]:
+        matcher = llguidance.LLMatcher(llg_tokenizer, grammar)
+        for token_id in hf_tokenizer.encode(text, add_special_tokens=False):
+            matcher.consume_token(token_id)
+            assert not matcher.get_error()
+        assert matcher.is_stopped()

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -10,12 +10,12 @@ from mlx_engine.tool_runtime import create_gemma4_reasoning_guard_logits_process
 class _Tokenizer:
     def __init__(self, tool_call_start_tokens=(4,)):
         self.decode_count = 0
-        self.think_start_tokens = (1,)
+        self.think_start_tokens = (1, 2)
         self.think_end_tokens = (3,)
         self.tool_call_start_tokens = tool_call_start_tokens
         self.text_by_token_id = {
-            1: GEMMA4_REASONING_START,
-            2: "\nNeed data.",
+            1: "<|channel>",
+            2: "thought",
             3: GEMMA4_CHANNEL_END,
             4: GEMMA4_TOOL_CALL_START,
             5: "ignored",
@@ -77,6 +77,7 @@ def test_gemma4_reasoning_guard_tracks_generated_reasoning_markers():
     assert processor is not None
     processor([5], logits)
     processor.process_last_token([1], logits)
+    processor.process_last_token([2], logits)
 
     assert logits.values[0][4] == -float("inf")
 
@@ -109,6 +110,7 @@ def test_gemma4_reasoning_guard_does_not_decode_during_generation():
     processor([1, 2], logits)
     processor.process_last_token([3], logits)
     processor.process_last_token([1], logits)
+    processor.process_last_token([2], logits)
 
     assert tokenizer.decode_count == decode_count_after_setup
 

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -42,6 +42,8 @@ class _Tokenizer:
             16: "search",
             17: "\n",
             18: "}}",
+            19: "\t",
+            20: "\r",
         }
         self.token_id_by_text = {
             text: token_id for token_id, text in self.text_by_token_id.items()
@@ -170,7 +172,6 @@ def _processor(tool_names=("get_weather",), reasoning_open=False):
         tool_grammar=_FakeToolGrammar(tool_names),
         eos_token_ids=(0,),
         whitespace_token_ids=(15, 17),
-        vocab_size=24,
     )
     processor([14], mx.zeros((1, 24), dtype=mx.float32))
     return processor
@@ -187,36 +188,36 @@ def test_gemma4_reasoning_guard_masks_tool_call_start_when_prompt_reasoning_open
 
 def test_gemma4_reasoning_guard_tracks_generated_reasoning_markers():
     processor = _processor()
-    logits = _FakeLogits(vocab_size=8)
+    context = _mx_context()
 
-    processor([5], logits)
-    processor.process_last_token([1], logits)
-    processor.process_last_token([2], logits)
+    _process_token(processor, context, 1)
+    logits = _process_token(processor, context, 2)
 
-    assert logits.values[0][4] == -float("inf")
+    assert logits[:, 4].tolist() == [-float("inf")]
 
 
 def test_gemma4_reasoning_guard_allows_tool_call_start_after_channel_end():
     processor = _processor(reasoning_open=True)
-    logits = _FakeLogits(vocab_size=8)
+    context = _mx_context()
 
-    processor([1, 2], logits)
-    logits_after_channel_end = _FakeLogits(vocab_size=8)
-    processor.process_last_token([3], logits_after_channel_end)
+    logits = _process_token(processor, context, 3)
 
-    assert logits_after_channel_end.values[0][4] == 0.0
+    assert logits[:, 4].tolist() == [0.0]
 
 
 def test_gemma4_reasoning_guard_does_not_decode_during_generation():
     tokenizer = _Tokenizer()
-    processor = _processor(reasoning_open=True)
-    logits = _FakeLogits(vocab_size=8)
-
+    processor = create_gemma4_reasoning_guard_logits_processor(
+        tokenizer=tokenizer,
+        context=_context(reasoning_open=True),
+    )
+    assert processor is not None
     decode_count_after_setup = tokenizer.decode_count
-    processor([1, 2], logits)
-    processor.process_last_token([3], logits)
-    processor.process_last_token([1], logits)
-    processor.process_last_token([2], logits)
+    processor([1, 2], mx.zeros((1, 24), dtype=mx.float32))
+    context = [1, 2]
+    _process_token(processor, context, 3)
+    _process_token(processor, context, 1)
+    _process_token(processor, context, 2)
 
     assert tokenizer.decode_count == decode_count_after_setup
 
@@ -225,15 +226,6 @@ def test_gemma4_reasoning_guard_requires_declared_tools():
     processor = create_gemma4_reasoning_guard_logits_processor(
         tokenizer=_Tokenizer(),
         context=_context(tool_names=()),
-    )
-
-    assert processor is None
-
-
-def test_gemma4_reasoning_guard_requires_single_token_tool_call_start():
-    processor = create_gemma4_reasoning_guard_logits_processor(
-        tokenizer=_Tokenizer(tool_call_start_tokens=(4, 5)),
-        context=_context(),
     )
 
     assert processor is None

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -76,7 +76,7 @@ def test_gemma4_reasoning_guard_tracks_generated_reasoning_markers():
 
     assert processor is not None
     processor([5], logits)
-    processor.process_last_token(1, logits)
+    processor.process_last_token([1], logits)
 
     assert logits.values[0][4] == -float("inf")
 
@@ -91,7 +91,7 @@ def test_gemma4_reasoning_guard_allows_tool_call_start_after_channel_end():
     assert processor is not None
     processor([1, 2], logits)
     logits_after_channel_end = _FakeLogits(vocab_size=8)
-    processor.process_last_token(3, logits_after_channel_end)
+    processor.process_last_token([3], logits_after_channel_end)
 
     assert logits_after_channel_end.values[0][4] == 0.0
 
@@ -107,8 +107,8 @@ def test_gemma4_reasoning_guard_does_not_decode_during_generation():
     assert processor is not None
     decode_count_after_setup = tokenizer.decode_count
     processor([1, 2], logits)
-    processor.process_last_token(3, logits)
-    processor.process_last_token(1, logits)
+    processor.process_last_token([3], logits)
+    processor.process_last_token([1], logits)
 
     assert tokenizer.decode_count == decode_count_after_setup
 

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -1,3 +1,5 @@
+import mlx.core as mx
+
 from mlx_engine.tool_protocols import (
     GEMMA4_CHANNEL_END,
     GEMMA4_REASONING_START,
@@ -10,15 +12,35 @@ from mlx_engine.tool_runtime import create_gemma4_reasoning_guard_logits_process
 class _Tokenizer:
     def __init__(self, tool_call_start_tokens=(4,)):
         self.decode_count = 0
+        self.vocab_size = 24
+        self.eos_token_ids = {0}
         self.think_start_tokens = (1, 2)
         self.think_end_tokens = (3,)
         self.tool_call_start_tokens = tool_call_start_tokens
+        self.tool_call_end_tokens = (5,)
         self.text_by_token_id = {
+            0: "<eos>",
             1: "<|channel>",
             2: "thought",
             3: GEMMA4_CHANNEL_END,
             4: GEMMA4_TOOL_CALL_START,
-            5: "ignored",
+            5: "<tool_call|>",
+            6: "call",
+            7: ":",
+            8: "get",
+            9: "_",
+            10: "weather",
+            11: "{",
+            12: "}",
+            13: '<|"|>',
+            14: "ignored",
+            15: " ",
+            16: "search",
+            17: "\n",
+            18: "}}",
+        }
+        self.token_id_by_text = {
+            text: token_id for token_id, text in self.text_by_token_id.items()
         }
 
     def encode(self, text, add_special_tokens=False):
@@ -29,6 +51,16 @@ class _Tokenizer:
             return list(self.think_end_tokens)
         if text == GEMMA4_TOOL_CALL_START:
             return list(self.tool_call_start_tokens)
+        if text == "<tool_call|>":
+            return list(self.tool_call_end_tokens)
+        if text == "call:":
+            return [6, 7]
+        if text == "get_weather":
+            return [8, 9, 10]
+        if text == "search":
+            return [16]
+        if text in self.token_id_by_text:
+            return [self.token_id_by_text[text]]
         return []
 
     def decode(self, token_ids):
@@ -36,6 +68,9 @@ class _Tokenizer:
         if isinstance(token_ids, int):
             token_ids = [token_ids]
         return "".join(self.text_by_token_id[int(token_id)] for token_id in token_ids)
+
+    def get_vocab(self):
+        return dict(self.token_id_by_text)
 
 
 class _FakeLogits:
@@ -131,3 +166,111 @@ def test_gemma4_reasoning_guard_requires_single_token_tool_call_start():
     )
 
     assert processor is None
+
+
+
+def _mx_processor(tool_names=("get_weather",)):
+    processor = create_gemma4_reasoning_guard_logits_processor(
+        tokenizer=_Tokenizer(),
+        context=_context(tool_names=tool_names),
+    )
+    assert processor is not None
+    processor([14], mx.zeros((1, 24), dtype=mx.float32))
+    return processor
+
+
+def _mx_context():
+    return [14]
+
+
+def _process_token(processor, context, token_id):
+    logits = processor.process_last_token_with_context(
+        context,
+        mx.array([token_id], dtype=mx.int32),
+        _mx_logits(),
+    )
+    context.append(token_id)
+    return logits
+
+
+def _mx_logits():
+    return mx.zeros((1, 24), dtype=mx.float32)
+
+
+def _forced_token_ids(logits):
+    return [
+        token_id
+        for token_id, value in enumerate(logits.reshape(-1).tolist())
+        if value > 1e8
+    ]
+
+
+def test_gemma4_structure_constrains_header_after_tool_call_start():
+    processor = _mx_processor()
+
+    context = _mx_context()
+
+    logits = _process_token(processor, context, 4)
+    assert _forced_token_ids(logits) == [6]
+
+    logits = _process_token(processor, context, 6)
+    assert _forced_token_ids(logits) == [7]
+
+    logits = _process_token(processor, context, 7)
+    assert _forced_token_ids(logits) == [8]
+
+    logits = _process_token(processor, context, 8)
+    assert _forced_token_ids(logits) == [9]
+
+    logits = _process_token(processor, context, 9)
+    assert _forced_token_ids(logits) == [10]
+
+    logits = _process_token(processor, context, 10)
+    assert _forced_token_ids(logits) == [11]
+
+
+def test_gemma4_structure_allows_only_known_tool_name_prefixes():
+    processor = _mx_processor(tool_names=("get_weather", "search"))
+    context = _mx_context()
+    _process_token(processor, context, 4)
+    _process_token(processor, context, 6)
+
+    logits = _process_token(processor, context, 7)
+
+    assert _forced_token_ids(logits) == [8, 16]
+
+
+def test_gemma4_structure_balances_args_and_requires_tool_end_marker():
+    processor = _mx_processor()
+    context = _mx_context()
+    for token_id in [4, 6, 7, 8, 9, 10]:
+        _process_token(processor, context, token_id)
+
+    logits = _process_token(processor, context, 11)
+    assert logits[:, 5].tolist() == [-float("inf")]
+    assert logits[:, 12].tolist() == [0.0]
+
+    logits = _process_token(processor, context, 12)
+    assert _forced_token_ids(logits) == [5]
+
+    logits = _process_token(processor, context, 5)
+    assert 0 in _forced_token_ids(logits)
+    assert 4 in _forced_token_ids(logits)
+    assert 15 in _forced_token_ids(logits)
+    assert 14 not in _forced_token_ids(logits)
+
+
+def test_gemma4_structure_ignores_braces_inside_gemma_strings():
+    processor = _mx_processor()
+    context = _mx_context()
+    for token_id in [4, 6, 7, 8, 9, 10, 11]:
+        _process_token(processor, context, token_id)
+
+    _process_token(processor, context, 13)
+    logits = _process_token(processor, context, 12)
+    assert logits[:, 5].tolist() == [-float("inf")]
+    assert logits[:, 14].tolist() == [0.0]
+
+    _process_token(processor, context, 13)
+    logits = _process_token(processor, context, 12)
+    assert _forced_token_ids(logits) == [5]

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -326,7 +326,7 @@ def test_gemma4_llguidance_grammar_uses_native_special_tokens():
     assert '<|"|>' in grammar
 
 
-def test_gemma4_llguidance_grammar_accepts_electron_parser_edge_cases():
+def test_gemma4_llguidance_grammar_accepts_parser_edge_cases():
     import llguidance
     import llguidance.hf
     from tokenizers import Tokenizer, decoders, models, pre_tokenizers, trainers

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -115,7 +115,9 @@ class _FakeToolGrammar:
     def consume_token(self, matcher, token_id: int) -> bool:
         if matcher["state"] == "header":
             pos = matcher["pos"]
-            headers = [header for header in matcher["headers"] if header[pos] == token_id]
+            headers = [
+                header for header in matcher["headers"] if header[pos] == token_id
+            ]
             if not headers:
                 raise ValueError(f"unexpected header token {token_id}")
             matcher["headers"] = headers
@@ -225,11 +227,11 @@ def _mx_context():
     return [14]
 
 
-def _process_token(processor, context, token_id):
+def _process_token(processor, context, token_id, logits=None):
     logits = processor.process_last_token_with_context(
         context,
         mx.array([token_id], dtype=mx.int32),
-        _mx_logits(),
+        _mx_logits() if logits is None else logits,
     )
     context.append(token_id)
     return logits
@@ -237,6 +239,25 @@ def _process_token(processor, context, token_id):
 
 def _mx_logits():
     return mx.zeros((1, 24), dtype=mx.float32)
+
+
+def _post_tool_logits():
+    values = [-10.0] * 24
+    values[0] = 1.0
+    values[4] = 3.0
+    values[15] = 2.0
+    values[17] = 0.5
+    values[14] = 100.0
+    return mx.array([values], dtype=mx.float32)
+
+
+def _assert_post_tool_logits_preserved(logits):
+    assert logits[:, 0].tolist() == [1.0]
+    assert logits[:, 4].tolist() == [3.0]
+    assert logits[:, 15].tolist() == [2.0]
+    assert logits[:, 17].tolist() == [0.5]
+    assert logits[:, 14].tolist() == [-float("inf")]
+    assert mx.argmax(logits, axis=-1).tolist() == [4]
 
 
 def _forced_token_ids(logits):
@@ -295,10 +316,25 @@ def test_gemma4_structure_balances_args_and_requires_tool_end_marker():
     assert _forced_token_ids(logits) == [5]
 
     logits = _process_token(processor, context, 5)
-    assert 0 in _forced_token_ids(logits)
-    assert 4 in _forced_token_ids(logits)
-    assert 15 in _forced_token_ids(logits)
-    assert 14 not in _forced_token_ids(logits)
+    assert logits[:, 0].tolist() == [0.0]
+    assert logits[:, 4].tolist() == [0.0]
+    assert logits[:, 15].tolist() == [0.0]
+    assert logits[:, 14].tolist() == [-float("inf")]
+
+
+def test_gemma4_post_tool_mask_preserves_allowed_logits():
+    processor = _processor()
+    context = _mx_context()
+    for token_id in [4, 6, 7, 8, 9, 10, 11, 12]:
+        _process_token(processor, context, token_id)
+
+    _assert_post_tool_logits_preserved(
+        _process_token(processor, context, 5, _post_tool_logits())
+    )
+
+    _assert_post_tool_logits_preserved(
+        _process_token(processor, context, 15, _post_tool_logits())
+    )
 
 
 def test_gemma4_structure_ignores_braces_inside_gemma_strings():

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -6,7 +6,11 @@ from mlx_engine.tool_protocols import (
     GEMMA4_TOOL_CALL_START,
     Gemma4ToolContext,
 )
-from mlx_engine.tool_runtime import create_gemma4_reasoning_guard_logits_processor
+from mlx_engine.tool_runtime import (
+    Gemma4ReasoningGuardLogitsProcessor,
+    _gemma4_llguidance_grammar,
+    create_gemma4_reasoning_guard_logits_processor,
+)
 
 
 class _Tokenizer:
@@ -85,31 +89,106 @@ class _FakeLogits:
             row[token_id] = value
 
 
+class _FakeToolGrammar:
+    initial_token_ids = (6,)
+
+    def __init__(self, tool_names=("get_weather",)):
+        name_tokens = {
+            "get_weather": (8, 9, 10),
+            "search": (16,),
+        }
+        self._headers = [
+            (6, 7, *name_tokens[tool_name], 11) for tool_name in tool_names
+        ]
+
+    def start_matcher(self):
+        return {
+            "state": "header",
+            "pos": 0,
+            "headers": self._headers,
+            "depth": 0,
+            "in_string": False,
+        }
+
+    def consume_token(self, matcher, token_id: int) -> bool:
+        if matcher["state"] == "header":
+            pos = matcher["pos"]
+            headers = [header for header in matcher["headers"] if header[pos] == token_id]
+            if not headers:
+                raise ValueError(f"unexpected header token {token_id}")
+            matcher["headers"] = headers
+            matcher["pos"] = pos + 1
+            if any(matcher["pos"] == len(header) for header in headers):
+                matcher["state"] = "args"
+                matcher["depth"] = 1
+            return False
+
+        if matcher["state"] == "args":
+            if token_id == 13:
+                matcher["in_string"] = not matcher["in_string"]
+                return False
+            if matcher["in_string"]:
+                return False
+            if token_id == 11:
+                matcher["depth"] += 1
+            elif token_id == 12:
+                matcher["depth"] -= 1
+                if matcher["depth"] == 0:
+                    matcher["state"] = "need_end"
+            return False
+
+        if matcher["state"] == "need_end":
+            if token_id != 5:
+                raise ValueError(f"expected tool-call end, got {token_id}")
+            matcher["state"] = "post"
+            return True
+
+        raise ValueError(f"unexpected token after complete tool call {token_id}")
+
+    def mask_logits(self, matcher, logits):
+        if matcher["state"] == "header":
+            pos = matcher["pos"]
+            allowed = sorted({header[pos] for header in matcher["headers"]})
+            logits[:, allowed] = 1e9
+        elif matcher["state"] == "args":
+            logits[:, [0, 4, 5]] = -float("inf")
+        elif matcher["state"] == "need_end":
+            logits[:, [5]] = 1e9
+        return logits
+
+
 def _context(tool_names=("get_weather",), reasoning_open=False):
     return Gemma4ToolContext(tool_names=tool_names, reasoning_open=reasoning_open)
 
 
-def test_gemma4_reasoning_guard_masks_tool_call_start_when_prompt_reasoning_open():
-    processor = create_gemma4_reasoning_guard_logits_processor(
-        tokenizer=_Tokenizer(),
-        context=_context(reasoning_open=True),
+def _processor(tool_names=("get_weather",), reasoning_open=False):
+    processor = Gemma4ReasoningGuardLogitsProcessor(
+        reasoning_open=reasoning_open,
+        reasoning_start_token_ids=(1, 2),
+        reasoning_end_token_ids=(3,),
+        tool_call_start_token_id=4,
+        tool_grammar=_FakeToolGrammar(tool_names),
+        eos_token_ids=(0,),
+        whitespace_token_ids=(15, 17),
+        vocab_size=24,
     )
+    processor([14], mx.zeros((1, 24), dtype=mx.float32))
+    return processor
+
+
+def test_gemma4_reasoning_guard_masks_tool_call_start_when_prompt_reasoning_open():
+    processor = _processor(reasoning_open=True)
     logits = _FakeLogits(vocab_size=8)
 
-    assert processor is not None
     assert processor([1, 2], logits) is logits
 
     assert logits.values[0][4] == -float("inf")
 
 
 def test_gemma4_reasoning_guard_tracks_generated_reasoning_markers():
-    processor = create_gemma4_reasoning_guard_logits_processor(
-        tokenizer=_Tokenizer(),
-        context=_context(),
-    )
+    processor = _processor()
     logits = _FakeLogits(vocab_size=8)
 
-    assert processor is not None
     processor([5], logits)
     processor.process_last_token([1], logits)
     processor.process_last_token([2], logits)
@@ -118,13 +197,9 @@ def test_gemma4_reasoning_guard_tracks_generated_reasoning_markers():
 
 
 def test_gemma4_reasoning_guard_allows_tool_call_start_after_channel_end():
-    processor = create_gemma4_reasoning_guard_logits_processor(
-        tokenizer=_Tokenizer(),
-        context=_context(reasoning_open=True),
-    )
+    processor = _processor(reasoning_open=True)
     logits = _FakeLogits(vocab_size=8)
 
-    assert processor is not None
     processor([1, 2], logits)
     logits_after_channel_end = _FakeLogits(vocab_size=8)
     processor.process_last_token([3], logits_after_channel_end)
@@ -134,13 +209,9 @@ def test_gemma4_reasoning_guard_allows_tool_call_start_after_channel_end():
 
 def test_gemma4_reasoning_guard_does_not_decode_during_generation():
     tokenizer = _Tokenizer()
-    processor = create_gemma4_reasoning_guard_logits_processor(
-        tokenizer=tokenizer,
-        context=_context(reasoning_open=True),
-    )
+    processor = _processor(reasoning_open=True)
     logits = _FakeLogits(vocab_size=8)
 
-    assert processor is not None
     decode_count_after_setup = tokenizer.decode_count
     processor([1, 2], logits)
     processor.process_last_token([3], logits)
@@ -166,17 +237,6 @@ def test_gemma4_reasoning_guard_requires_single_token_tool_call_start():
     )
 
     assert processor is None
-
-
-
-def _mx_processor(tool_names=("get_weather",)):
-    processor = create_gemma4_reasoning_guard_logits_processor(
-        tokenizer=_Tokenizer(),
-        context=_context(tool_names=tool_names),
-    )
-    assert processor is not None
-    processor([14], mx.zeros((1, 24), dtype=mx.float32))
-    return processor
 
 
 def _mx_context():
@@ -206,8 +266,7 @@ def _forced_token_ids(logits):
 
 
 def test_gemma4_structure_constrains_header_after_tool_call_start():
-    processor = _mx_processor()
-
+    processor = _processor()
     context = _mx_context()
 
     logits = _process_token(processor, context, 4)
@@ -230,7 +289,7 @@ def test_gemma4_structure_constrains_header_after_tool_call_start():
 
 
 def test_gemma4_structure_allows_only_known_tool_name_prefixes():
-    processor = _mx_processor(tool_names=("get_weather", "search"))
+    processor = _processor(tool_names=("get_weather", "search"))
     context = _mx_context()
     _process_token(processor, context, 4)
     _process_token(processor, context, 6)
@@ -241,7 +300,7 @@ def test_gemma4_structure_allows_only_known_tool_name_prefixes():
 
 
 def test_gemma4_structure_balances_args_and_requires_tool_end_marker():
-    processor = _mx_processor()
+    processor = _processor()
     context = _mx_context()
     for token_id in [4, 6, 7, 8, 9, 10]:
         _process_token(processor, context, token_id)
@@ -261,7 +320,7 @@ def test_gemma4_structure_balances_args_and_requires_tool_end_marker():
 
 
 def test_gemma4_structure_ignores_braces_inside_gemma_strings():
-    processor = _mx_processor()
+    processor = _processor()
     context = _mx_context()
     for token_id in [4, 6, 7, 8, 9, 10, 11]:
         _process_token(processor, context, token_id)
@@ -274,3 +333,12 @@ def test_gemma4_structure_ignores_braces_inside_gemma_strings():
     _process_token(processor, context, 13)
     logits = _process_token(processor, context, 12)
     assert _forced_token_ids(logits) == [5]
+
+
+def test_gemma4_llguidance_grammar_uses_native_special_tokens():
+    grammar = _gemma4_llguidance_grammar(("get_weather", "search-tool"))
+
+    assert '"get_weather"' in grammar
+    assert '"search-tool"' in grammar
+    assert "<tool_call|>" in grammar
+    assert '<|"|>' in grammar

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -9,6 +9,9 @@ from mlx_engine.tool_runtime import create_gemma4_reasoning_guard_logits_process
 
 class _Tokenizer:
     def __init__(self, tool_call_start_tokens=(4,)):
+        self.decode_count = 0
+        self.think_start_tokens = (1,)
+        self.think_end_tokens = (3,)
         self.tool_call_start_tokens = tool_call_start_tokens
         self.text_by_token_id = {
             1: GEMMA4_REASONING_START,
@@ -20,11 +23,16 @@ class _Tokenizer:
 
     def encode(self, text, add_special_tokens=False):
         assert add_special_tokens is False
+        if text == GEMMA4_REASONING_START:
+            return list(self.think_start_tokens)
+        if text == GEMMA4_CHANNEL_END:
+            return list(self.think_end_tokens)
         if text == GEMMA4_TOOL_CALL_START:
             return list(self.tool_call_start_tokens)
         return []
 
     def decode(self, token_ids):
+        self.decode_count += 1
         if isinstance(token_ids, int):
             token_ids = [token_ids]
         return "".join(self.text_by_token_id[int(token_id)] for token_id in token_ids)
@@ -42,14 +50,14 @@ class _FakeLogits:
             row[token_id] = value
 
 
-def _context(tool_names=("get_weather",)):
-    return Gemma4ToolContext(tool_names=tool_names, reasoning_open=False)
+def _context(tool_names=("get_weather",), reasoning_open=False):
+    return Gemma4ToolContext(tool_names=tool_names, reasoning_open=reasoning_open)
 
 
-def test_gemma4_reasoning_guard_masks_tool_call_start_while_reasoning_open():
+def test_gemma4_reasoning_guard_masks_tool_call_start_when_prompt_reasoning_open():
     processor = create_gemma4_reasoning_guard_logits_processor(
         tokenizer=_Tokenizer(),
-        context=_context(),
+        context=_context(reasoning_open=True),
     )
     logits = _FakeLogits(vocab_size=8)
 
@@ -59,7 +67,7 @@ def test_gemma4_reasoning_guard_masks_tool_call_start_while_reasoning_open():
     assert logits.values[0][4] == -float("inf")
 
 
-def test_gemma4_reasoning_guard_allows_tool_call_start_after_channel_end():
+def test_gemma4_reasoning_guard_tracks_generated_reasoning_markers():
     processor = create_gemma4_reasoning_guard_logits_processor(
         tokenizer=_Tokenizer(),
         context=_context(),
@@ -67,9 +75,42 @@ def test_gemma4_reasoning_guard_allows_tool_call_start_after_channel_end():
     logits = _FakeLogits(vocab_size=8)
 
     assert processor is not None
-    processor([1, 2, 3], logits)
+    processor([5], logits)
+    processor.process_last_token(1, logits)
 
-    assert logits.values[0][4] == 0.0
+    assert logits.values[0][4] == -float("inf")
+
+
+def test_gemma4_reasoning_guard_allows_tool_call_start_after_channel_end():
+    processor = create_gemma4_reasoning_guard_logits_processor(
+        tokenizer=_Tokenizer(),
+        context=_context(reasoning_open=True),
+    )
+    logits = _FakeLogits(vocab_size=8)
+
+    assert processor is not None
+    processor([1, 2], logits)
+    logits_after_channel_end = _FakeLogits(vocab_size=8)
+    processor.process_last_token(3, logits_after_channel_end)
+
+    assert logits_after_channel_end.values[0][4] == 0.0
+
+
+def test_gemma4_reasoning_guard_does_not_decode_during_generation():
+    tokenizer = _Tokenizer()
+    processor = create_gemma4_reasoning_guard_logits_processor(
+        tokenizer=tokenizer,
+        context=_context(reasoning_open=True),
+    )
+    logits = _FakeLogits(vocab_size=8)
+
+    assert processor is not None
+    decode_count_after_setup = tokenizer.decode_count
+    processor([1, 2], logits)
+    processor.process_last_token(3, logits)
+    processor.process_last_token(1, logits)
+
+    assert tokenizer.decode_count == decode_count_after_setup
 
 
 def test_gemma4_reasoning_guard_requires_declared_tools():

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -1,0 +1,90 @@
+from mlx_engine.tool_protocols import (
+    GEMMA4_CHANNEL_END,
+    GEMMA4_REASONING_START,
+    GEMMA4_TOOL_CALL_START,
+    Gemma4ToolContext,
+)
+from mlx_engine.tool_runtime import create_gemma4_reasoning_guard_logits_processor
+
+
+class _Tokenizer:
+    def __init__(self, tool_call_start_tokens=(4,)):
+        self.tool_call_start_tokens = tool_call_start_tokens
+        self.text_by_token_id = {
+            1: GEMMA4_REASONING_START,
+            2: "\nNeed data.",
+            3: GEMMA4_CHANNEL_END,
+            4: GEMMA4_TOOL_CALL_START,
+            5: "ignored",
+        }
+
+    def encode(self, text, add_special_tokens=False):
+        assert add_special_tokens is False
+        if text == GEMMA4_TOOL_CALL_START:
+            return list(self.tool_call_start_tokens)
+        return []
+
+    def decode(self, token_ids):
+        if isinstance(token_ids, int):
+            token_ids = [token_ids]
+        return "".join(self.text_by_token_id[int(token_id)] for token_id in token_ids)
+
+
+class _FakeLogits:
+    def __init__(self, vocab_size: int):
+        self.shape = (1, vocab_size)
+        self.values = [[0.0 for _ in range(vocab_size)]]
+
+    def __setitem__(self, key, value):
+        row_selector, token_id = key
+        assert row_selector == slice(None)
+        for row in self.values:
+            row[token_id] = value
+
+
+def _context(tool_names=("get_weather",)):
+    return Gemma4ToolContext(tool_names=tool_names, reasoning_open=False)
+
+
+def test_gemma4_reasoning_guard_masks_tool_call_start_while_reasoning_open():
+    processor = create_gemma4_reasoning_guard_logits_processor(
+        tokenizer=_Tokenizer(),
+        context=_context(),
+    )
+    logits = _FakeLogits(vocab_size=8)
+
+    assert processor is not None
+    assert processor([1, 2], logits) is logits
+
+    assert logits.values[0][4] == -float("inf")
+
+
+def test_gemma4_reasoning_guard_allows_tool_call_start_after_channel_end():
+    processor = create_gemma4_reasoning_guard_logits_processor(
+        tokenizer=_Tokenizer(),
+        context=_context(),
+    )
+    logits = _FakeLogits(vocab_size=8)
+
+    assert processor is not None
+    processor([1, 2, 3], logits)
+
+    assert logits.values[0][4] == 0.0
+
+
+def test_gemma4_reasoning_guard_requires_declared_tools():
+    processor = create_gemma4_reasoning_guard_logits_processor(
+        tokenizer=_Tokenizer(),
+        context=_context(tool_names=()),
+    )
+
+    assert processor is None
+
+
+def test_gemma4_reasoning_guard_requires_single_token_tool_call_start():
+    processor = create_gemma4_reasoning_guard_logits_processor(
+        tokenizer=_Tokenizer(tool_call_start_tokens=(4, 5)),
+        context=_context(),
+    )
+
+    assert processor is None

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -173,7 +173,7 @@ def _processor(tool_names=("get_weather",), reasoning_open=False):
         eos_token_ids=(0,),
         whitespace_token_ids=(15, 17),
     )
-    processor([14], mx.zeros((1, 24), dtype=mx.float32))
+    processor(mx.array([14], dtype=mx.int32), mx.zeros((1, 24), dtype=mx.float32))
     return processor
 
 
@@ -181,7 +181,7 @@ def test_gemma4_reasoning_guard_masks_tool_call_start_when_prompt_reasoning_open
     processor = _processor(reasoning_open=True)
     logits = _FakeLogits(vocab_size=8)
 
-    assert processor([1, 2], logits) is logits
+    assert processor(mx.array([1, 2], dtype=mx.int32), logits) is logits
 
     assert logits.values[0][4] == -float("inf")
 
@@ -211,24 +211,14 @@ def test_gemma4_reasoning_guard_does_not_decode_during_generation():
         tokenizer=tokenizer,
         context=_context(reasoning_open=True),
     )
-    assert processor is not None
     decode_count_after_setup = tokenizer.decode_count
-    processor([1, 2], mx.zeros((1, 24), dtype=mx.float32))
+    processor(mx.array([1, 2], dtype=mx.int32), mx.zeros((1, 24), dtype=mx.float32))
     context = [1, 2]
     _process_token(processor, context, 3)
     _process_token(processor, context, 1)
     _process_token(processor, context, 2)
 
     assert tokenizer.decode_count == decode_count_after_setup
-
-
-def test_gemma4_reasoning_guard_requires_declared_tools():
-    processor = create_gemma4_reasoning_guard_logits_processor(
-        tokenizer=_Tokenizer(),
-        context=_context(tool_names=()),
-    )
-
-    assert processor is None
 
 
 def _mx_context():


### PR DESCRIPTION
## Summary

This PR adds a Gemma4-only tool-call logits processor for the MLX Engine batched VLM generator.

It activates only when a Gemma4 VLM prompt already contains native Gemma4 tool declarations. If the model later chooses to emit `<|tool_call>`, MLX Engine constrains the rest of the native call so malformed structure is not sampled into the generated token stream.

## Why

MLX Engine currently streams model-native text and applies ordinary stop/string handling after tokens are sampled. That is not enough for Gemma4 tool-call reliability: once a model starts a native call, invalid syntax can create an invalid tool call, which hurts model effectiveness.

The main reliability target here is structural correctness after the model has already selected tool-call mode:

```text
<|tool_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>
```

The processor prevents common bad continuations such as unknown tool names, broken `call:` headers, unbalanced argument objects, unclosed Gemma strings, missing `<tool_call|>`.

## Design decisions and tradeoffs

- **Reasoning guard**: vLLM’s Gemma4 parser can treat `<|tool_call>` inside reasoning as an implicit transition out of reasoning. Since the LM Studio app currently ignores tool calls within reasoning blocks, update the model logits to disallow it. This will materially change the model output generation, but overall prevents models from making tool calls without prior structure. Down the road, when we can handle tool calls interrupting thinking, we can refactor to remove this logit mask.
- **llguidance grammar**: llguidance gives us a compact grammar for the post-`<|tool_call>` span and only runs once tool-call mode has started. The grammar enforces structure and known tool names.
- **Preserve adjacent calls**: After `<tool_call|>`, the processor does not force an immediate stop. It allows whitespace and another adjacent `<|tool_call>`, so multiple back-to-back native calls remain possible if the model emits them.

## Performance / regression considerations

Normal generation should remain effectively unchanged. A small amount of extra work while actively decoding a tool call is acceptable; the important path is no-tool / pre-tool generation. No-tool perf smoke on the Gemma4 E2B VLM path showed no material slowdown:

  ```text
  baseline median: 93.69 tok/s
  guarded median:  93.22 tok/s
  delta: -0.51%
  ```

## References
Upstream behavior used for comparison:

- vLLM Gemma4 parser preserves special tokens, tracks visible reasoning, parses `<|tool_call>call:NAME{...}<tool_call|>`, and scans args until `<tool_call|>` outside Gemma strings: https://github.com/vllm-project/vllm/blob/main/rust/src/parser/src/unified/gemma4.rs
- llama.cpp Gemma4 chat grammar preserves Gemma4 markers, defines Gemma4 thinking tags, triggers grammar on `<|tool_call>`, and constrains native calls as `<|tool_call>call:...<tool_call|>`: https://github.com/ggml-org/llama.cpp/blob/master/common/chat.cpp
- llguidance supports Lark-like CFGs, tokenizer special-token references, numeric token-id references, and efficient token-mask computation: https://github.com/guidance-ai/llguidance/blob/main/docs/syntax.md and https://github.com/guidance-ai/llguidance
