### PR TITLE
Update disk cache budget after auto-fit

### DIFF
--- a/mlx_engine/model_kit/batched_vision/model_kit.py
+++ b/mlx_engine/model_kit/batched_vision/model_kit.py
@@ -244,6 +244,10 @@ class BatchedVisionModelKit:
                 model=self.model,
                 prefill_step_size=self.prefill_step_size,
             )
+            if self._effective_context_length is not None:
+                self._prompt_cache_store.ensure_max_kv_size(
+                    self._effective_context_length
+                )
 
     @property
     def effective_context_length(self) -> int | None:

--- a/mlx_engine/model_kit/batched_vision/prompt_cache/cache_store.py
+++ b/mlx_engine/model_kit/batched_vision/prompt_cache/cache_store.py
@@ -115,7 +115,14 @@ class VlmPromptCacheStore:
 
     def ensure_max_kv_size(self, max_kv_size: int) -> None:
         """Keep the larger configured or fitted context as the budget target."""
-        self._max_kv_size = max(self._max_kv_size or 0, max_kv_size)
+        configured_max_kv_size = self._max_kv_size
+        self._max_kv_size = max(configured_max_kv_size or 0, max_kv_size)
+        logger.info(
+            "VLM prompt cache context target: configured=%s fitted=%s effective=%s",
+            "None" if configured_max_kv_size is None else f"{configured_max_kv_size:,}",
+            f"{max_kv_size:,}",
+            f"{self._max_kv_size:,}",
+        )
 
     def plan_longest_prefix_restore(
         self,

--- a/mlx_engine/model_kit/batched_vision/prompt_cache/cache_store.py
+++ b/mlx_engine/model_kit/batched_vision/prompt_cache/cache_store.py
@@ -113,6 +113,10 @@ class VlmPromptCacheStore:
             "cleanup=model_unload_or_process_exit"
         )
 
+    def ensure_max_kv_size(self, max_kv_size: int) -> None:
+        """Keep the larger configured or fitted context as the budget target."""
+        self._max_kv_size = max(self._max_kv_size or 0, max_kv_size)
+
     def plan_longest_prefix_restore(
         self,
         prompt_input_ids: list[int],

--- a/mlx_engine/model_kit/batched_vision/prompt_cache/disk_budget.py
+++ b/mlx_engine/model_kit/batched_vision/prompt_cache/disk_budget.py
@@ -69,7 +69,10 @@ def final_cache_store_budget_bytes(
         desired_bytes,
     )
     logger.info(
-        "VLM prompt cache disk budget: stage=final cap_gib=%.2f limiter=%s",
+        "VLM prompt cache disk budget: stage=final target_tokens=%s "
+        "desired_gib=%.2f cap_gib=%.2f limiter=%s",
+        f"{max_kv_size:,}",
+        _bytes_to_gib(desired_bytes),
         _bytes_to_gib(budget_bytes),
         "free_disk_space" if limited_by_free_disk else "max_kv_size",
     )

--- a/tests/test_batched_vision_cache_store.py
+++ b/tests/test_batched_vision_cache_store.py
@@ -80,12 +80,17 @@ def _save_chunk(
     )
 
 
-def test_cache_store_keeps_larger_configured_or_fitted_context():
+def test_cache_store_keeps_larger_configured_or_fitted_context(caplog):
+    caplog.set_level("INFO")
     store = VlmPromptCacheStore(max_kv_size=131_072)
 
     try:
         store.ensure_max_kv_size(65_536)
         assert store._max_kv_size == 131_072
+        assert (
+            "context target: configured=131,072 fitted=65,536 effective=131,072"
+            in caplog.text
+        )
         store.ensure_max_kv_size(262_144)
         assert store._max_kv_size == 262_144
     finally:

--- a/tests/test_batched_vision_cache_store.py
+++ b/tests/test_batched_vision_cache_store.py
@@ -80,6 +80,18 @@ def _save_chunk(
     )
 
 
+def test_cache_store_keeps_larger_configured_or_fitted_context():
+    store = VlmPromptCacheStore(max_kv_size=131_072)
+
+    try:
+        store.ensure_max_kv_size(65_536)
+        assert store._max_kv_size == 131_072
+        store.ensure_max_kv_size(262_144)
+        assert store._max_kv_size == 262_144
+    finally:
+        store.close()
+
+
 def _assert_two_chunk_restore(loaded):
     kv_keys, kv_values = loaded.prompt_cache[0].state
     boundary_state = loaded.prompt_cache[1][0]

--- a/tests/test_batched_vision_disk_budget.py
+++ b/tests/test_batched_vision_disk_budget.py
@@ -64,9 +64,10 @@ def test_final_budget_requires_max_kv_size(monkeypatch, tmp_path):
     )
 
 
-def test_final_budget_scales_cache_kinds(monkeypatch, tmp_path):
+def test_final_budget_scales_cache_kinds(monkeypatch, tmp_path, caplog):
     """KV/SWA scale to max size, while state scales by checkpoint count."""
     _set_free_disk(monkeypatch, 200 * _GIB)
+    caplog.set_level("INFO")
     max_kv_size = 16
     prompt_cache = [
         _kv_cache(4),
@@ -84,6 +85,10 @@ def test_final_budget_scales_cache_kinds(monkeypatch, tmp_path):
     rotating_bytes = 2 * max_kv_size * 4
     arrays_bytes = 1 * 2 * 3 * 4
     assert budget == kv_bytes + rotating_bytes + arrays_bytes
+    assert (
+        "stage=final target_tokens=16 desired_gib=0.00 cap_gib=0.00 "
+        "limiter=max_kv_size" in caplog.text
+    )
 
     budget = disk_budget.final_cache_store_budget_bytes(
         tmp_path,

--- a/tests/test_batched_vision_model_kit.py
+++ b/tests/test_batched_vision_model_kit.py
@@ -214,11 +214,17 @@ def test_load_model_stores_context_fit_before_startup(monkeypatch, tmp_path):
     kit.model_type = "other_vlm"
     kit._uses_gemma4_bidirectional_visual_attention = False
     kit.prefill_step_size = 2_048
+    kit._prompt_cache_store = SimpleNamespace(
+        ensure_max_kv_size=lambda max_kv_size: calls.update(
+            disk_cache_max_kv_size=max_kv_size
+        )
+    )
 
     kit._load_model()
 
     assert kit.effective_context_length == fitted_context_length
     assert calls["fit"] == {"model": loaded_model, "prefill_step_size": 2_048}
+    assert calls["disk_cache_max_kv_size"] == fitted_context_length
 
 
 def test_load_model_skips_context_fit_for_unchunked_prefill(


### PR DESCRIPTION
If the auto-fitter detects that a larger context size can be used, expand the disk cache capacity. This prevents cache nuking when the harness sends long prompts that is within the auto-fit size.