### PR TITLE
Mask invalid native tool bridge tokens

### DIFF
--- a/mlx_engine/tool_runtime.py
+++ b/mlx_engine/tool_runtime.py
@@ -38,9 +38,6 @@ _QWEN35_TOOLS_RE = re.compile(
 )
 _GEMMA4_CALL_PREFIX = "call:"
 _TOOL_WHITESPACE = (" ", "\n", "\t", "\r")
-# For tiny forced-token states, update only the allowed token ids instead of
-# adding an unnecessary full-vocabulary mask.
-_FORCED_TOOL_LOGIT = 1e9
 _LLG_TOKENIZER_CACHE: dict[tuple[int, int, tuple[int, ...]], Any] = {}
 
 
@@ -304,9 +301,9 @@ class NativeToolReasoningGuardLogitsProcessor:
             # Bridge the first token after a tool-call start without syncing
             # token_id to Python. Starting llguidance here would require
             # token_id.item() on every normal decode step; instead, use an MLX
-            # condition to force the grammar's valid first token only when the
-            # tool-call marker was sampled.
-            logits = _boost_token_ids_mx(
+            # condition to mask all but the grammar's valid first tokens when
+            # the tool-call marker was sampled.
+            logits = _mask_except_token_ids_mx(
                 logits,
                 token_id == self._tool_call_start_token_id,
                 self._initial_tool_token_ids,
@@ -333,8 +330,8 @@ class NativeToolReasoningGuardLogitsProcessor:
                 logits = self._tool_grammar.mask_logits(self._tool_matcher, logits)
 
         elif self._tool_state == self._STATE_POST_TOOL:
-            # If another tool call was sampled, force its first grammar token.
-            logits = _boost_token_ids_mx(
+            # If another tool call was sampled, allow only its first grammar tokens.
+            logits = _mask_except_token_ids_mx(
                 logits,
                 token_id == self._tool_call_start_token_id,
                 self._initial_tool_token_ids,
@@ -477,20 +474,6 @@ def _tokenizer_vocab_size(tokenizer: Any) -> int:
     return max(
         int(tokenizer.vocab_size), max(int(token_id) for token_id in vocab.values()) + 1
     )
-
-
-def _boost_token_ids_mx(
-    logits: mx.array,
-    condition: mx.array,
-    token_ids: tuple[int, ...],
-) -> mx.array:
-    token_id_list = list(token_ids)
-    logits[:, token_id_list] = mx.where(
-        condition,
-        _FORCED_TOOL_LOGIT,
-        logits[:, token_id_list],
-    )
-    return logits
 
 
 def _mask_except_token_ids_mx(

--- a/tests/test_tool_runtime_reasoning_guard.py
+++ b/tests/test_tool_runtime_reasoning_guard.py
@@ -1,3 +1,4 @@
+import math
 from types import SimpleNamespace
 
 import mlx.core as mx
@@ -335,13 +336,28 @@ def test_qwen35_reasoning_guard_does_not_decode_during_generation():
     assert tokenizer.decode_count == decode_count_after_setup
 
 
-def test_qwen35_structure_bridges_after_tool_call_start():
-    processor = _qwen_processor()
-    context = _mx_context()
+def test_qwen35_structure_bridges_after_tool_call_start_for_all_logits_dtypes():
+    for logits_dtype in (mx.float16, mx.bfloat16, mx.float32):
+        processor = _qwen_processor()
+        context = _mx_context()
 
-    logits = _process_token(processor, context, 4)
+        sampled_token_id = _sample_bridge_token(processor, context, logits_dtype)
+        logits = _process_token(processor, context, sampled_token_id)
 
-    assert _forced_token_ids(logits) == [6]
+        assert _forced_token_ids(logits) == [7]
+
+
+def test_qwen35_structure_bridges_adjacent_tool_calls_for_all_logits_dtypes():
+    for logits_dtype in (mx.float16, mx.bfloat16, mx.float32):
+        processor = _qwen_processor()
+        context = _mx_context()
+        for token_id in [4, 6, 7, 8, 9, 10, 11, 12, 5]:
+            _process_token(processor, context, token_id)
+
+        sampled_token_id = _sample_bridge_token(processor, context, logits_dtype)
+        logits = _process_token(processor, context, sampled_token_id)
+
+        assert _forced_token_ids(logits) == [7]
 
 
 def _mx_context():
@@ -360,6 +376,22 @@ def _process_token(processor, context, token_id, logits=None):
 
 def _mx_logits():
     return mx.zeros((1, 24), dtype=mx.float32)
+
+
+def _sample_bridge_token(processor, context, logits_dtype):
+    logits = _process_token(
+        processor,
+        context,
+        4,
+        mx.zeros((1, 24), dtype=logits_dtype),
+    )
+    assert _finite_token_ids(logits) == [6]
+
+    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    sampled_token_id = int(mx.argmax(logprobs, axis=-1).item())
+    assert sampled_token_id == 6
+    assert math.isfinite(logprobs[0, sampled_token_id].item())
+    return sampled_token_id
 
 
 def _post_tool_logits():
@@ -389,12 +421,20 @@ def _forced_token_ids(logits):
     ]
 
 
+def _finite_token_ids(logits):
+    return [
+        token_id
+        for token_id, value in enumerate(logits.reshape(-1).tolist())
+        if math.isfinite(value)
+    ]
+
+
 def test_gemma4_structure_constrains_header_after_tool_call_start():
     processor = _processor()
     context = _mx_context()
 
     logits = _process_token(processor, context, 4)
-    assert _forced_token_ids(logits) == [6]
+    assert _finite_token_ids(logits) == [6]
 
     logits = _process_token(processor, context, 6)
     assert _forced_token_ids(logits) == [7]


### PR DESCRIPTION
Closes #349 

During tool call logit masking, stop boosting tokens and instead mask all of the other tokens. Boosting the tokens caused the issue linked above.