### PR TITLE
Context length auto fit

### DIFF
--- a/mlx_engine/__init__.py
+++ b/mlx_engine/__init__.py
@@ -4,6 +4,7 @@
 
 __all__ = [
     "load_model",
+    "get_runtime_load_info",
     "load_draft_model",
     "is_draft_model_compatible",
     "unload_draft_model",
@@ -23,6 +24,7 @@ from .utils.logger import setup_logging
 
 from .generate import (
     load_model,
+    get_runtime_load_info,
     load_draft_model,
     is_draft_model_compatible,
     unload_draft_model,

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -195,7 +195,6 @@ def load_model(
     kv_group_size: Optional[int] = None,
     quantized_kv_start: Optional[int] = None,
     prefill_step_size: Optional[int] = None,
-    auto_fit_context: bool = False,
 ) -> LoadedModelKit:
     """
     Load a language model or vision-language model from the specified path.
@@ -216,8 +215,6 @@ def load_model(
         quantized_kv_start (Optional[int]): Step to begin KV cache quantization when enabled.
         prefill_step_size (Optional[int]): Number of tokens to process per prefill chunk.
             Defaults to PROMPT_PROCESSING_CHUNK_SIZE when None.
-        auto_fit_context (bool): Calculate and report a recommended context length for
-            batched VLMs.
 
     Returns:
         LoadedModelKit: An initialized model instance:
@@ -268,7 +265,6 @@ def load_model(
             max_seq_nums=max_seq_nums,
             trust_remote_code=trust_remote_code,
             seed=seed,
-            auto_fit_context=auto_fit_context,
         )
     else:
         # For non-vision models, choose between BatchedModelKit

--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -195,6 +195,7 @@ def load_model(
     kv_group_size: Optional[int] = None,
     quantized_kv_start: Optional[int] = None,
     prefill_step_size: Optional[int] = None,
+    auto_fit_context: bool = False,
 ) -> LoadedModelKit:
     """
     Load a language model or vision-language model from the specified path.
@@ -215,6 +216,8 @@ def load_model(
         quantized_kv_start (Optional[int]): Step to begin KV cache quantization when enabled.
         prefill_step_size (Optional[int]): Number of tokens to process per prefill chunk.
             Defaults to PROMPT_PROCESSING_CHUNK_SIZE when None.
+        auto_fit_context (bool): Calculate and report a recommended context length for
+            batched VLMs.
 
     Returns:
         LoadedModelKit: An initialized model instance:
@@ -265,6 +268,7 @@ def load_model(
             max_seq_nums=max_seq_nums,
             trust_remote_code=trust_remote_code,
             seed=seed,
+            auto_fit_context=auto_fit_context,
         )
     else:
         # For non-vision models, choose between BatchedModelKit
@@ -327,6 +331,14 @@ def load_model(
         sanitize_eos_tokens(model_kit)
     model_kit.start()
     return model_kit
+
+
+def get_runtime_load_info(model_kit: LoadedModelKit) -> dict:
+    """Return load-time values discovered by the running model kit."""
+    context_length = getattr(model_kit, "effective_context_length", None)
+    if context_length is None:
+        return {}
+    return {"context_length": context_length}
 
 
 def load_draft_model(

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -1,0 +1,313 @@
+import gc
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+from mlx_lm.models.cache import make_prompt_cache
+
+logger = logging.getLogger(__name__)
+
+
+GIB = 1024**3
+MIN_FITTED_CONTEXT_TOKENS = 4_096
+MIN_RUNTIME_RESERVE_BYTES = 3 * GIB
+
+_FAMILY_GEMMA4 = "gemma4"
+_FAMILY_QWEN3_5 = "qwen3_5"
+_SUPPORTED_CACHE_TYPES = {
+    _FAMILY_GEMMA4: {"KVCache", "RotatingKVCache"},
+    _FAMILY_QWEN3_5: {"KVCache", "ArraysCache"},
+}
+
+
+@dataclass(frozen=True)
+class CacheFitProfile:
+    family: str
+    allocation_step: int
+    full_kv_bytes_per_token: int
+    prompt_embedding_bytes_per_token: int
+    query_attention_heads: int
+    activation_dtype_bytes: int
+    prefill_step_size: int
+    rotating_peak_bytes: int
+    fixed_ssm_bytes: int
+    max_context_length: int
+
+
+@dataclass(frozen=True)
+class ContextFitResult:
+    context_length: int
+    runtime_reserve_bytes: int
+    safe_ceiling_bytes: int
+
+
+def fit_batched_vlm_context(
+    *,
+    model: Any,
+    prefill_step_size: int,
+) -> int:
+    """Return the context length that the loaded model should use.
+
+    A one-token probe measures the model's cache, embedding, and activation
+    layout. The fit leaves a runtime reserve, subtracts fixed memory, then uses
+    the remaining memory for KV, retained prompt embeddings, and chunked
+    attention work. The return value is the fitted token limit. If fitting fails,
+    the error is logged and `max_position_embeddings` is returned instead.
+    """
+    language_model = getattr(model, "language_model", model)
+    max_context_length = getattr(
+        getattr(language_model, "config", None),
+        "max_position_embeddings",
+        None,
+    )
+    if max_context_length is None:
+        max_context_length = language_model.args.max_position_embeddings
+
+    try:
+        model_type = language_model.model_type.lower()
+        if model_type.startswith("gemma4"):
+            family = _FAMILY_GEMMA4
+        elif model_type.startswith(("qwen3_5", "qwen3_6")):
+            family = _FAMILY_QWEN3_5
+        else:
+            logger.error(
+                "Unsupported model family %s; using max context %s",
+                model_type,
+                f"{max_context_length:,}",
+            )
+            return max_context_length
+
+        try:
+            profile = _probe_cache_fit_profile(
+                model=model,
+                language_model=language_model,
+                family=family,
+                max_context_length=max_context_length,
+                prefill_step_size=prefill_step_size,
+            )
+        finally:
+            # Release the temporary probe arrays before measuring the loaded model.
+            mx.synchronize()
+            gc.collect()
+            mx.clear_cache()
+            mx.synchronize()
+
+        if profile is None:
+            return max_context_length
+
+        # Count live model memory plus reusable MLX buffers left after the probe.
+        baseline_bytes = mx.get_active_memory() + mx.get_cache_memory()
+        working_set_bytes = mx.device_info()["max_recommended_working_set_size"]
+        result = calculate_context_fit(
+            profile,
+            working_set_bytes=working_set_bytes,
+            baseline_bytes=baseline_bytes,
+        )
+
+        attention_workspace_bytes_per_token = (
+            profile.query_attention_heads
+            * profile.prefill_step_size
+            * profile.activation_dtype_bytes
+        )
+        peak_bytes_per_token = (
+            profile.full_kv_bytes_per_token
+            + profile.prompt_embedding_bytes_per_token
+            + attention_workspace_bytes_per_token
+        )
+        estimated_memory_bytes = (
+            baseline_bytes
+            + profile.rotating_peak_bytes
+            + profile.fixed_ssm_bytes
+            + peak_bytes_per_token * result.context_length
+        )
+        logger.info(
+            "Model context auto-fit: family=%s max=%s fitted=%s "
+            "working_set=%.2fGiB reserve=%.2fGiB safe_ceiling=%.2fGiB "
+            "baseline=%.2fGiB full_kv=%dB/token embedding=%dB/token "
+            "attention=%dB/token rotating_peak=%.2fGiB fixed_ssm=%.2fGiB "
+            "estimated_peak=%.2fGiB",
+            profile.family,
+            f"{max_context_length:,}",
+            f"{result.context_length:,}",
+            working_set_bytes / GIB,
+            result.runtime_reserve_bytes / GIB,
+            result.safe_ceiling_bytes / GIB,
+            baseline_bytes / GIB,
+            profile.full_kv_bytes_per_token,
+            profile.prompt_embedding_bytes_per_token,
+            attention_workspace_bytes_per_token,
+            profile.rotating_peak_bytes / GIB,
+            profile.fixed_ssm_bytes / GIB,
+            estimated_memory_bytes / GIB,
+        )
+        return result.context_length
+    except Exception:
+        logger.exception(
+            "Model context auto-fit failed; using max context %s",
+            f"{max_context_length:,}",
+        )
+        return max_context_length
+
+
+def calculate_context_fit(
+    profile: CacheFitProfile,
+    *,
+    working_set_bytes: int,
+    baseline_bytes: int,
+) -> ContextFitResult:
+    """Calculate the context limit from the model's measured memory costs.
+
+    The fit subtracts the runtime reserve and fixed memory from the recommended
+    working set. It divides what remains by the per-token peak for KV, retained
+    prompt embeddings, and chunked attention work. The result contains the
+    chosen token limit and the reserve and safe ceiling used to calculate it.
+    """
+    # The modeled terms undercounted measured prefill peaks by at most 2.41 GiB.
+    # Leave 3 GiB for that variation, or 5% on very large working sets.
+    runtime_reserve_bytes = max(MIN_RUNTIME_RESERVE_BYTES, working_set_bytes // 20)
+    safe_ceiling_bytes = working_set_bytes - runtime_reserve_bytes
+    fixed_memory_bytes = (
+        baseline_bytes + profile.rotating_peak_bytes + profile.fixed_ssm_bytes
+    )
+    attention_workspace_bytes_per_token = (
+        profile.query_attention_heads
+        * profile.prefill_step_size
+        * profile.activation_dtype_bytes
+    )
+    peak_bytes_per_token = (
+        profile.full_kv_bytes_per_token
+        + profile.prompt_embedding_bytes_per_token
+        + attention_workspace_bytes_per_token
+    )
+
+    # These three per-token costs coexist near the end of a long prompt prefill.
+    available_context_bytes = max(0, safe_ceiling_bytes - fixed_memory_bytes)
+    memory_limited_context = available_context_bytes // peak_bytes_per_token
+    allocation_step = profile.allocation_step
+    context_length = (
+        (memory_limited_context + allocation_step - 1)
+        // allocation_step
+        * allocation_step
+    )
+    if context_length < MIN_FITTED_CONTEXT_TOKENS:
+        logger.warning(
+            "Model context auto-fit calculated %s tokens; using the %s token minimum",
+            f"{context_length:,}",
+            f"{MIN_FITTED_CONTEXT_TOKENS:,}",
+        )
+        context_length = MIN_FITTED_CONTEXT_TOKENS
+    context_length = min(profile.max_context_length, context_length)
+
+    return ContextFitResult(
+        context_length=context_length,
+        runtime_reserve_bytes=runtime_reserve_bytes,
+        safe_ceiling_bytes=safe_ceiling_bytes,
+    )
+
+
+def _probe_cache_fit_profile(
+    *,
+    model: Any,
+    language_model: Any,
+    family: str,
+    max_context_length: int,
+    prefill_step_size: int,
+) -> CacheFitProfile | None:
+    prompt_cache = make_prompt_cache(language_model)
+    # One token is enough to allocate every cache in its real shape and dtype.
+    input_ids = mx.zeros((1, 1), dtype=mx.int32)
+    embedding_kwargs = {
+        key: value
+        for key, value in model.get_input_embeddings(input_ids).to_dict().items()
+        if value is not None
+    }
+    inputs_embeds = embedding_kwargs.pop("inputs_embeds")
+    prompt_embedding_bytes_per_token = inputs_embeds.nbytes
+    activation_dtype_bytes = inputs_embeds.itemsize
+    language_config = getattr(language_model, "config", None)
+    query_attention_heads = getattr(language_config, "num_attention_heads", None)
+    if query_attention_heads is None:
+        query_attention_heads = language_model.args.num_attention_heads
+
+    language_model(
+        input_ids,
+        cache=prompt_cache,
+        inputs_embeds=inputs_embeds,
+        **embedding_kwargs,
+    )
+    mx.eval([cache.state for cache in prompt_cache])
+    mx.synchronize()
+
+    # Full KV grows with context. Rotating KV and Qwen SSM state are fixed costs.
+    full_kv_bytes_per_token = 0
+    rotating_peak_bytes = 0
+    fixed_ssm_bytes = 0
+    # KV caches grow in token blocks. Every layer must use the same block size so
+    # one rounded context length describes the whole model.
+    cache_allocation_steps = set()
+
+    for cache in prompt_cache:
+        cache_type = type(cache).__name__
+        if cache_type not in _SUPPORTED_CACHE_TYPES[family]:
+            logger.error(
+                "Unsupported %s in %s cache topology; using max context %s",
+                cache_type,
+                family,
+                f"{max_context_length:,}",
+            )
+            return None
+
+        if cache_type == "KVCache":
+            full_kv_bytes_per_token += cache.nbytes // cache.keys.shape[2]
+            cache_allocation_steps.add(cache.step)
+        elif cache_type == "RotatingKVCache":
+            if cache.keep != 0:
+                logger.error(
+                    "Gemma4 rotating cache uses keep=%s; using max context %s",
+                    cache.keep,
+                    f"{max_context_length:,}",
+                )
+                return None
+            rotating_peak_bytes += (
+                cache.nbytes
+                // cache.keys.shape[2]
+                * (cache.max_size + prefill_step_size - 1)
+            )
+            cache_allocation_steps.add(cache.step)
+        else:
+            # Qwen Gated DeltaNet keeps convolution history and recurrent state.
+            if len(cache.cache) != 2 or any(state is None for state in cache.cache):
+                logger.error(
+                    "Qwen ArraysCache probe did not initialize both states; "
+                    "using max context %s",
+                    f"{max_context_length:,}",
+                )
+                return None
+            fixed_ssm_bytes += cache.nbytes
+
+    if full_kv_bytes_per_token == 0:
+        logger.error(
+            "Model cache has no full KV layers; using max context %s",
+            f"{max_context_length:,}",
+        )
+        return None
+    if len(cache_allocation_steps) != 1:
+        logger.error(
+            "MLX prompt caches use inconsistent allocation steps; using max context %s",
+            f"{max_context_length:,}",
+        )
+        return None
+
+    return CacheFitProfile(
+        family=family,
+        allocation_step=next(iter(cache_allocation_steps)),
+        full_kv_bytes_per_token=full_kv_bytes_per_token,
+        prompt_embedding_bytes_per_token=prompt_embedding_bytes_per_token,
+        query_attention_heads=query_attention_heads,
+        activation_dtype_bytes=activation_dtype_bytes,
+        prefill_step_size=prefill_step_size,
+        rotating_peak_bytes=rotating_peak_bytes,
+        fixed_ssm_bytes=fixed_ssm_bytes,
+        max_context_length=max_context_length,
+    )

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -144,7 +144,7 @@ def fit_batched_vlm_context(
             mx.synchronize()
 
         if profile is None:
-            return max_context_length if validated_family else None
+            return None
 
         # Active arrays and allocator cache both occupy unified memory. Together
         # they are the starting cost before the prompt grows.
@@ -203,12 +203,6 @@ def fit_batched_vlm_context(
         )
         return result.context_length
     except Exception:
-        if validated_family and max_context_length is not None:
-            logger.exception(
-                "Model context auto-fit failed; using max context %s",
-                f"{max_context_length:,}",
-            )
-            return max_context_length
         logger.exception("Model context auto-fit failed; leaving context unchanged")
         return None
 

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -4,7 +4,8 @@ A model's native context limit does not account for its loaded weights or the
 memory needed to read a long prompt. Guessing by allocating progressively larger
 prompts is unsafe because a Metal out-of-memory error can terminate the process.
 Instead, a one-token probe reveals the loaded model's real cache shapes and
-dtypes, then the fit uses:
+dtypes, then uses the formula below. The fitted override is limited to Gemma 4
+and Qwen 3.5; other model families keep their existing context behavior.
 
     fixed = loaded baseline + rotating cache + recurrent state
     bytes/token = full KV + prompt embedding + attention workspace
@@ -70,37 +71,44 @@ def fit_batched_vlm_context(
     *,
     model: Any,
     prefill_step_size: int,
-) -> int:
-    """Return the context length that the loaded model should use.
+) -> int | None:
+    """Return a fitted token limit, or `None` to leave the limit unchanged.
 
     A one-token probe measures the model's cache, embedding, and activation
     layout. The fit leaves a runtime reserve, subtracts fixed memory, then uses
     the remaining memory for KV, retained prompt embeddings, and chunked
-    attention work. The return value is the fitted token limit. If fitting fails,
-    the error is logged and `max_position_embeddings` is returned instead.
+    attention work. Unsupported families return `None`. Errors fall back to the
+    model's maximum context when it is known, otherwise they also return `None`.
     """
-    language_model = getattr(model, "language_model", model)
-    max_context_length = getattr(
-        getattr(language_model, "config", None),
-        "max_position_embeddings",
-        None,
-    )
-    if max_context_length is None:
-        max_context_length = language_model.args.max_position_embeddings
-
+    max_context_length = None
     try:
-        model_type = language_model.model_type.lower()
+        language_model = getattr(model, "language_model", model)
+        language_config = getattr(language_model, "config", None)
+        language_args = getattr(language_model, "args", None)
+        model_type = str(
+            getattr(language_model, "model_type", None)
+            or getattr(language_config, "model_type", None)
+            or getattr(language_args, "model_type", "")
+        ).lower()
         if model_type.startswith("gemma4"):
             family = _FAMILY_GEMMA4
         elif model_type.startswith(("qwen3_5", "qwen3_6")):
             family = _FAMILY_QWEN3_5
         else:
-            logger.error(
-                "Unsupported model family %s; using max context %s",
-                model_type,
-                f"{max_context_length:,}",
+            logger.info(
+                "Model family %s does not use context auto-fit; "
+                "leaving context unchanged",
+                model_type or "unknown",
             )
-            return max_context_length
+            return None
+
+        max_context_length = getattr(
+            language_config,
+            "max_position_embeddings",
+            None,
+        )
+        if max_context_length is None:
+            max_context_length = language_args.max_position_embeddings
 
         try:
             profile = _probe_cache_fit_profile(
@@ -169,6 +177,12 @@ def fit_batched_vlm_context(
         )
         return result.context_length
     except Exception:
+        if max_context_length is None:
+            logger.exception(
+                "Model context auto-fit failed before finding a fallback; "
+                "leaving context unchanged"
+            )
+            return None
         logger.exception(
             "Model context auto-fit failed; using max context %s",
             f"{max_context_length:,}",

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -8,7 +8,7 @@ dtypes, then uses the formula below. The formula is validated for Gemma 4 and
 Qwen 3.5, and is used as a best-effort fit for other measurable cache layouts.
 
     fixed = loaded baseline + rotating cache + recurrent state
-    bytes/token = full KV + prompt embedding + attention workspace
+    bytes/token = full KV + retained prompt inputs + attention workspace
     context = (recommended working set - reserve - fixed) / bytes/token
 
 Long-prefill experiments on dense and MoE Qwen and Gemma models showed that
@@ -54,7 +54,7 @@ class CacheFitProfile:
     family: str
     allocation_step: int
     full_kv_bytes_per_token: int
-    prompt_embedding_bytes_per_token: int
+    prompt_input_bytes_per_token: int
     query_attention_heads: int
     activation_dtype_bytes: int
     prefill_step_size: int
@@ -77,9 +77,9 @@ def fit_batched_vlm_context(
 ) -> int | None:
     """Return a fitted token limit, or `None` to leave the limit unchanged.
 
-    A one-token probe measures the model's cache, embedding, and activation
-    layout. Gemma 4 and Qwen 3.5 use the validated fit. Other families use the
-    same fit when their memory layout can be measured without assumptions.
+    A one-token probe measures the model's cache, retained prompt inputs, and
+    activation layout. Gemma 4 and Qwen 3.5 use the validated fit. Other families
+    use the same fit when their memory layout can be measured without assumptions.
     """
     max_context_length = None
     validated_family = False
@@ -172,7 +172,7 @@ def fit_batched_vlm_context(
         )
         peak_bytes_per_token = (
             profile.full_kv_bytes_per_token
-            + profile.prompt_embedding_bytes_per_token
+            + profile.prompt_input_bytes_per_token
             + attention_workspace_bytes_per_token
         )
         estimated_memory_bytes = (
@@ -184,7 +184,7 @@ def fit_batched_vlm_context(
         logger.info(
             "Model context auto-fit: family=%s max=%s fitted=%s "
             "working_set=%.2fGiB reserve=%.2fGiB safe_ceiling=%.2fGiB "
-            "baseline=%.2fGiB full_kv=%dB/token embedding=%dB/token "
+            "baseline=%.2fGiB full_kv=%dB/token prompt_inputs=%dB/token "
             "attention=%dB/token rotating_peak=%.2fGiB fixed_ssm=%.2fGiB "
             "estimated_peak=%.2fGiB",
             profile.family,
@@ -195,7 +195,7 @@ def fit_batched_vlm_context(
             result.safe_ceiling_bytes / GIB,
             baseline_bytes / GIB,
             profile.full_kv_bytes_per_token,
-            profile.prompt_embedding_bytes_per_token,
+            profile.prompt_input_bytes_per_token,
             attention_workspace_bytes_per_token,
             profile.rotating_peak_bytes / GIB,
             profile.fixed_ssm_bytes / GIB,
@@ -217,7 +217,7 @@ def calculate_context_fit(
 
     The fit subtracts the runtime reserve and fixed memory from the recommended
     working set. It divides what remains by the per-token peak for KV, retained
-    prompt embeddings, and chunked attention work. The result contains the
+    prompt inputs, and chunked attention work. The result contains the
     chosen token limit and the reserve and safe ceiling used to calculate it.
     """
     # The modeled terms undercounted measured prefill peaks by at most 2.41 GiB.
@@ -239,7 +239,7 @@ def calculate_context_fit(
     )
     peak_bytes_per_token = (
         profile.full_kv_bytes_per_token
-        + profile.prompt_embedding_bytes_per_token
+        + profile.prompt_input_bytes_per_token
         + attention_workspace_bytes_per_token
     )
 
@@ -291,9 +291,12 @@ def _probe_cache_fit_profile(
         if value is not None
     }
     inputs_embeds = embedding_kwargs.pop("inputs_embeds")
-    # With one token, embedding nbytes is directly the retained bytes/token;
-    # itemsize gives the activation dtype size used by attention.
-    prompt_embedding_bytes_per_token = inputs_embeds.nbytes
+    # Gemma 4 keeps per-layer inputs alive for the full prompt too.
+    prompt_input_bytes_per_token = inputs_embeds.nbytes
+    per_layer_inputs = embedding_kwargs.get("per_layer_inputs")
+    if per_layer_inputs is not None:
+        prompt_input_bytes_per_token += per_layer_inputs.nbytes
+    # Attention uses the same activation dtype as the token embeddings.
     activation_dtype_bytes = inputs_embeds.itemsize
 
     language_config = getattr(language_model, "config", None)
@@ -383,7 +386,7 @@ def _probe_cache_fit_profile(
         family=family,
         allocation_step=next(iter(cache_allocation_steps)),
         full_kv_bytes_per_token=full_kv_bytes_per_token,
-        prompt_embedding_bytes_per_token=prompt_embedding_bytes_per_token,
+        prompt_input_bytes_per_token=prompt_input_bytes_per_token,
         query_attention_heads=query_attention_heads,
         activation_dtype_bytes=activation_dtype_bytes,
         prefill_step_size=prefill_step_size,

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -4,8 +4,8 @@ A model's native context limit does not account for its loaded weights or the
 memory needed to read a long prompt. Guessing by allocating progressively larger
 prompts is unsafe because a Metal out-of-memory error can terminate the process.
 Instead, a one-token probe reveals the loaded model's real cache shapes and
-dtypes, then uses the formula below. The fitted override is limited to Gemma 4
-and Qwen 3.5; other model families keep their existing context behavior.
+dtypes, then uses the formula below. The formula is validated for Gemma 4 and
+Qwen 3.5, and is used as a best-effort fit for other measurable cache layouts.
 
     fixed = loaded baseline + rotating cache + recurrent state
     bytes/token = full KV + prompt embedding + attention workspace
@@ -40,10 +40,13 @@ MIN_RUNTIME_RESERVE_BYTES = 3 * GIB
 
 _FAMILY_GEMMA4 = "gemma4"
 _FAMILY_QWEN3_5 = "qwen3_5"
-_SUPPORTED_CACHE_TYPES = {
-    _FAMILY_GEMMA4: {"KVCache", "RotatingKVCache"},
-    _FAMILY_QWEN3_5: {"KVCache", "ArraysCache"},
-}
+_SUPPORTED_CACHE_TYPES = {"KVCache", "RotatingKVCache", "ArraysCache"}
+
+
+def _config_value(config: Any, key: str) -> Any:
+    if isinstance(config, dict):
+        return config.get(key)
+    return getattr(config, key, None)
 
 
 @dataclass(frozen=True)
@@ -75,40 +78,55 @@ def fit_batched_vlm_context(
     """Return a fitted token limit, or `None` to leave the limit unchanged.
 
     A one-token probe measures the model's cache, embedding, and activation
-    layout. The fit leaves a runtime reserve, subtracts fixed memory, then uses
-    the remaining memory for KV, retained prompt embeddings, and chunked
-    attention work. Unsupported families return `None`. Errors fall back to the
-    model's maximum context when it is known, otherwise they also return `None`.
+    layout. Gemma 4 and Qwen 3.5 use the validated fit. Other families use the
+    same fit when their memory layout can be measured without assumptions.
     """
     max_context_length = None
+    validated_family = False
     try:
         language_model = getattr(model, "language_model", model)
         language_config = getattr(language_model, "config", None)
         language_args = getattr(language_model, "args", None)
-        model_type = str(
-            getattr(language_model, "model_type", None)
-            or getattr(language_config, "model_type", None)
-            or getattr(language_args, "model_type", "")
-        ).lower()
+        model_config = getattr(model, "config", None)
+        text_config = _config_value(model_config, "text_config")
+        config_sources = (
+            language_config,
+            language_args,
+            text_config,
+            model_config,
+        )
+        model_type = getattr(language_model, "model_type", None)
+        for source in config_sources:
+            if model_type is not None:
+                break
+            model_type = _config_value(source, "model_type")
+        model_type = str(model_type or "unknown").lower()
         if model_type.startswith("gemma4"):
             family = _FAMILY_GEMMA4
+            validated_family = True
         elif model_type.startswith(("qwen3_5", "qwen3_6")):
             family = _FAMILY_QWEN3_5
+            validated_family = True
         else:
-            logger.info(
-                "Model family %s does not use context auto-fit; "
-                "leaving context unchanged",
-                model_type or "unknown",
+            family = model_type
+
+        for source in config_sources:
+            max_context_length = _config_value(source, "max_position_embeddings")
+            if max_context_length is not None:
+                break
+        if max_context_length is None:
+            logger.error(
+                "Model context auto-fit could not find the native context; "
+                "leaving context unchanged"
             )
             return None
-
-        max_context_length = getattr(
-            language_config,
-            "max_position_embeddings",
-            None,
-        )
-        if max_context_length is None:
-            max_context_length = language_args.max_position_embeddings
+        if not validated_family and max_context_length <= MIN_FITTED_CONTEXT_TOKENS:
+            logger.info(
+                "Model family %s reports a %s token maximum; leaving context unchanged",
+                family,
+                f"{max_context_length:,}",
+            )
+            return None
 
         try:
             profile = _probe_cache_fit_profile(
@@ -126,7 +144,7 @@ def fit_batched_vlm_context(
             mx.synchronize()
 
         if profile is None:
-            return max_context_length
+            return max_context_length if validated_family else None
 
         # Active arrays and allocator cache both occupy unified memory. Together
         # they are the starting cost before the prompt grows.
@@ -138,6 +156,14 @@ def fit_batched_vlm_context(
             working_set_bytes=working_set_bytes,
             baseline_bytes=baseline_bytes,
         )
+        if not validated_family and result.context_length <= MIN_FITTED_CONTEXT_TOKENS:
+            logger.info(
+                "Best-effort context fit for model family %s was only %s tokens; "
+                "leaving context unchanged",
+                family,
+                f"{result.context_length:,}",
+            )
+            return None
 
         attention_workspace_bytes_per_token = (
             profile.query_attention_heads
@@ -177,17 +203,14 @@ def fit_batched_vlm_context(
         )
         return result.context_length
     except Exception:
-        if max_context_length is None:
+        if validated_family and max_context_length is not None:
             logger.exception(
-                "Model context auto-fit failed before finding a fallback; "
-                "leaving context unchanged"
+                "Model context auto-fit failed; using max context %s",
+                f"{max_context_length:,}",
             )
-            return None
-        logger.exception(
-            "Model context auto-fit failed; using max context %s",
-            f"{max_context_length:,}",
-        )
-        return max_context_length
+            return max_context_length
+        logger.exception("Model context auto-fit failed; leaving context unchanged")
+        return None
 
 
 def calculate_context_fit(
@@ -279,11 +302,15 @@ def _probe_cache_fit_profile(
     prompt_embedding_bytes_per_token = inputs_embeds.nbytes
     activation_dtype_bytes = inputs_embeds.itemsize
 
-    # Gemma exposes text settings on config, while Qwen exposes them on args.
     language_config = getattr(language_model, "config", None)
-    query_attention_heads = getattr(language_config, "num_attention_heads", None)
+    language_args = getattr(language_model, "args", None)
+    query_attention_heads = _config_value(
+        language_config, "num_attention_heads"
+    ) or _config_value(language_args, "num_attention_heads")
     if query_attention_heads is None:
-        query_attention_heads = language_model.args.num_attention_heads
+        query_attention_heads = _config_value(
+            language_config, "n_heads"
+        ) or _config_value(language_args, "n_heads")
 
     language_model(
         input_ids,
@@ -304,12 +331,11 @@ def _probe_cache_fit_profile(
 
     for cache in prompt_cache:
         cache_type = type(cache).__name__
-        if cache_type not in _SUPPORTED_CACHE_TYPES[family]:
+        if cache_type not in _SUPPORTED_CACHE_TYPES:
             logger.error(
-                "Unsupported %s in %s cache topology; using max context %s",
+                "Unsupported %s in %s cache topology; skipping context auto-fit",
                 cache_type,
                 family,
-                f"{max_context_length:,}",
             )
             return None
 
@@ -321,9 +347,9 @@ def _probe_cache_fit_profile(
         elif cache_type == "RotatingKVCache":
             if cache.keep != 0:
                 logger.error(
-                    "Gemma4 rotating cache uses keep=%s; using max context %s",
+                    "Rotating cache in %s uses keep=%s; skipping context auto-fit",
+                    family,
                     cache.keep,
-                    f"{max_context_length:,}",
                 )
                 return None
             # One layer can briefly hold its window plus the new prefill chunk,
@@ -335,26 +361,27 @@ def _probe_cache_fit_profile(
             )
             cache_allocation_steps.add(cache.step)
         else:
-            # Qwen Gated DeltaNet keeps convolution history and recurrent state.
-            if len(cache.cache) != 2 or any(state is None for state in cache.cache):
+            # ArraysCache holds fixed-size convolution or recurrent state.
+            if any(state is None for state in cache.cache):
                 logger.error(
-                    "Qwen ArraysCache probe did not initialize both states; "
-                    "using max context %s",
-                    f"{max_context_length:,}",
+                    "ArraysCache probe for %s left state uninitialized; "
+                    "skipping context auto-fit",
+                    family,
                 )
                 return None
             fixed_ssm_bytes += cache.nbytes
 
     if full_kv_bytes_per_token == 0:
         logger.error(
-            "Model cache has no full KV layers; using max context %s",
-            f"{max_context_length:,}",
+            "Model cache for %s has no full KV layers; skipping context auto-fit",
+            family,
         )
         return None
     if len(cache_allocation_steps) != 1:
         logger.error(
-            "MLX prompt caches use inconsistent allocation steps; using max context %s",
-            f"{max_context_length:,}",
+            "Model cache for %s uses inconsistent allocation steps; "
+            "skipping context auto-fit",
+            family,
         )
         return None
 

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -12,9 +12,8 @@ dtypes, then the fit uses:
 
 Long-prefill experiments on dense and MoE Qwen and Gemma models showed that
 attention memory matched `query heads * prefill chunk * activation dtype size`.
-They also showed that MLX does not retain a second model-wide KV cache, so
-full KV is counted once. The largest measured peak not explained by these
-terms was 2.41 GiB, motivating the 3 GiB reserve floor.
+The largest measured peak not explained by the formula was 2.41 GiB,
+motivating the 3 GiB reserve floor.
 
 For example, Qwen 3.6 35B-A3B on a 27 GiB working set has about 19.06 GiB of
 fixed memory and uses 88 KiB per token. After the 3 GiB reserve, the formula
@@ -213,17 +212,19 @@ def calculate_context_fit(
         + attention_workspace_bytes_per_token
     )
 
-    # These three per-token costs coexist near the end of a long prompt prefill.
-    available_context_bytes = max(0, safe_ceiling_bytes - fixed_memory_bytes)
-    memory_limited_context = available_context_bytes // peak_bytes_per_token
+    # First find how many bytes remain for the prompt after paying the model's
+    # fixed costs. If those costs already exceed the ceiling, zero bytes remain.
+    available_prompt_bytes = max(0, safe_ceiling_bytes - fixed_memory_bytes)
+
+    # Dividing the remaining bytes by one token's peak cost gives the number of
+    # prompt tokens that fit in memory.
+    tokens_that_fit = available_prompt_bytes // peak_bytes_per_token
 
     # MLX allocates KV in token blocks. Round to the measured block boundary;
     # the reserve absorbs the less-than-one-block difference.
     allocation_step = profile.allocation_step
     context_length = (
-        (memory_limited_context + allocation_step - 1)
-        // allocation_step
-        * allocation_step
+        (tokens_that_fit + allocation_step - 1) // allocation_step * allocation_step
     )
     if context_length < MIN_FITTED_CONTEXT_TOKENS:
         logger.warning(
@@ -299,8 +300,8 @@ def _probe_cache_fit_profile(
             return None
 
         if cache_type == "KVCache":
-            # nbytes already includes keys and values. Divide by allocated token
-            # width; experiments showed no second model-wide KV to multiply by 2.
+            # nbytes includes both keys and values. Divide by the allocated token
+            # width to get the cost of one token.
             full_kv_bytes_per_token += cache.nbytes // cache.keys.shape[2]
             cache_allocation_steps.add(cache.step)
         elif cache_type == "RotatingKVCache":

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -1,3 +1,26 @@
+"""Fit a model's context length to the available unified memory.
+
+A model's native context limit does not account for its loaded weights or the
+memory needed to read a long prompt. Guessing by allocating progressively larger
+prompts is unsafe because a Metal out-of-memory error can terminate the process.
+Instead, a one-token probe reveals the loaded model's real cache shapes and
+dtypes, then the fit uses:
+
+    fixed = loaded baseline + rotating cache + recurrent state
+    bytes/token = full KV + prompt embedding + attention workspace
+    context = (recommended working set - reserve - fixed) / bytes/token
+
+Long-prefill experiments on dense and MoE Qwen and Gemma models showed that
+attention memory matched `query heads * prefill chunk * activation dtype size`.
+They also showed that MLX does not retain a second model-wide KV cache, so
+full KV is counted once. The largest measured peak not explained by these
+terms was 2.41 GiB, motivating the 3 GiB reserve floor.
+
+For example, Qwen 3.6 35B-A3B on a 27 GiB working set has about 19.06 GiB of
+fixed memory and uses 88 KiB per token. After the 3 GiB reserve, the formula
+fits 58,846 tokens, which rounds to a 58,880-token cache boundary.
+"""
+
 import gc
 import logging
 from dataclasses import dataclass
@@ -10,7 +33,9 @@ logger = logging.getLogger(__name__)
 
 
 GIB = 1024**3
+# Product minimum; the fitted value is still capped by the model's native limit.
 MIN_FITTED_CONTEXT_TOKENS = 4_096
+# Round the largest 2.41 GiB unexplained experimental peak up to 3 GiB.
 MIN_RUNTIME_RESERVE_BYTES = 3 * GIB
 
 _FAMILY_GEMMA4 = "gemma4"
@@ -96,8 +121,10 @@ def fit_batched_vlm_context(
         if profile is None:
             return max_context_length
 
-        # Count live model memory plus reusable MLX buffers left after the probe.
+        # Active arrays and allocator cache both occupy unified memory. Together
+        # they are the starting cost before the prompt grows.
         baseline_bytes = mx.get_active_memory() + mx.get_cache_memory()
+        # Apple's recommended working set is the process budget, not total RAM.
         working_set_bytes = mx.device_info()["max_recommended_working_set_size"]
         result = calculate_context_fit(
             profile,
@@ -167,9 +194,14 @@ def calculate_context_fit(
     # Leave 3 GiB for that variation, or 5% on very large working sets.
     runtime_reserve_bytes = max(MIN_RUNTIME_RESERVE_BYTES, working_set_bytes // 20)
     safe_ceiling_bytes = working_set_bytes - runtime_reserve_bytes
+    # These costs do not grow with the ordinary full-context KV cache.
     fixed_memory_bytes = (
         baseline_bytes + profile.rotating_peak_bytes + profile.fixed_ssm_bytes
     )
+
+    # Long-prefill measurements matched one activation value per query head and
+    # prefill token for every context token. The dtype size is measured at runtime
+    # rather than assuming the tested models' two-byte BF16/FP16 activations.
     attention_workspace_bytes_per_token = (
         profile.query_attention_heads
         * profile.prefill_step_size
@@ -184,6 +216,9 @@ def calculate_context_fit(
     # These three per-token costs coexist near the end of a long prompt prefill.
     available_context_bytes = max(0, safe_ceiling_bytes - fixed_memory_bytes)
     memory_limited_context = available_context_bytes // peak_bytes_per_token
+
+    # MLX allocates KV in token blocks. Round to the measured block boundary;
+    # the reserve absorbs the less-than-one-block difference.
     allocation_step = profile.allocation_step
     context_length = (
         (memory_limited_context + allocation_step - 1)
@@ -197,6 +232,7 @@ def calculate_context_fit(
             f"{MIN_FITTED_CONTEXT_TOKENS:,}",
         )
         context_length = MIN_FITTED_CONTEXT_TOKENS
+    # Available memory never permits extending the model beyond its native limit.
     context_length = min(profile.max_context_length, context_length)
 
     return ContextFitResult(
@@ -223,8 +259,12 @@ def _probe_cache_fit_profile(
         if value is not None
     }
     inputs_embeds = embedding_kwargs.pop("inputs_embeds")
+    # With one token, embedding nbytes is directly the retained bytes/token;
+    # itemsize gives the activation dtype size used by attention.
     prompt_embedding_bytes_per_token = inputs_embeds.nbytes
     activation_dtype_bytes = inputs_embeds.itemsize
+
+    # Gemma exposes text settings on config, while Qwen exposes them on args.
     language_config = getattr(language_model, "config", None)
     query_attention_heads = getattr(language_config, "num_attention_heads", None)
     if query_attention_heads is None:
@@ -259,6 +299,8 @@ def _probe_cache_fit_profile(
             return None
 
         if cache_type == "KVCache":
+            # nbytes already includes keys and values. Divide by allocated token
+            # width; experiments showed no second model-wide KV to multiply by 2.
             full_kv_bytes_per_token += cache.nbytes // cache.keys.shape[2]
             cache_allocation_steps.add(cache.step)
         elif cache_type == "RotatingKVCache":
@@ -269,6 +311,8 @@ def _probe_cache_fit_profile(
                     f"{max_context_length:,}",
                 )
                 return None
+            # One layer can briefly hold its window plus the new prefill chunk,
+            # with one overlapping token: max_size + prefill_step_size - 1.
             rotating_peak_bytes += (
                 cache.nbytes
                 // cache.keys.shape[2]

--- a/mlx_engine/model_kit/batched_vision/model_kit.py
+++ b/mlx_engine/model_kit/batched_vision/model_kit.py
@@ -22,6 +22,7 @@ from mlx_engine.model_kit.batched_model_kit_types import (
 from mlx_engine.model_kit.batched_vision.batch_generator import (
     BatchGenerator as LocalVlmBatchGenerator,
 )
+from mlx_engine.model_kit.batched_vision.context_fit import fit_batched_vlm_context
 from mlx_engine.model_kit.batched_vision.prompt_cache.coordinator import (
     VlmPromptCacheCoordinator,
 )
@@ -126,6 +127,7 @@ class BatchedVisionModelKit:
         max_seq_nums: int | None = DEFAULT_MAX_SEQ_NUMS,
         trust_remote_code: bool = False,
         seed: int | None = None,
+        auto_fit_context: bool = False,
     ):
         # External requests and internal generation events share one queue so
         # restore completions wake the generation thread without polling.
@@ -137,6 +139,8 @@ class BatchedVisionModelKit:
         self._startup_complete = Event()
         self.prefill_step_size = prefill_step_size
         self._model_path = model_path
+        self._auto_fit_context = auto_fit_context
+        self._effective_context_length: int | None = None
         if max_seq_nums is None:
             max_seq_nums = DEFAULT_MAX_SEQ_NUMS
         elif max_seq_nums < 1:
@@ -229,6 +233,16 @@ class BatchedVisionModelKit:
         patch_loaded_gemma4_model(self.model)
         mx.synchronize()
         mx.clear_cache()
+
+        if self._auto_fit_context:
+            self._effective_context_length = fit_batched_vlm_context(
+                model=self.model,
+                prefill_step_size=self.prefill_step_size,
+            )
+
+    @property
+    def effective_context_length(self) -> int | None:
+        return self._effective_context_length
 
     def start(self):
         self._generation_thread = Thread(

--- a/mlx_engine/model_kit/batched_vision/model_kit.py
+++ b/mlx_engine/model_kit/batched_vision/model_kit.py
@@ -127,7 +127,6 @@ class BatchedVisionModelKit:
         max_seq_nums: int | None = DEFAULT_MAX_SEQ_NUMS,
         trust_remote_code: bool = False,
         seed: int | None = None,
-        auto_fit_context: bool = False,
     ):
         # External requests and internal generation events share one queue so
         # restore completions wake the generation thread without polling.
@@ -139,7 +138,6 @@ class BatchedVisionModelKit:
         self._startup_complete = Event()
         self.prefill_step_size = prefill_step_size
         self._model_path = model_path
-        self._auto_fit_context = auto_fit_context
         self._effective_context_length: int | None = None
         if max_seq_nums is None:
             max_seq_nums = DEFAULT_MAX_SEQ_NUMS
@@ -234,11 +232,10 @@ class BatchedVisionModelKit:
         mx.synchronize()
         mx.clear_cache()
 
-        if self._auto_fit_context:
-            self._effective_context_length = fit_batched_vlm_context(
-                model=self.model,
-                prefill_step_size=self.prefill_step_size,
-            )
+        self._effective_context_length = fit_batched_vlm_context(
+            model=self.model,
+            prefill_step_size=self.prefill_step_size,
+        )
 
     @property
     def effective_context_length(self) -> int | None:

--- a/mlx_engine/model_kit/batched_vision/model_kit.py
+++ b/mlx_engine/model_kit/batched_vision/model_kit.py
@@ -232,10 +232,18 @@ class BatchedVisionModelKit:
         mx.synchronize()
         mx.clear_cache()
 
-        self._effective_context_length = fit_batched_vlm_context(
-            model=self.model,
-            prefill_step_size=self.prefill_step_size,
-        )
+        if _requires_global_no_chunked_prefill(
+            self.model,
+            self.model_type,
+            self._uses_gemma4_bidirectional_visual_attention,
+        ):
+            logger.info("Model requires unchunked prefill; leaving context unchanged")
+            self._effective_context_length = None
+        else:
+            self._effective_context_length = fit_batched_vlm_context(
+                model=self.model,
+                prefill_step_size=self.prefill_step_size,
+            )
 
     @property
     def effective_context_length(self) -> int | None:

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -145,6 +145,20 @@ def test_probe_counts_actual_qwen_arrays_state_bytes(monkeypatch):
     assert profile.query_attention_heads == 16
 
 
+def test_probe_accepts_single_fixed_array_state(monkeypatch):
+    arrays_cache = ArraysCache(size=1)
+    arrays_cache[0] = mx.ones((1, 3, 4), dtype=mx.float16)
+    mx.eval(arrays_cache.state)
+
+    profile = _probe_profile(
+        monkeypatch,
+        [_initialized_kv_cache(), arrays_cache],
+        family="other_vlm",
+    )
+
+    assert profile.fixed_ssm_bytes == arrays_cache.nbytes
+
+
 def test_probe_rejects_unknown_cache_type(monkeypatch, caplog):
     class UnknownCache:
         state = []
@@ -468,49 +482,99 @@ def test_qwen3_6_uses_args_context(monkeypatch):
     assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 8_192
 
 
-@pytest.mark.parametrize(
-    "model_type",
-    [
-        "pixtral",
-        "mistral",
-        "lfm2-vl",
-        "lfm2_vl",
-        "lfm2",
-        "mistral3",
-        "ministral3",
-        "qwen2_vl",
-        "qwen2_5_vl",
-        "qwen3_vl",
-        "qwen3_vl_text",
-        "qwen3_vl_moe",
-        "llava_next",
-        "mllama",
-        "paligemma",
-        "gemma2",
-        "gemma3",
-        "gemma3_text",
-        "gemma3n",
-        "gemma3n_text",
-        "granite4_vision",
-        "granitemoehybrid",
-        "future_vlm",
-        None,
-    ],
-)
-def test_unsupported_families_leave_context_unchanged(monkeypatch, caplog, model_type):
+def test_other_family_uses_best_effort_fit(monkeypatch):
+    language_model = SimpleNamespace(
+        config=SimpleNamespace(
+            model_type="other_vlm",
+            max_position_embeddings=8_192,
+        )
+    )
+    model = SimpleNamespace(language_model=language_model)
+    monkeypatch.setattr(
+        context_fit,
+        "_probe_cache_fit_profile",
+        lambda **_kwargs: _profile(
+            family="other_vlm",
+            max_context_length=8_192,
+            full_kv_bytes_per_token=512 * KIB,
+        ),
+    )
+    monkeypatch.setattr(context_fit.mx, "get_active_memory", lambda: 0)
+    monkeypatch.setattr(context_fit.mx, "get_cache_memory", lambda: 0)
+    monkeypatch.setattr(
+        context_fit.mx,
+        "device_info",
+        lambda: {"max_recommended_working_set_size": 10 * GIB},
+    )
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 8_192
+
+
+def test_other_family_leaves_low_reported_maximum_unchanged(monkeypatch, caplog):
     probe_called = False
 
     def unexpected_probe(**_kwargs):
         nonlocal probe_called
         probe_called = True
 
+    language_model = SimpleNamespace(
+        model_type="other_vlm",
+        config=SimpleNamespace(max_position_embeddings=4_096),
+    )
+    model = SimpleNamespace(language_model=language_model)
     monkeypatch.setattr(context_fit, "_probe_cache_fit_profile", unexpected_probe)
     caplog.set_level("INFO")
-    model = SimpleNamespace(language_model=SimpleNamespace(model_type=model_type))
 
     assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
     assert not probe_called
     assert "leaving context unchanged" in caplog.text
+
+
+def test_other_family_does_not_override_context_with_minimum_fit(monkeypatch):
+    profile = _profile(
+        family="other_vlm",
+        max_context_length=100_000,
+    )
+    language_model = SimpleNamespace(
+        model_type="other_vlm",
+        config=SimpleNamespace(max_position_embeddings=100_000),
+    )
+    model = SimpleNamespace(language_model=language_model)
+    monkeypatch.setattr(
+        context_fit,
+        "_probe_cache_fit_profile",
+        lambda **_kwargs: profile,
+    )
+    monkeypatch.setattr(
+        context_fit.mx,
+        "get_active_memory",
+        lambda: 7 * GIB - 2_000 * _peak_bytes_per_token(profile),
+    )
+    monkeypatch.setattr(context_fit.mx, "get_cache_memory", lambda: 0)
+    monkeypatch.setattr(
+        context_fit.mx,
+        "device_info",
+        lambda: {"max_recommended_working_set_size": 10 * GIB},
+    )
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
+
+
+def test_other_family_leaves_context_unchanged_when_probe_is_unsupported(
+    monkeypatch,
+):
+    language_model = SimpleNamespace(
+        model_type="other_vlm",
+        config=SimpleNamespace(max_position_embeddings=32_768),
+    )
+    model = SimpleNamespace(language_model=language_model)
+    monkeypatch.setattr(
+        context_fit,
+        "_probe_cache_fit_profile",
+        lambda **_kwargs: None,
+    )
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
 
 
 def test_fit_leaves_context_unchanged_when_fallback_is_unknown(caplog):

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -68,7 +68,7 @@ def _profile(
     family="gemma4",
     max_context_length=100_000,
     full_kv_bytes_per_token=MIB,
-    prompt_embedding_bytes_per_token=4 * KIB,
+    prompt_input_bytes_per_token=4 * KIB,
     query_attention_heads=8,
     activation_dtype_bytes=2,
     prefill_step_size=2_048,
@@ -79,7 +79,7 @@ def _profile(
         family=family,
         allocation_step=256,
         full_kv_bytes_per_token=full_kv_bytes_per_token,
-        prompt_embedding_bytes_per_token=prompt_embedding_bytes_per_token,
+        prompt_input_bytes_per_token=prompt_input_bytes_per_token,
         query_attention_heads=query_attention_heads,
         activation_dtype_bytes=activation_dtype_bytes,
         prefill_step_size=prefill_step_size,
@@ -92,7 +92,7 @@ def _profile(
 def _peak_bytes_per_token(profile):
     return (
         profile.full_kv_bytes_per_token
-        + profile.prompt_embedding_bytes_per_token
+        + profile.prompt_input_bytes_per_token
         + profile.query_attention_heads
         * profile.prefill_step_size
         * profile.activation_dtype_bytes
@@ -109,10 +109,29 @@ def test_probe_sums_full_kv_bytes_from_real_allocation(monkeypatch):
     assert profile.full_kv_bytes_per_token == (
         first_cache.nbytes // 256 + second_cache.nbytes // 256
     )
-    assert profile.prompt_embedding_bytes_per_token == 4
+    assert profile.prompt_input_bytes_per_token == 4
     assert profile.query_attention_heads == 8
     assert profile.activation_dtype_bytes == 2
     assert profile.prefill_step_size == 2_048
+
+
+def test_probe_counts_retained_per_layer_inputs(monkeypatch):
+    class EmbeddingOutput:
+        def to_dict(self):
+            return {
+                "inputs_embeds": mx.ones((1, 1, 2), dtype=mx.float16),
+                "per_layer_inputs": mx.ones((1, 1, 3, 4), dtype=mx.float16),
+            }
+
+    monkeypatch.setattr(
+        _ProbeModel,
+        "get_input_embeddings",
+        lambda _self, _input_ids: EmbeddingOutput(),
+    )
+
+    profile = _probe_profile(monkeypatch, [_initialized_kv_cache()])
+
+    assert profile.prompt_input_bytes_per_token == 4 + 24
 
 
 def test_probe_uses_rotating_prefill_peak(monkeypatch):
@@ -296,7 +315,7 @@ def test_fit_uses_minimum_when_fixed_memory_reaches_ceiling():
                 family="qwen3_5",
                 max_context_length=262_144,
                 full_kv_bytes_per_token=12_288,
-                prompt_embedding_bytes_per_token=4_096,
+                prompt_input_bytes_per_token=4_096,
                 query_attention_heads=8,
                 fixed_ssm_bytes=19_537_920,
             ),
@@ -309,7 +328,7 @@ def test_fit_uses_minimum_when_fixed_memory_reaches_ceiling():
                 family="qwen3_5",
                 max_context_length=262_144,
                 full_kv_bytes_per_token=20_480,
-                prompt_embedding_bytes_per_token=4_096,
+                prompt_input_bytes_per_token=4_096,
                 query_attention_heads=16,
                 fixed_ssm_bytes=64_389_120,
             ),
@@ -322,7 +341,7 @@ def test_fit_uses_minimum_when_fixed_memory_reaches_ceiling():
                 family="qwen3_5",
                 max_context_length=262_144,
                 full_kv_bytes_per_token=65_536,
-                prompt_embedding_bytes_per_token=10_240,
+                prompt_input_bytes_per_token=10_240,
                 query_attention_heads=24,
                 fixed_ssm_bytes=153_944_064,
             ),
@@ -334,7 +353,7 @@ def test_fit_uses_minimum_when_fixed_memory_reaches_ceiling():
             _profile(
                 max_context_length=131_072,
                 full_kv_bytes_per_token=6_144,
-                prompt_embedding_bytes_per_token=3_072,
+                prompt_input_bytes_per_token=20_992,
                 query_attention_heads=8,
                 rotating_peak_bytes=31_444_992,
             ),
@@ -346,7 +365,7 @@ def test_fit_uses_minimum_when_fixed_memory_reaches_ceiling():
             _profile(
                 max_context_length=262_144,
                 full_kv_bytes_per_token=20_480,
-                prompt_embedding_bytes_per_token=5_632,
+                prompt_input_bytes_per_token=5_632,
                 query_attention_heads=16,
                 rotating_peak_bytes=628_940_800,
             ),
@@ -358,7 +377,7 @@ def test_fit_uses_minimum_when_fixed_memory_reaches_ceiling():
             _profile(
                 max_context_length=262_144,
                 full_kv_bytes_per_token=16_384,
-                prompt_embedding_bytes_per_token=7_680,
+                prompt_input_bytes_per_token=7_680,
                 query_attention_heads=16,
                 rotating_peak_bytes=1_006_305_280,
             ),
@@ -370,7 +389,7 @@ def test_fit_uses_minimum_when_fixed_memory_reaches_ceiling():
             _profile(
                 max_context_length=262_144,
                 full_kv_bytes_per_token=16_384,
-                prompt_embedding_bytes_per_token=7_680,
+                prompt_input_bytes_per_token=7_680,
                 query_attention_heads=16,
                 rotating_peak_bytes=1_006_305_280,
             ),
@@ -403,7 +422,7 @@ def test_fit_scales_across_memory_tiers(working_set_gib, expected_context):
     profile = _profile(
         max_context_length=262_144,
         full_kv_bytes_per_token=16_384,
-        prompt_embedding_bytes_per_token=7_680,
+        prompt_input_bytes_per_token=7_680,
         query_attention_heads=16,
         rotating_peak_bytes=1_006_305_280,
     )

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -577,6 +577,23 @@ def test_other_family_leaves_context_unchanged_when_probe_is_unsupported(
     assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
 
 
+def test_validated_family_leaves_context_unchanged_when_probe_is_unsupported(
+    monkeypatch,
+):
+    language_model = SimpleNamespace(
+        model_type="gemma4_text",
+        config=SimpleNamespace(max_position_embeddings=32_768),
+    )
+    model = SimpleNamespace(language_model=language_model)
+    monkeypatch.setattr(
+        context_fit,
+        "_probe_cache_fit_profile",
+        lambda **_kwargs: None,
+    )
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
+
+
 def test_fit_leaves_context_unchanged_when_fallback_is_unknown(caplog):
     language_model = SimpleNamespace(
         model_type="gemma4_text",
@@ -588,7 +605,7 @@ def test_fit_leaves_context_unchanged_when_fallback_is_unknown(caplog):
     assert "leaving context unchanged" in caplog.text
 
 
-def test_fit_logs_and_falls_back_when_probe_raises(monkeypatch, caplog):
+def test_fit_logs_and_leaves_context_unchanged_when_probe_raises(monkeypatch, caplog):
     language_model = SimpleNamespace(
         model_type="gemma4_text",
         config=SimpleNamespace(max_position_embeddings=16_384),
@@ -604,5 +621,5 @@ def test_fit_logs_and_falls_back_when_probe_raises(monkeypatch, caplog):
         raise_probe_error,
     )
 
-    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 16_384
-    assert "using max context 16,384" in caplog.text
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
+    assert "failed; leaving context unchanged" in caplog.text

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -468,12 +468,77 @@ def test_qwen3_6_uses_args_context(monkeypatch):
     assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 8_192
 
 
-def test_fit_logs_and_falls_back_for_unsupported_family(caplog):
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "pixtral",
+        "mistral",
+        "lfm2-vl",
+        "lfm2_vl",
+        "lfm2",
+        "mistral3",
+        "ministral3",
+        "qwen2_vl",
+        "qwen2_5_vl",
+        "qwen3_vl",
+        "qwen3_vl_text",
+        "qwen3_vl_moe",
+        "llava_next",
+        "mllama",
+        "paligemma",
+        "gemma2",
+        "gemma3",
+        "gemma3_text",
+        "gemma3n",
+        "gemma3n_text",
+        "granite4_vision",
+        "granitemoehybrid",
+        "future_vlm",
+        None,
+    ],
+)
+def test_unsupported_families_leave_context_unchanged(monkeypatch, caplog, model_type):
+    probe_called = False
+
+    def unexpected_probe(**_kwargs):
+        nonlocal probe_called
+        probe_called = True
+
+    monkeypatch.setattr(context_fit, "_probe_cache_fit_profile", unexpected_probe)
+    caplog.set_level("INFO")
+    model = SimpleNamespace(language_model=SimpleNamespace(model_type=model_type))
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
+    assert not probe_called
+    assert "leaving context unchanged" in caplog.text
+
+
+def test_fit_leaves_context_unchanged_when_fallback_is_unknown(caplog):
     language_model = SimpleNamespace(
-        model_type="unsupported",
+        model_type="gemma4_text",
+        config=SimpleNamespace(model_type="gemma4_text"),
+    )
+    model = SimpleNamespace(language_model=language_model)
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
+    assert "leaving context unchanged" in caplog.text
+
+
+def test_fit_logs_and_falls_back_when_probe_raises(monkeypatch, caplog):
+    language_model = SimpleNamespace(
+        model_type="gemma4_text",
         config=SimpleNamespace(max_position_embeddings=16_384),
     )
     model = SimpleNamespace(language_model=language_model)
+
+    def raise_probe_error(**_kwargs):
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(
+        context_fit,
+        "_probe_cache_fit_profile",
+        raise_probe_error,
+    )
 
     assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 16_384
     assert "using max context 16,384" in caplog.text

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -1,0 +1,479 @@
+from types import SimpleNamespace
+
+import pytest
+
+import mlx.core as mx
+from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
+
+from mlx_engine.model_kit.batched_vision import context_fit
+from mlx_engine.model_kit.batched_vision.context_fit import (
+    CacheFitProfile,
+    calculate_context_fit,
+    fit_batched_vlm_context,
+)
+
+
+GIB = 1024**3
+MIB = 1024**2
+KIB = 1024
+
+
+class _EmbeddingOutput:
+    def to_dict(self):
+        return {"inputs_embeds": mx.ones((1, 1, 2), dtype=mx.float16)}
+
+
+class _ProbeModel:
+    def get_input_embeddings(self, _input_ids):
+        return _EmbeddingOutput()
+
+
+class _ProbeLanguageModel:
+    config = SimpleNamespace(num_attention_heads=8)
+
+    def __call__(self, *_args, **_kwargs):
+        return None
+
+
+def _initialized_kv_cache(cache=None, *, heads=1, head_dim=2, dtype=mx.float16):
+    if cache is None:
+        cache = KVCache()
+    keys = mx.ones((1, heads, 1, head_dim), dtype=dtype)
+    cache.update_and_fetch(keys, keys)
+    mx.eval(cache.state)
+    return cache
+
+
+def _probe_profile(
+    monkeypatch,
+    prompt_cache,
+    *,
+    family="gemma4",
+    language_model=None,
+):
+    if language_model is None:
+        language_model = _ProbeLanguageModel()
+    monkeypatch.setattr(context_fit, "make_prompt_cache", lambda _model: prompt_cache)
+    return context_fit._probe_cache_fit_profile(
+        model=_ProbeModel(),
+        language_model=language_model,
+        family=family,
+        max_context_length=8_192,
+        prefill_step_size=2_048,
+    )
+
+
+def _profile(
+    *,
+    family="gemma4",
+    max_context_length=100_000,
+    full_kv_bytes_per_token=MIB,
+    prompt_embedding_bytes_per_token=4 * KIB,
+    query_attention_heads=8,
+    activation_dtype_bytes=2,
+    prefill_step_size=2_048,
+    rotating_peak_bytes=0,
+    fixed_ssm_bytes=0,
+):
+    return CacheFitProfile(
+        family=family,
+        allocation_step=256,
+        full_kv_bytes_per_token=full_kv_bytes_per_token,
+        prompt_embedding_bytes_per_token=prompt_embedding_bytes_per_token,
+        query_attention_heads=query_attention_heads,
+        activation_dtype_bytes=activation_dtype_bytes,
+        prefill_step_size=prefill_step_size,
+        rotating_peak_bytes=rotating_peak_bytes,
+        fixed_ssm_bytes=fixed_ssm_bytes,
+        max_context_length=max_context_length,
+    )
+
+
+def _peak_bytes_per_token(profile):
+    return (
+        profile.full_kv_bytes_per_token
+        + profile.prompt_embedding_bytes_per_token
+        + profile.query_attention_heads
+        * profile.prefill_step_size
+        * profile.activation_dtype_bytes
+    )
+
+
+def test_probe_sums_full_kv_bytes_from_real_allocation(monkeypatch):
+    first_cache = _initialized_kv_cache(heads=1, head_dim=2)
+    second_cache = _initialized_kv_cache(heads=2, head_dim=4)
+
+    profile = _probe_profile(monkeypatch, [first_cache, second_cache])
+
+    assert profile.allocation_step == 256
+    assert profile.full_kv_bytes_per_token == (
+        first_cache.nbytes // 256 + second_cache.nbytes // 256
+    )
+    assert profile.prompt_embedding_bytes_per_token == 4
+    assert profile.query_attention_heads == 8
+    assert profile.activation_dtype_bytes == 2
+    assert profile.prefill_step_size == 2_048
+
+
+def test_probe_uses_rotating_prefill_peak(monkeypatch):
+    kv_cache = _initialized_kv_cache()
+    rotating_cache = _initialized_kv_cache(RotatingKVCache(max_size=1_024, keep=0))
+
+    profile = _probe_profile(monkeypatch, [kv_cache, rotating_cache])
+
+    rotating_bytes_per_token = rotating_cache.nbytes // rotating_cache.keys.shape[2]
+    assert profile.rotating_peak_bytes == rotating_bytes_per_token * (1_024 + 2_048 - 1)
+
+
+def test_probe_counts_actual_qwen_arrays_state_bytes(monkeypatch):
+    arrays_cache = ArraysCache(size=2)
+    arrays_cache[0] = mx.ones((1, 3, 4), dtype=mx.float16)
+    arrays_cache[1] = mx.ones((1, 2, 2), dtype=mx.float16)
+    mx.eval(arrays_cache.state)
+    language_model = _ProbeLanguageModel()
+    language_model.config = SimpleNamespace()
+    language_model.args = SimpleNamespace(num_attention_heads=16)
+
+    profile = _probe_profile(
+        monkeypatch,
+        [_initialized_kv_cache(), arrays_cache],
+        family="qwen3_5",
+        language_model=language_model,
+    )
+
+    assert profile.fixed_ssm_bytes == arrays_cache.nbytes
+    assert profile.query_attention_heads == 16
+
+
+def test_probe_rejects_unknown_cache_type(monkeypatch, caplog):
+    class UnknownCache:
+        state = []
+
+    profile = _probe_profile(
+        monkeypatch,
+        [_initialized_kv_cache(), UnknownCache()],
+    )
+
+    assert profile is None
+    assert "Unsupported UnknownCache" in caplog.text
+
+
+def test_probe_rejects_rotating_keep(monkeypatch):
+    rotating_cache = _initialized_kv_cache(RotatingKVCache(max_size=1_024, keep=4))
+
+    profile = _probe_profile(
+        monkeypatch,
+        [_initialized_kv_cache(), rotating_cache],
+    )
+
+    assert profile is None
+
+
+def test_probe_rejects_inconsistent_allocation_steps(monkeypatch):
+    alternate_cache = type("KVCache", (), {})()
+    alternate_cache.keys = mx.ones((1, 1, 128, 1), dtype=mx.float16)
+    alternate_cache.nbytes = alternate_cache.keys.nbytes * 2
+    alternate_cache.step = 128
+    alternate_cache.state = (alternate_cache.keys, alternate_cache.keys)
+
+    profile = _probe_profile(
+        monkeypatch,
+        [_initialized_kv_cache(), alternate_cache],
+    )
+
+    assert profile is None
+
+
+def test_probe_rejects_empty_qwen_state(monkeypatch):
+    arrays_cache = ArraysCache(size=2)
+    arrays_cache[0] = mx.ones((1, 3, 4), dtype=mx.float16)
+
+    profile = _probe_profile(
+        monkeypatch,
+        [_initialized_kv_cache(), arrays_cache],
+        family="qwen3_5",
+    )
+
+    assert profile is None
+
+
+def test_fit_clamps_to_max_context():
+    result = calculate_context_fit(
+        _profile(
+            max_context_length=8_192,
+            full_kv_bytes_per_token=512 * KIB,
+        ),
+        working_set_bytes=10 * GIB,
+        baseline_bytes=0,
+    )
+
+    assert result.context_length == 8_192
+    assert result.safe_ceiling_bytes == 7 * GIB
+
+
+def test_fit_rounds_up_to_allocation_step():
+    profile = _profile()
+    result = calculate_context_fit(
+        profile,
+        working_set_bytes=10 * GIB,
+        baseline_bytes=7 * GIB - 5_000 * _peak_bytes_per_token(profile),
+    )
+
+    assert result.context_length == 5_120
+
+
+def test_fit_accepts_exactly_minimum_context():
+    profile = _profile()
+    result = calculate_context_fit(
+        profile,
+        working_set_bytes=10 * GIB,
+        baseline_bytes=7 * GIB - 4_096 * _peak_bytes_per_token(profile),
+    )
+
+    assert result.context_length == 4_096
+
+
+def test_fit_raises_a_small_result_to_minimum(caplog):
+    profile = _profile()
+    result = calculate_context_fit(
+        profile,
+        working_set_bytes=10 * GIB,
+        baseline_bytes=7 * GIB - 2_000 * _peak_bytes_per_token(profile),
+    )
+
+    assert result.context_length == 4_096
+    assert "using the 4,096 token minimum" in caplog.text
+
+
+def test_runtime_reserve_uses_five_percent_or_three_gib():
+    percentage_result = calculate_context_fit(
+        _profile(max_context_length=4_096),
+        working_set_bytes=80 * GIB,
+        baseline_bytes=0,
+    )
+    minimum_result = calculate_context_fit(
+        _profile(max_context_length=4_096),
+        working_set_bytes=16 * GIB,
+        baseline_bytes=0,
+    )
+
+    assert percentage_result.runtime_reserve_bytes == 4 * GIB
+    assert percentage_result.safe_ceiling_bytes == 76 * GIB
+    assert minimum_result.runtime_reserve_bytes == 3 * GIB
+    assert minimum_result.safe_ceiling_bytes == 13 * GIB
+
+
+def test_fit_uses_minimum_when_fixed_memory_reaches_ceiling():
+    result = calculate_context_fit(
+        _profile(fixed_ssm_bytes=GIB),
+        working_set_bytes=10 * GIB,
+        baseline_bytes=6 * GIB,
+    )
+
+    assert result.context_length == 4_096
+
+
+# These profiles use measurements from the target models on a 27 GiB working set.
+@pytest.mark.parametrize(
+    ("profile", "baseline_bytes", "expected_context"),
+    [
+        pytest.param(
+            _profile(
+                family="qwen3_5",
+                max_context_length=262_144,
+                full_kv_bytes_per_token=12_288,
+                prompt_embedding_bytes_per_token=4_096,
+                query_attention_heads=8,
+                fixed_ssm_bytes=19_537_920,
+            ),
+            1_722_151_626,
+            262_144,
+            id="qwen-3.5-2b-dense-4bit",
+        ),
+        pytest.param(
+            _profile(
+                family="qwen3_5",
+                max_context_length=262_144,
+                full_kv_bytes_per_token=20_480,
+                prompt_embedding_bytes_per_token=4_096,
+                query_attention_heads=16,
+                fixed_ssm_bytes=64_389_120,
+            ),
+            20_402_597_098,
+            58_880,
+            id="qwen-3.6-35b-a3b-moe-4bit",
+        ),
+        pytest.param(
+            _profile(
+                family="qwen3_5",
+                max_context_length=262_144,
+                full_kv_bytes_per_token=65_536,
+                prompt_embedding_bytes_per_token=10_240,
+                query_attention_heads=24,
+                fixed_ssm_bytes=153_944_064,
+            ),
+            16_055_717_354,
+            55_040,
+            id="qwen-3.6-27b-dense-4bit",
+        ),
+        pytest.param(
+            _profile(
+                max_context_length=131_072,
+                full_kv_bytes_per_token=6_144,
+                prompt_embedding_bytes_per_token=3_072,
+                query_attention_heads=8,
+                rotating_peak_bytes=31_444_992,
+            ),
+            4_339_854_220,
+            131_072,
+            id="gemma-4-e2b-dense-4bit",
+        ),
+        pytest.param(
+            _profile(
+                max_context_length=262_144,
+                full_kv_bytes_per_token=20_480,
+                prompt_embedding_bytes_per_token=5_632,
+                query_attention_heads=16,
+                rotating_peak_bytes=628_940_800,
+            ),
+            15_611_655_610,
+            104_192,
+            id="gemma-4-26b-a4b-moe-4bit",
+        ),
+        pytest.param(
+            _profile(
+                max_context_length=262_144,
+                full_kv_bytes_per_token=16_384,
+                prompt_embedding_bytes_per_token=7_680,
+                query_attention_heads=16,
+                rotating_peak_bytes=1_006_305_280,
+            ),
+            10_990_079_092,
+            153_856,
+            id="gemma-4-12b-dense-4bit",
+        ),
+        pytest.param(
+            _profile(
+                max_context_length=262_144,
+                full_kv_bytes_per_token=16_384,
+                prompt_embedding_bytes_per_token=7_680,
+                query_attention_heads=16,
+                rotating_peak_bytes=1_006_305_280,
+            ),
+            12_718_509_172,
+            134_656,
+            id="gemma-4-12b-dense-8bit",
+        ),
+    ],
+)
+def test_fit_matches_measured_model_profiles(profile, baseline_bytes, expected_context):
+    result = calculate_context_fit(
+        profile,
+        working_set_bytes=27 * GIB,
+        baseline_bytes=baseline_bytes,
+    )
+
+    assert result.context_length == expected_context
+
+
+@pytest.mark.parametrize(
+    ("working_set_gib", "expected_context"),
+    [
+        pytest.param(16, 4_096, id="lower-memory"),
+        pytest.param(27, 134_656, id="tested-memory"),
+        pytest.param(48, 262_144, id="higher-memory"),
+        pytest.param(96, 262_144, id="percentage-reserve"),
+    ],
+)
+def test_fit_scales_across_memory_tiers(working_set_gib, expected_context):
+    profile = _profile(
+        max_context_length=262_144,
+        full_kv_bytes_per_token=16_384,
+        prompt_embedding_bytes_per_token=7_680,
+        query_attention_heads=16,
+        rotating_peak_bytes=1_006_305_280,
+    )
+
+    result = calculate_context_fit(
+        profile,
+        working_set_bytes=working_set_gib * GIB,
+        baseline_bytes=12_718_509_172,
+    )
+
+    assert result.context_length == expected_context
+
+
+def test_one_token_probe_uses_token_zero_and_reports_fit(monkeypatch):
+    prompt_cache = [KVCache()]
+    calls = []
+
+    class LanguageModel:
+        model_type = "gemma4_text"
+        config = SimpleNamespace(
+            max_position_embeddings=8_192,
+            num_attention_heads=1,
+        )
+
+        def __call__(self, input_ids, *, cache, inputs_embeds, **kwargs):
+            calls.append((input_ids.tolist(), inputs_embeds.shape, kwargs))
+            keys = mx.ones((1, 1, 1, 2), dtype=mx.float16)
+            cache[0].update_and_fetch(keys, keys)
+
+    language_model = LanguageModel()
+    model = SimpleNamespace(
+        language_model=language_model,
+        get_input_embeddings=lambda _input_ids: _EmbeddingOutput(),
+    )
+    monkeypatch.setattr(context_fit, "make_prompt_cache", lambda _model: prompt_cache)
+    monkeypatch.setattr(context_fit.mx, "get_active_memory", lambda: GIB)
+    monkeypatch.setattr(context_fit.mx, "get_cache_memory", lambda: 0)
+    monkeypatch.setattr(
+        context_fit.mx,
+        "device_info",
+        lambda: {"max_recommended_working_set_size": 10 * GIB},
+    )
+
+    context_length = fit_batched_vlm_context(
+        model=model,
+        prefill_step_size=2_048,
+    )
+
+    assert calls == [([[0]], (1, 1, 2), {})]
+    assert context_length == 8_192
+
+
+def test_qwen3_6_uses_args_context(monkeypatch):
+    language_model = SimpleNamespace(
+        model_type="qwen3_6_moe",
+        config=SimpleNamespace(),
+        args=SimpleNamespace(max_position_embeddings=8_192),
+    )
+    model = SimpleNamespace(language_model=language_model)
+    monkeypatch.setattr(
+        context_fit,
+        "_probe_cache_fit_profile",
+        lambda **_kwargs: _profile(
+            max_context_length=8_192,
+            full_kv_bytes_per_token=512 * KIB,
+        ),
+    )
+    monkeypatch.setattr(context_fit.mx, "get_active_memory", lambda: 0)
+    monkeypatch.setattr(context_fit.mx, "get_cache_memory", lambda: 0)
+    monkeypatch.setattr(
+        context_fit.mx,
+        "device_info",
+        lambda: {"max_recommended_working_set_size": 10 * GIB},
+    )
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 8_192
+
+
+def test_fit_logs_and_falls_back_for_unsupported_family(caplog):
+    language_model = SimpleNamespace(
+        model_type="unsupported",
+        config=SimpleNamespace(max_position_embeddings=16_384),
+    )
+    model = SimpleNamespace(language_model=language_model)
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 16_384
+    assert "using max context 16,384" in caplog.text

--- a/tests/test_batched_vision_model_kit.py
+++ b/tests/test_batched_vision_model_kit.py
@@ -91,6 +91,7 @@ def test_load_model_forces_no_trust_remote_code(monkeypatch, tmp_path):
     kit._shutdown = SimpleNamespace(is_set=lambda: True)
     kit._model_path = tmp_path
     kit._trust_remote_code = True
+    kit._auto_fit_context = False
 
     kit._load_model()
 
@@ -171,3 +172,43 @@ def test_generate_fatal_error_preserves_state_for_exception_propagation(monkeypa
     assert not FakeController.instance.cancelled
     assert batch_generator.closed
     assert kit._generation_thread_state is not None
+
+
+def test_load_model_stores_context_fit_before_startup(monkeypatch, tmp_path):
+    loaded_model = SimpleNamespace()
+    fitted_context_length = 65_536
+    calls = {}
+
+    monkeypatch.setattr(
+        model_kit_module.mlx_vlm.utils,
+        "load_model",
+        lambda *_args, **_kwargs: loaded_model,
+    )
+    monkeypatch.setattr(
+        model_kit_module,
+        "patch_loaded_gemma4_model",
+        lambda _model: None,
+    )
+    monkeypatch.setattr(model_kit_module.mx, "synchronize", lambda: None)
+    monkeypatch.setattr(model_kit_module.mx, "clear_cache", lambda: None)
+
+    def fake_fit_context(**kwargs):
+        calls["fit"] = kwargs
+        return fitted_context_length
+
+    monkeypatch.setattr(
+        model_kit_module,
+        "fit_batched_vlm_context",
+        fake_fit_context,
+    )
+    kit = object.__new__(BatchedVisionModelKit)
+    kit._shutdown = SimpleNamespace(is_set=lambda: True)
+    kit._model_path = tmp_path
+    kit._auto_fit_context = True
+    kit._effective_context_length = None
+    kit.prefill_step_size = 2_048
+
+    kit._load_model()
+
+    assert kit.effective_context_length == fitted_context_length
+    assert calls["fit"] == {"model": loaded_model, "prefill_step_size": 2_048}

--- a/tests/test_batched_vision_model_kit.py
+++ b/tests/test_batched_vision_model_kit.py
@@ -96,6 +96,8 @@ def test_load_model_forces_no_trust_remote_code(monkeypatch, tmp_path):
     kit._shutdown = SimpleNamespace(is_set=lambda: True)
     kit._model_path = tmp_path
     kit._trust_remote_code = True
+    kit.model_type = "other_vlm"
+    kit._uses_gemma4_bidirectional_visual_attention = False
     kit.prefill_step_size = 2_048
 
     kit._load_model()
@@ -209,9 +211,51 @@ def test_load_model_stores_context_fit_before_startup(monkeypatch, tmp_path):
     kit = object.__new__(BatchedVisionModelKit)
     kit._shutdown = SimpleNamespace(is_set=lambda: True)
     kit._model_path = tmp_path
+    kit.model_type = "other_vlm"
+    kit._uses_gemma4_bidirectional_visual_attention = False
     kit.prefill_step_size = 2_048
 
     kit._load_model()
 
     assert kit.effective_context_length == fitted_context_length
     assert calls["fit"] == {"model": loaded_model, "prefill_step_size": 2_048}
+
+
+def test_load_model_skips_context_fit_for_unchunked_prefill(
+    monkeypatch, tmp_path, caplog
+):
+    loaded_model = SimpleNamespace(no_chunked_prefill=True)
+    monkeypatch.setattr(
+        model_kit_module.mlx_vlm.utils,
+        "load_model",
+        lambda *_args, **_kwargs: loaded_model,
+    )
+    monkeypatch.setattr(
+        model_kit_module,
+        "patch_loaded_gemma4_model",
+        lambda _model: None,
+    )
+    monkeypatch.setattr(model_kit_module.mx, "synchronize", lambda: None)
+    monkeypatch.setattr(model_kit_module.mx, "clear_cache", lambda: None)
+
+    def unexpected_fit(**_kwargs):
+        pytest.fail("context fitting should be skipped")
+
+    monkeypatch.setattr(
+        model_kit_module,
+        "fit_batched_vlm_context",
+        unexpected_fit,
+    )
+    caplog.set_level("INFO")
+
+    kit = object.__new__(BatchedVisionModelKit)
+    kit._shutdown = SimpleNamespace(is_set=lambda: True)
+    kit._model_path = tmp_path
+    kit.model_type = "falcon_ocr"
+    kit._uses_gemma4_bidirectional_visual_attention = False
+    kit.prefill_step_size = 2_048
+
+    kit._load_model()
+
+    assert kit.effective_context_length is None
+    assert "requires unchunked prefill" in caplog.text

--- a/tests/test_batched_vision_model_kit.py
+++ b/tests/test_batched_vision_model_kit.py
@@ -86,12 +86,17 @@ def test_load_model_forces_no_trust_remote_code(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(model_kit_module.mx, "synchronize", lambda: None)
     monkeypatch.setattr(model_kit_module.mx, "clear_cache", lambda: None)
+    monkeypatch.setattr(
+        model_kit_module,
+        "fit_batched_vlm_context",
+        lambda **_kwargs: None,
+    )
 
     kit = object.__new__(BatchedVisionModelKit)
     kit._shutdown = SimpleNamespace(is_set=lambda: True)
     kit._model_path = tmp_path
     kit._trust_remote_code = True
-    kit._auto_fit_context = False
+    kit.prefill_step_size = 2_048
 
     kit._load_model()
 
@@ -204,8 +209,6 @@ def test_load_model_stores_context_fit_before_startup(monkeypatch, tmp_path):
     kit = object.__new__(BatchedVisionModelKit)
     kit._shutdown = SimpleNamespace(is_set=lambda: True)
     kit._model_path = tmp_path
-    kit._auto_fit_context = True
-    kit._effective_context_length = None
     kit.prefill_step_size = 2_048
 
     kit._load_model()

--- a/tests/test_context_auto_fit_integration.py
+++ b/tests/test_context_auto_fit_integration.py
@@ -1,44 +1,6 @@
-import json
 from types import SimpleNamespace
 
-import pytest
-
 import mlx_engine.generate as generate_module
-
-
-class _FakeVisionModelKit:
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-        self.started = False
-
-    def start(self):
-        self.started = True
-
-
-@pytest.mark.parametrize("auto_fit_context", [False, True])
-def test_load_model_forwards_context_auto_fit_to_batched_vision(
-    monkeypatch,
-    tmp_path,
-    auto_fit_context,
-):
-    (tmp_path / "config.json").write_text(json.dumps({"vision_config": {}}))
-    monkeypatch.setattr(
-        generate_module,
-        "BatchedVisionModelKit",
-        _FakeVisionModelKit,
-    )
-    monkeypatch.setattr(generate_module, "sanitize_eos_tokens", lambda _kit: None)
-
-    model_kit = generate_module.load_model(
-        tmp_path,
-        max_kv_size=12_345,
-        auto_fit_context=auto_fit_context,
-    )
-
-    assert model_kit.started
-    assert model_kit.kwargs["max_kv_size"] == 12_345
-    assert model_kit.kwargs["auto_fit_context"] is auto_fit_context
 
 
 def test_runtime_load_info_reports_only_fitted_context():

--- a/tests/test_context_auto_fit_integration.py
+++ b/tests/test_context_auto_fit_integration.py
@@ -1,0 +1,51 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import mlx_engine.generate as generate_module
+
+
+class _FakeVisionModelKit:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+
+@pytest.mark.parametrize("auto_fit_context", [False, True])
+def test_load_model_forwards_context_auto_fit_to_batched_vision(
+    monkeypatch,
+    tmp_path,
+    auto_fit_context,
+):
+    (tmp_path / "config.json").write_text(json.dumps({"vision_config": {}}))
+    monkeypatch.setattr(
+        generate_module,
+        "BatchedVisionModelKit",
+        _FakeVisionModelKit,
+    )
+    monkeypatch.setattr(generate_module, "sanitize_eos_tokens", lambda _kit: None)
+
+    model_kit = generate_module.load_model(
+        tmp_path,
+        max_kv_size=12_345,
+        auto_fit_context=auto_fit_context,
+    )
+
+    assert model_kit.started
+    assert model_kit.kwargs["max_kv_size"] == 12_345
+    assert model_kit.kwargs["auto_fit_context"] is auto_fit_context
+
+
+def test_runtime_load_info_reports_only_fitted_context():
+    fitted_kit = SimpleNamespace(effective_context_length=65_536)
+    ordinary_kit = SimpleNamespace()
+
+    assert generate_module.get_runtime_load_info(fitted_kit) == {
+        "context_length": 65_536
+    }
+    assert generate_module.get_runtime_load_info(ordinary_kit) == {}


### PR DESCRIPTION
## Summary

A model’s native context limit says what its architecture allows, not what a particular Mac can safely run. We need the latter for reliable max context length info.

This PR adds a context fit for batched MLX models and reports the result after load. It does not enforce the limit or change prompt-cache behavior.

## Method

We measured long-prefill and generation memory on various mac systems across dense and MoE Qwen 3.5/3.6 and Gemma 4 models, including 4-bit and 8-bit variants. We continuously monitored MLX memory, system memory, and performance near the practical limit.

The resulting fit uses a one-token probe to measure the loaded model’s real cache shapes and dtypes:

```text
fixed memory = loaded baseline + rotating cache + recurrent state
bytes/token  = full KV + prompt embeddings + attention workspace
context      = (recommended working set - reserve - fixed memory) / bytes/token
```

The reserve is `max(3 GiB, 5% of the recommended working set)`. The largest measured peak not explained by the formula was 2.41 GiB, so the 3 GiB floor leaves a small empirical margin without giving up excessive context. The result is rounded to the model’s cache allocation boundary and capped at its native context limit.

Because weights, cache shapes, and dtypes are measured at runtime, the calculation does not assume a particular model size or quantization.

## Results

The estimate tracked observed peak memory across the tested dense and MoE models without requiring risky large-prompt probes.

For example, Qwen 3.6 35B-A3B on a 27 GiB recommended working set measured about 19.06 GiB of fixed memory and 88 KiB per token. The resulting fit is 58,880 tokens.

A real Qwen 3.5 2B load fit the full native 262,144-token context. Best-effort probing also produced useful results for compatible models such as Qwen 3 VL, Qwen 2.5 VL, Pixtral, and Devstral.

This PR only reports the fitted value through `get_runtime_load_info()`. Enforcement and downstream integration remain separate concerns.

### M3 Max example

These measurements use a 36 GiB M3 Max with a 27 GiB MLX recommended working set:

```text
runtime reserve = max(3 GiB, 5% of 27 GiB) = 3 GiB
safe ceiling    = 27 GiB - 3 GiB = 24 GiB
```

All four models have a native 262,144-token context. Values were measured from the final fitter using the 4-bit variants.

| Model | Baseline | Other fixed memory | Total fixed | Context budget | KV + embedding + attention | Raw fit | Reported fit | Estimated peak |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Qwen 3.6 27B dense | 14.95 GiB | 0.14 GiB SSM | 15.10 GiB | 8.90 GiB | 64 + 10 + 96 = 170 KiB/token | 54,918 | **55,040** | 24.02 GiB |
| Qwen 3.6 35B-A3B MoE | 19.00 GiB | 0.06 GiB SSM | 19.06 GiB | 4.94 GiB | 20 + 4 + 64 = 88 KiB/token | 58,846 | **58,880** | 24.00 GiB |
| Gemma 4 12B dense | 10.24 GiB | 0.94 GiB rotating KV | 11.17 GiB | 12.83 GiB | 16 + 7.5 + 64 = 87.5 KiB/token | 153,719 | **153,856** | 24.01 GiB |
| Gemma 4 26B-A4B MoE | 14.54 GiB | 0.59 GiB rotating KV | 15.13 GiB | 8.87 GiB | 20 + 5.5 + 64 = 89.5 KiB/token | 103,976 | **104,192** | 24.02 GiB |

The raw fit is the context budget divided by total bytes per token. The reported fit rounds up to MLX’s 256-token cache allocation boundary.