### PR TITLE
Enable disk-backed KV cache for text-only models

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -18,9 +18,9 @@ import threading
 
 from mlx_engine.utils.kv_cache_quantization import get_kv_cache_quantization_params
 from mlx_lm.generate import stream_generate
-from mlx_lm.utils import load as mlx_lm_load
-from mlx_lm.models.cache import make_prompt_cache
+from mlx_vlm.models.cache import make_prompt_cache
 from mlx_vlm.structured import build_json_schema_logits_processor
+from mlx_vlm.utils import load_model as mlx_vlm_load_model
 
 from mlx_engine.model_kit.model_kit import ModelKit
 from mlx_engine.utils.token import Token
@@ -225,7 +225,6 @@ def load_model(
     Returns:
         LoadedModelKit: An initialized model instance:
             - ModelKit: for sequential text-only models and vocab-only loads
-            - BatchedModelKit: for text-only continuous batching
             - BatchedVisionModelKit: for mlx-vlm continuous batching
 
     Raises:
@@ -247,11 +246,8 @@ def load_model(
                 f"The model will process requests sequentially."
             )
 
-    # Determine which model kit to use based on model capabilities and configuration.
-    # The decision tree is:
-    # 1. BatchedVisionModelKit: mlx-vlm continuous batching for VLMs
-    # 2. BatchedModelKit: continuous batching for text-only models
-    # 3. ModelKit: fallback for sequential text-only processing
+    # BatchedVisionModelKit provides mlx-vlm continuous batching for both text
+    # and vision models. ModelKit remains the fallback for sequential text loads.
     if "vision_config" in config_json and vocab_only:
         model_kit = ModelKit(
             model_path,
@@ -273,8 +269,6 @@ def load_model(
             seed=seed,
         )
     else:
-        # For non-vision models, choose between BatchedModelKit
-        # (continuous batching) and ModelKit (sequential).
         kv_bits, kv_group_size, quantized_kv_start = get_kv_cache_quantization_params(
             kv_bits,
             kv_group_size,
@@ -282,13 +276,10 @@ def load_model(
         )
 
         def is_batchable() -> bool:
-            # 0. Ensure the load isn't vocab only
-            if vocab_only:
-                return False
-            # 1. All cache layers must support merge
-            model, _ = mlx_lm_load(model_path, lazy=True)
+            model = mlx_vlm_load_model(model_path, lazy=True)
+            language_model = getattr(model, "language_model", model)
             cache_has_merge_attr = all(
-                hasattr(c, "merge") for c in make_prompt_cache(model)
+                hasattr(cache, "merge") for cache in make_prompt_cache(language_model)
             )
             del model
             if not cache_has_merge_attr:
@@ -296,26 +287,25 @@ def load_model(
                     "this model architecture does not support continuous batching"
                 )
                 return False
-            # 2. KV cache quantization is not compatible with batching yet
-            if kv_bits is not None:
-                warn_if_parallel(
-                    "concurrency is not supported with KV Cache Quantization"
-                )
-                return False
             return True
 
-        # If max_seq_nums is set to 1, use ModelKit instead of BatchedModelKit. This gives users an escape hatch,
-        # which they could use to enable spec decoding. We can remove this additional restriction once we add
-        # spec decoding support to the batched backend
-        use_batched_kit = max_seq_nums != 1 and is_batchable()
+        # max_seq_nums=1 remains an escape hatch for sequential generation and
+        # speculative decoding. KV cache quantization also stays on that path.
+        if vocab_only or max_seq_nums == 1:
+            use_batched_kit = False
+        elif kv_bits is not None:
+            warn_if_parallel("concurrency is not supported with KV Cache Quantization")
+            use_batched_kit = False
+        else:
+            use_batched_kit = is_batchable()
 
         if use_batched_kit:
-            batched_max_seq_nums = 4 if max_seq_nums is None else max_seq_nums
-            model_kit = BatchedModelKit(
+            model_kit = BatchedVisionModelKit(
                 model_path,
                 max_kv_size=max_kv_size,
-                max_seq_nums=batched_max_seq_nums,
+                max_seq_nums=max_seq_nums,
                 prefill_step_size=prefill_step_size,
+                trust_remote_code=trust_remote_code,
                 seed=seed,
             )
         else:

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -120,11 +120,27 @@ def fit_batched_vlm_context(
                 "leaving context unchanged"
             )
             return None
+
         if not validated_family and max_context_length <= MIN_FITTED_CONTEXT_TOKENS:
             logger.info(
                 "Model family %s reports a %s token maximum; leaving context unchanged",
                 family,
                 f"{max_context_length:,}",
+            )
+            return None
+
+        query_attention_heads = None
+        for key in ("num_attention_heads", "n_heads"):
+            for source in config_sources:
+                query_attention_heads = _config_value(source, key)
+                if query_attention_heads is not None:
+                    break
+            if query_attention_heads is not None:
+                break
+        if query_attention_heads is None:
+            logger.error(
+                "Model context auto-fit could not find the query attention head count; "
+                "leaving context unchanged"
             )
             return None
 
@@ -134,6 +150,7 @@ def fit_batched_vlm_context(
                 language_model=language_model,
                 family=family,
                 max_context_length=max_context_length,
+                query_attention_heads=query_attention_heads,
                 prefill_step_size=prefill_step_size,
             )
         finally:
@@ -280,6 +297,7 @@ def _probe_cache_fit_profile(
     language_model: Any,
     family: str,
     max_context_length: int,
+    query_attention_heads: int,
     prefill_step_size: int,
 ) -> CacheFitProfile | None:
     prompt_cache = make_prompt_cache(language_model)
@@ -298,16 +316,6 @@ def _probe_cache_fit_profile(
         prompt_input_bytes_per_token += per_layer_inputs.nbytes
     # Attention uses the same activation dtype as the token embeddings.
     activation_dtype_bytes = inputs_embeds.itemsize
-
-    language_config = getattr(language_model, "config", None)
-    language_args = getattr(language_model, "args", None)
-    query_attention_heads = _config_value(
-        language_config, "num_attention_heads"
-    ) or _config_value(language_args, "num_attention_heads")
-    if query_attention_heads is None:
-        query_attention_heads = _config_value(
-            language_config, "n_heads"
-        ) or _config_value(language_args, "n_heads")
 
     language_model(
         input_ids,

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -4,15 +4,18 @@ A model's native context limit does not account for its loaded weights or the
 memory needed to read a long prompt. Guessing by allocating progressively larger
 prompts is unsafe because a Metal out-of-memory error can terminate the process.
 Instead, a one-token probe reveals the loaded model's real cache shapes and
-dtypes, then uses the formula below. The formula is validated for Gemma 4 and
-Qwen 3.5, and is used as a best-effort fit for other measurable cache layouts.
+dtypes, then uses the formula below. The score term is validated for unfused
+Gemma 4 and Qwen 3.5 attention and fused 64-dimensional GPT-OSS attention. Other
+measurable cache layouts use the conservative unfused fit as a best effort.
 
     fixed = loaded baseline + rotating cache + recurrent state
-    bytes/token = full KV + retained prompt inputs + attention workspace
+    bytes/token = full KV + retained prompt inputs + attention scores
     context = (recommended working set - reserve - fixed) / bytes/token
 
 Long-prefill experiments on dense and MoE Qwen and Gemma models showed that
-attention memory matched `query heads * prefill chunk * activation dtype size`.
+unfused attention materialized scores matching
+`query heads * prefill chunk * activation dtype size`. GPT-OSS uses MLX's fused
+attention for its 64-dimensional heads, so it has no context-linear score term.
 The largest measured peak not explained by the formula was 2.41 GiB,
 motivating the 3 GiB reserve floor.
 
@@ -39,6 +42,7 @@ MIN_FITTED_CONTEXT_TOKENS = 4_096
 MIN_RUNTIME_RESERVE_BYTES = 3 * GIB
 
 _FAMILY_GEMMA4 = "gemma4"
+_FAMILY_GPT_OSS = "gpt_oss"
 _FAMILY_QWEN3_5 = "qwen3_5"
 _SUPPORTED_CACHE_TYPES = {"KVCache", "RotatingKVCache", "ArraysCache"}
 
@@ -55,6 +59,7 @@ class CacheFitProfile:
     allocation_step: int
     full_kv_bytes_per_token: int
     prompt_input_bytes_per_token: int
+    materializes_attention_scores: bool
     query_attention_heads: int
     activation_dtype_bytes: int
     prefill_step_size: int
@@ -78,8 +83,9 @@ def fit_batched_vlm_context(
     """Return a fitted token limit, or `None` to leave the limit unchanged.
 
     A one-token probe measures the model's cache, retained prompt inputs, and
-    activation layout. Gemma 4 and Qwen 3.5 use the validated fit. Other families
-    use the same fit when their memory layout can be measured without assumptions.
+    activation layout. Gemma 4 and Qwen 3.5 use the validated unfused fit;
+    64-dimensional GPT-OSS uses its validated fused fit. Other families use the
+    conservative unfused fit when their memory layout can be measured.
     """
     max_context_length = None
     validated_family = False
@@ -129,6 +135,26 @@ def fit_batched_vlm_context(
             )
             return None
 
+        materializes_attention_scores = True
+        if family == _FAMILY_GPT_OSS:
+            query_head_dim = None
+            for source in config_sources:
+                query_head_dim = _config_value(source, "head_dim")
+                if query_head_dim is not None:
+                    break
+            # MLX 0.32 uses fused long-prefill SDPA for GPT-OSS's official
+            # 64-dimensional attention layout. Unexpected variants retain the
+            # conservative score-matrix estimate.
+            materializes_attention_scores = query_head_dim != 64
+            if not materializes_attention_scores:
+                validated_family = True
+            else:
+                logger.info(
+                    "GPT-OSS head_dim=%s is not the validated fused layout; "
+                    "retaining the conservative attention-score estimate",
+                    query_head_dim,
+                )
+
         query_attention_heads = None
         for key in ("num_attention_heads", "n_heads"):
             for source in config_sources:
@@ -152,6 +178,7 @@ def fit_batched_vlm_context(
                 max_context_length=max_context_length,
                 query_attention_heads=query_attention_heads,
                 prefill_step_size=prefill_step_size,
+                materializes_attention_scores=materializes_attention_scores,
             )
         finally:
             # Release the temporary probe arrays before measuring the loaded model.
@@ -182,15 +209,11 @@ def fit_batched_vlm_context(
             )
             return None
 
-        attention_workspace_bytes_per_token = (
-            profile.query_attention_heads
-            * profile.prefill_step_size
-            * profile.activation_dtype_bytes
-        )
+        attention_scores_bytes_per_token = _attention_scores_bytes_per_token(profile)
         peak_bytes_per_token = (
             profile.full_kv_bytes_per_token
             + profile.prompt_input_bytes_per_token
-            + attention_workspace_bytes_per_token
+            + attention_scores_bytes_per_token
         )
         estimated_memory_bytes = (
             baseline_bytes
@@ -213,7 +236,7 @@ def fit_batched_vlm_context(
             baseline_bytes / GIB,
             profile.full_kv_bytes_per_token,
             profile.prompt_input_bytes_per_token,
-            attention_workspace_bytes_per_token,
+            attention_scores_bytes_per_token,
             profile.rotating_peak_bytes / GIB,
             profile.fixed_ssm_bytes / GIB,
             estimated_memory_bytes / GIB,
@@ -222,6 +245,16 @@ def fit_batched_vlm_context(
     except Exception:
         logger.exception("Model context auto-fit failed; leaving context unchanged")
         return None
+
+
+def _attention_scores_bytes_per_token(profile: CacheFitProfile) -> int:
+    if not profile.materializes_attention_scores:
+        return 0
+    return (
+        profile.query_attention_heads
+        * profile.prefill_step_size
+        * profile.activation_dtype_bytes
+    )
 
 
 def calculate_context_fit(
@@ -234,7 +267,7 @@ def calculate_context_fit(
 
     The fit subtracts the runtime reserve and fixed memory from the recommended
     working set. It divides what remains by the per-token peak for KV, retained
-    prompt inputs, and chunked attention work. The result contains the
+    prompt inputs, and any materialized attention scores. The result contains the
     chosen token limit and the reserve and safe ceiling used to calculate it.
     """
     # The modeled terms undercounted measured prefill peaks by at most 2.41 GiB.
@@ -246,18 +279,14 @@ def calculate_context_fit(
         baseline_bytes + profile.rotating_peak_bytes + profile.fixed_ssm_bytes
     )
 
-    # Long-prefill measurements matched one activation value per query head and
-    # prefill token for every context token. The dtype size is measured at runtime
-    # rather than assuming the tested models' two-byte BF16/FP16 activations.
-    attention_workspace_bytes_per_token = (
-        profile.query_attention_heads
-        * profile.prefill_step_size
-        * profile.activation_dtype_bytes
-    )
+    # Unfused long-prefill attention materializes one score value per query head
+    # and prefill token for every context token. Validated fused paths omit this
+    # context-linear allocation; their fixed-size workspace remains in the reserve.
+    attention_scores_bytes_per_token = _attention_scores_bytes_per_token(profile)
     peak_bytes_per_token = (
         profile.full_kv_bytes_per_token
         + profile.prompt_input_bytes_per_token
-        + attention_workspace_bytes_per_token
+        + attention_scores_bytes_per_token
     )
 
     # First find how many bytes remain for the prompt after paying the model's
@@ -299,6 +328,7 @@ def _probe_cache_fit_profile(
     max_context_length: int,
     query_attention_heads: int,
     prefill_step_size: int,
+    materializes_attention_scores: bool = True,
 ) -> CacheFitProfile | None:
     prompt_cache = make_prompt_cache(language_model)
     # One token is enough to allocate every cache in its real shape and dtype.
@@ -395,6 +425,7 @@ def _probe_cache_fit_profile(
         allocation_step=next(iter(cache_allocation_steps)),
         full_kv_bytes_per_token=full_kv_bytes_per_token,
         prompt_input_bytes_per_token=prompt_input_bytes_per_token,
+        materializes_attention_scores=materializes_attention_scores,
         query_attention_heads=query_attention_heads,
         activation_dtype_bytes=activation_dtype_bytes,
         prefill_step_size=prefill_step_size,

--- a/tests/test_batched_generation.py
+++ b/tests/test_batched_generation.py
@@ -2,7 +2,7 @@ import pytest
 import threading
 import time
 
-from mlx_engine.model_kit.batched_model_kit import BatchedModelKit
+from mlx_engine.model_kit.batched_vision import BatchedVisionModelKit
 from tests.shared import model_getter
 from mlx_engine.generate import load_model, create_generator, tokenize, unload
 
@@ -19,7 +19,7 @@ def model_kit():
 def test_batched_generation_max_tokens(model_kit):
     """Test that batched generation stops with token_limit when max_tokens is reached."""
 
-    assert isinstance(model_kit, BatchedModelKit)
+    assert isinstance(model_kit, BatchedVisionModelKit)
 
     prompt = """<|im_start|>user
 Write a short paragraph about the Eiffel Tower in Paris.<|im_end|>
@@ -51,7 +51,7 @@ Write a short paragraph about the Eiffel Tower in Paris.<|im_end|>
 def test_batched_generation_two_threads(model_kit):
     """Test batched generation with two concurrent threads."""
 
-    assert isinstance(model_kit, BatchedModelKit)
+    assert isinstance(model_kit, BatchedVisionModelKit)
 
     # Define two different prompts with different topics
     prompts = [

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -79,6 +79,7 @@ def _profile(
     max_context_length=100_000,
     full_kv_bytes_per_token=MIB,
     prompt_input_bytes_per_token=4 * KIB,
+    materializes_attention_scores=True,
     query_attention_heads=8,
     activation_dtype_bytes=2,
     prefill_step_size=2_048,
@@ -90,6 +91,7 @@ def _profile(
         allocation_step=256,
         full_kv_bytes_per_token=full_kv_bytes_per_token,
         prompt_input_bytes_per_token=prompt_input_bytes_per_token,
+        materializes_attention_scores=materializes_attention_scores,
         query_attention_heads=query_attention_heads,
         activation_dtype_bytes=activation_dtype_bytes,
         prefill_step_size=prefill_step_size,
@@ -103,9 +105,13 @@ def _peak_bytes_per_token(profile):
     return (
         profile.full_kv_bytes_per_token
         + profile.prompt_input_bytes_per_token
-        + profile.query_attention_heads
-        * profile.prefill_step_size
-        * profile.activation_dtype_bytes
+        + (
+            profile.query_attention_heads
+            * profile.prefill_step_size
+            * profile.activation_dtype_bytes
+            if profile.materializes_attention_scores
+            else 0
+        )
     )
 
 
@@ -522,6 +528,60 @@ def test_text_adapter_uses_top_level_config(monkeypatch):
     assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 8_192
     assert probe_args["max_context_length"] == 8_192
     assert probe_args["query_attention_heads"] == 12
+    assert probe_args["materializes_attention_scores"] is True
+
+
+@pytest.mark.parametrize(
+    ("head_dim", "expected_context", "materializes_attention_scores"),
+    [
+        pytest.param(64, 131_072, False, id="official-fused-layout"),
+        pytest.param(128, 50_432, True, id="unexpected-conservative-layout"),
+    ],
+)
+def test_gpt_oss_fused_attention_fit_is_guarded_by_head_dim(
+    monkeypatch,
+    head_dim,
+    expected_context,
+    materializes_attention_scores,
+):
+    probe_args = {}
+    language_model = SimpleNamespace(model_type="gpt_oss")
+    model = SimpleNamespace(
+        language_model=language_model,
+        config=SimpleNamespace(
+            model_type="gpt_oss",
+            max_position_embeddings=131_072,
+            num_attention_heads=64,
+            head_dim=head_dim,
+        ),
+    )
+
+    def capture_probe_args(**kwargs):
+        probe_args.update(kwargs)
+        return _profile(
+            family="gpt_oss",
+            max_context_length=131_072,
+            full_kv_bytes_per_token=24_576,
+            prompt_input_bytes_per_token=5_760,
+            materializes_attention_scores=kwargs["materializes_attention_scores"],
+            query_attention_heads=kwargs["query_attention_heads"],
+            rotating_peak_bytes=53_452_800,
+        )
+
+    monkeypatch.setattr(context_fit, "_probe_cache_fit_profile", capture_probe_args)
+    monkeypatch.setattr(context_fit.mx, "get_active_memory", lambda: 11_014_942_220)
+    monkeypatch.setattr(context_fit.mx, "get_cache_memory", lambda: 0)
+    monkeypatch.setattr(
+        context_fit.mx,
+        "device_info",
+        lambda: {"max_recommended_working_set_size": 27 * GIB},
+    )
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == (
+        expected_context
+    )
+    assert probe_args["materializes_attention_scores"] is materializes_attention_scores
+    assert probe_args["query_attention_heads"] == 64
 
 
 def test_fit_skips_model_without_attention_head_count(monkeypatch, caplog):

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -50,6 +50,7 @@ def _probe_profile(
     *,
     family="gemma4",
     language_model=None,
+    query_attention_heads=8,
 ):
     if language_model is None:
         language_model = _ProbeLanguageModel()
@@ -59,6 +60,7 @@ def _probe_profile(
         language_model=language_model,
         family=family,
         max_context_length=8_192,
+        query_attention_heads=query_attention_heads,
         prefill_step_size=2_048,
     )
 
@@ -158,14 +160,13 @@ def test_probe_counts_actual_qwen_arrays_state_bytes(monkeypatch):
     arrays_cache[1] = mx.ones((1, 2, 2), dtype=mx.float16)
     mx.eval(arrays_cache.state)
     language_model = _ProbeLanguageModel()
-    language_model.config = SimpleNamespace()
-    language_model.args = SimpleNamespace(num_attention_heads=16)
 
     profile = _probe_profile(
         monkeypatch,
         [_initialized_kv_cache(), arrays_cache],
         family="qwen3_5",
         language_model=language_model,
+        query_attention_heads=16,
     )
 
     assert profile.fixed_ssm_bytes == arrays_cache.nbytes
@@ -483,11 +484,73 @@ def test_one_token_probe_uses_token_zero_and_reports_fit(monkeypatch):
     assert context_length == 8_192
 
 
+def test_text_adapter_uses_top_level_config(monkeypatch):
+    probe_args = {}
+    language_model = SimpleNamespace(model_type="qwen2")
+    model = SimpleNamespace(
+        language_model=language_model,
+        config=SimpleNamespace(
+            model_type="qwen2",
+            max_position_embeddings=8_192,
+            num_attention_heads=12,
+            text_config=SimpleNamespace(),
+        ),
+    )
+
+    def capture_probe_args(**kwargs):
+        probe_args.update(kwargs)
+        return _profile(
+            family="qwen2",
+            max_context_length=8_192,
+            full_kv_bytes_per_token=512 * KIB,
+            query_attention_heads=kwargs["query_attention_heads"],
+        )
+
+    monkeypatch.setattr(
+        context_fit,
+        "_probe_cache_fit_profile",
+        capture_probe_args,
+    )
+    monkeypatch.setattr(context_fit.mx, "get_active_memory", lambda: 0)
+    monkeypatch.setattr(context_fit.mx, "get_cache_memory", lambda: 0)
+    monkeypatch.setattr(
+        context_fit.mx,
+        "device_info",
+        lambda: {"max_recommended_working_set_size": 10 * GIB},
+    )
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) == 8_192
+    assert probe_args["max_context_length"] == 8_192
+    assert probe_args["query_attention_heads"] == 12
+
+
+def test_fit_skips_model_without_attention_head_count(monkeypatch, caplog):
+    probe_called = False
+
+    def unexpected_probe(**_kwargs):
+        nonlocal probe_called
+        probe_called = True
+
+    language_model = SimpleNamespace(
+        model_type="other_vlm",
+        config=SimpleNamespace(max_position_embeddings=8_192),
+    )
+    model = SimpleNamespace(language_model=language_model)
+    monkeypatch.setattr(context_fit, "_probe_cache_fit_profile", unexpected_probe)
+
+    assert fit_batched_vlm_context(model=model, prefill_step_size=2_048) is None
+    assert not probe_called
+    assert "could not find the query attention head count" in caplog.text
+
+
 def test_qwen3_6_uses_args_context(monkeypatch):
     language_model = SimpleNamespace(
         model_type="qwen3_6_moe",
         config=SimpleNamespace(),
-        args=SimpleNamespace(max_position_embeddings=8_192),
+        args=SimpleNamespace(
+            max_position_embeddings=8_192,
+            num_attention_heads=8,
+        ),
     )
     model = SimpleNamespace(language_model=language_model)
     monkeypatch.setattr(
@@ -514,6 +577,7 @@ def test_other_family_uses_best_effort_fit(monkeypatch):
         config=SimpleNamespace(
             model_type="other_vlm",
             max_position_embeddings=8_192,
+            num_attention_heads=8,
         )
     )
     model = SimpleNamespace(language_model=language_model)
@@ -564,7 +628,10 @@ def test_other_family_does_not_override_context_with_minimum_fit(monkeypatch):
     )
     language_model = SimpleNamespace(
         model_type="other_vlm",
-        config=SimpleNamespace(max_position_embeddings=100_000),
+        config=SimpleNamespace(
+            max_position_embeddings=100_000,
+            num_attention_heads=8,
+        ),
     )
     model = SimpleNamespace(language_model=language_model)
     monkeypatch.setattr(
@@ -592,7 +659,10 @@ def test_other_family_leaves_context_unchanged_when_probe_is_unsupported(
 ):
     language_model = SimpleNamespace(
         model_type="other_vlm",
-        config=SimpleNamespace(max_position_embeddings=32_768),
+        config=SimpleNamespace(
+            max_position_embeddings=32_768,
+            num_attention_heads=8,
+        ),
     )
     model = SimpleNamespace(language_model=language_model)
     monkeypatch.setattr(
@@ -609,7 +679,10 @@ def test_validated_family_leaves_context_unchanged_when_probe_is_unsupported(
 ):
     language_model = SimpleNamespace(
         model_type="gemma4_text",
-        config=SimpleNamespace(max_position_embeddings=32_768),
+        config=SimpleNamespace(
+            max_position_embeddings=32_768,
+            num_attention_heads=8,
+        ),
     )
     model = SimpleNamespace(language_model=language_model)
     monkeypatch.setattr(
@@ -635,7 +708,10 @@ def test_fit_leaves_context_unchanged_when_fallback_is_unknown(caplog):
 def test_fit_logs_and_leaves_context_unchanged_when_probe_raises(monkeypatch, caplog):
     language_model = SimpleNamespace(
         model_type="gemma4_text",
-        config=SimpleNamespace(max_position_embeddings=16_384),
+        config=SimpleNamespace(
+            max_position_embeddings=16_384,
+            num_attention_heads=8,
+        ),
     )
     model = SimpleNamespace(language_model=language_model)
 

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -1,0 +1,171 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import mlx_engine.generate as generate_module
+
+
+class _MergeableCache:
+    def merge(self, caches):
+        return caches
+
+
+class _NonMergeableCache:
+    pass
+
+
+def _write_text_config(tmp_path: Path) -> Path:
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen2",
+                "max_position_embeddings": 32_768,
+                "num_attention_heads": 8,
+            }
+        )
+    )
+    return tmp_path
+
+
+def _install_fake_kit(monkeypatch, class_name: str):
+    created_kits = []
+
+    class FakeKit:
+        def __init__(self, model_path, **options):
+            self.model_path = model_path
+            self.options = options
+            self.started = False
+            created_kits.append(self)
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(generate_module, class_name, FakeKit)
+    return FakeKit, created_kits
+
+
+def _disable_eos_sanitization(monkeypatch) -> None:
+    monkeypatch.setattr(generate_module, "sanitize_eos_tokens", lambda _model_kit: None)
+
+
+def test_batchable_text_model_uses_mlx_vlm_kit(monkeypatch, tmp_path):
+    model_path = _write_text_config(tmp_path)
+    fake_kit_class, created_kits = _install_fake_kit(
+        monkeypatch,
+        "BatchedVisionModelKit",
+    )
+    loaded_models = []
+
+    def fake_load_model(path, *, lazy):
+        loaded_models.append((path, lazy))
+        return SimpleNamespace(language_model=SimpleNamespace())
+
+    monkeypatch.setattr(generate_module, "mlx_vlm_load_model", fake_load_model)
+    monkeypatch.setattr(
+        generate_module,
+        "make_prompt_cache",
+        lambda _language_model: [_MergeableCache()],
+    )
+    _disable_eos_sanitization(monkeypatch)
+
+    model_kit = generate_module.load_model(
+        model_path,
+        max_kv_size=8_192,
+        max_seq_nums=3,
+        trust_remote_code=True,
+        seed=7,
+    )
+
+    assert isinstance(model_kit, fake_kit_class)
+    assert model_kit is created_kits[0]
+    assert model_kit.started
+    assert loaded_models == [(model_path, True)]
+    assert model_kit.options == {
+        "max_kv_size": 8_192,
+        "max_seq_nums": 3,
+        "prefill_step_size": 2_048,
+        "trust_remote_code": True,
+        "seed": 7,
+    }
+
+
+def test_non_mergeable_text_model_stays_sequential(monkeypatch, tmp_path):
+    model_path = _write_text_config(tmp_path)
+    fake_kit_class, _created_kits = _install_fake_kit(monkeypatch, "ModelKit")
+    monkeypatch.setattr(
+        generate_module,
+        "mlx_vlm_load_model",
+        lambda _path, *, lazy: SimpleNamespace(language_model=SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        generate_module,
+        "make_prompt_cache",
+        lambda _language_model: [_NonMergeableCache()],
+    )
+    _disable_eos_sanitization(monkeypatch)
+
+    model_kit = generate_module.load_model(model_path, max_seq_nums=4)
+
+    assert isinstance(model_kit, fake_kit_class)
+    assert model_kit.started
+
+
+@pytest.mark.parametrize(
+    "load_options",
+    [
+        pytest.param({"vocab_only": True}, id="vocab-only"),
+        pytest.param({"max_seq_nums": 1}, id="single-sequence"),
+        pytest.param({"kv_bits": 8, "kv_group_size": 64}, id="quantized-kv"),
+    ],
+)
+def test_special_text_modes_stay_sequential(
+    monkeypatch,
+    tmp_path,
+    load_options,
+):
+    model_path = _write_text_config(tmp_path)
+    fake_kit_class, _created_kits = _install_fake_kit(monkeypatch, "ModelKit")
+
+    def unexpected_vlm_load(*_arguments, **_options):
+        pytest.fail("mlx-vlm preflight should not run for sequential text modes")
+
+    monkeypatch.setattr(generate_module, "mlx_vlm_load_model", unexpected_vlm_load)
+    _disable_eos_sanitization(monkeypatch)
+
+    model_kit = generate_module.load_model(model_path, **load_options)
+
+    assert isinstance(model_kit, fake_kit_class)
+    assert model_kit.started
+
+
+def test_vision_model_continues_to_use_mlx_vlm_kit(monkeypatch, tmp_path):
+    model_path = _write_text_config(tmp_path)
+    (model_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen2_vl",
+                "vision_config": {"hidden_size": 16},
+            }
+        )
+    )
+    fake_kit_class, _created_kits = _install_fake_kit(
+        monkeypatch,
+        "BatchedVisionModelKit",
+    )
+
+    def unexpected_vlm_preflight(*_arguments, **_options):
+        pytest.fail("vision models should not use the text batching preflight")
+
+    monkeypatch.setattr(
+        generate_module,
+        "mlx_vlm_load_model",
+        unexpected_vlm_preflight,
+    )
+    _disable_eos_sanitization(monkeypatch)
+
+    model_kit = generate_module.load_model(model_path)
+
+    assert isinstance(model_kit, fake_kit_class)
+    assert model_kit.started

--- a/tests/test_prefill_step_size.py
+++ b/tests/test_prefill_step_size.py
@@ -8,7 +8,6 @@ from mlx_engine.cache_wrapper import (
     PROMPT_PROCESSING_CHUNK_SIZE,
     validate_prefill_step_size,
 )
-from mlx_engine.model_kit.batched_model_kit import BatchedModelKit
 from mlx_engine.model_kit.batched_vision import BatchedVisionModelKit
 from mlx_engine.model_kit.model_kit import ModelKit
 from tests.shared import model_getter, RecordingReporter
@@ -39,21 +38,6 @@ def test_load_model_rejects_invalid_prefill_step_size(prefill_step_size):
         ValueError, match="prefill_step_size must be a positive integer"
     ):
         load_model(model_path="unused", prefill_step_size=prefill_step_size)
-
-
-def _expected_batched_prefill_updates(
-    num_prompt_tokens: int, prefill_step_size: int
-) -> int:
-    """Compute the expected number of 'update' events from BatchedMlxLmReporterAdapter.
-
-    BatchGenerator._process_prompts fires one progress callback per prefill chunk,
-    leaving prompt_checkpoint (1) token for the final step.
-    BatchedMlxLmReporterAdapter maps these callbacks to events: the first callback
-    emits both begin and update (no early return after begin), middle callbacks emit
-    update, and the last emits finish. So: num_updates = num_callbacks - 1.
-    """
-    prefillable_tokens = num_prompt_tokens - 1
-    return math.ceil(prefillable_tokens / prefill_step_size) - 1
 
 
 def _expected_batched_vision_prefill_updates(
@@ -151,12 +135,12 @@ def test_batched_prefill_step_size(batched_model_kit_custom_prefill):
     model_kit = batched_model_kit_custom_prefill
 
     # GIVEN
-    assert isinstance(model_kit, BatchedModelKit)
+    assert isinstance(model_kit, BatchedVisionModelKit)
     prompt_tokens = _long_prompt_tokens(model_kit)
-    expected_updates = _expected_batched_prefill_updates(
+    expected_updates = _expected_batched_vision_prefill_updates(
         len(prompt_tokens), CUSTOM_PREFILL_STEP_SIZE
     )
-    expected_at_default = _expected_batched_prefill_updates(
+    expected_at_default = _expected_batched_vision_prefill_updates(
         len(prompt_tokens), PROMPT_PROCESSING_CHUNK_SIZE
     )
     assert expected_updates != expected_at_default, (

--- a/tests/test_text_models.py
+++ b/tests/test_text_models.py
@@ -105,9 +105,7 @@ Who is this passage about? Only say the name, and nothing else<|im_end|>
         # First generation should have no cached tokens
         begin_event = reporter.events[0]
         self.assertEqual(begin_event["type"], "begin")
-        # TODO: Implement proper cached_tokens tracking in batched model kit
-        # Currently hardcoded to 0 in BatchedMlxLmReporterAdapter
-        # self.assertEqual(begin_event["cached_tokens"], 0)
+        self.assertEqual(begin_event["cached_tokens"], 0)
         self.assertGreater(len(generated_text), 0, "Model failed to generate any text")
         ben_franklin_in_response = "Benjamin Franklin" in generated_text
         self.assertTrue(
@@ -131,7 +129,7 @@ repeat<|im_end|>
         # Second generation should have cached tokens from first generation
         begin_event = reporter.events[0]
         self.assertEqual(begin_event["type"], "begin")
-        # self.assertGreater(begin_event["cached_tokens"], 0)
+        self.assertGreater(begin_event["cached_tokens"], 0)
         self.assertGreater(len(generated_text), 0, "Model failed to generate any text")
         ben_franklin_in_response = "Benjamin Franklin" in generated_text
         self.assertTrue(
@@ -183,9 +181,7 @@ Who is this passage about? Only say the name, and nothing else<end_of_turn>
         # First generation should have no cached tokens
         begin_event = reporter.events[0]
         self.assertEqual(begin_event["type"], "begin")
-        # TODO: Implement proper cached_tokens tracking in batched model kit
-        # Currently hardcoded to 0 in BatchedMlxLmReporterAdapter
-        # self.assertEqual(begin_event["cached_tokens"], 0)
+        self.assertEqual(begin_event["cached_tokens"], 0)
         self.assertGreater(
             len(generated_text_1), 0, "Model failed to generate any text"
         )
@@ -214,13 +210,13 @@ Who is this passage about? Only say the name, and nothing else<end_of_turn>
         reporter.events.clear()
         generate(text_accumulator=generated_text_list_2)
         generated_text_2 = "".join(generated_text_list_2)
-        # Expect prompt cache to be intact for the first half of the file_content, so we should get 1
-        # intermediate update callback this time (begin + 1x update + finish = 4)
-        self.assertEqual(len(reporter.events), 3)
+        # The restored cache is not aligned to the prefill step grid, so mlx-vlm
+        # reports a short alignment update before the normal prefill update.
+        self.assertEqual(len(reporter.events), 4)
         # Second generation should have some cached tokens (partial cache hit after trim)
         begin_event = reporter.events[0]
         self.assertEqual(begin_event["type"], "begin")
-        # self.assertGreater(begin_event["cached_tokens"], 0)
+        self.assertGreater(begin_event["cached_tokens"], 0)
         self.assertGreater(
             len(generated_text_2), 0, "Model failed to generate any text"
         )


### PR DESCRIPTION
## Motivation

Text-only models used a separate mlx-lm batching path. Routing them through mlx-vlm gives text and vision models the same batching, disk-backed prompt caching, and structured-output implementation.

The context fitter also overestimated GPT-OSS memory because it assumed attention always materialized a full score matrix. MLX uses fused attention for GPT-OSS, making the existing 50,432-token fit too conservative.

## Changes

- Route batchable text models through `BatchedVisionModelKit`.
- Use mlx-vlm loading and cache inspection to check whether a text model supports batching.
- Keep vocab-only, single-sequence/speculative, KV-quantized, and non-mergeable models on the existing sequential path.
- Read context and attention settings from top-level and nested text configs so adapter-backed text models can use context fitting.
- Omit the context-linear attention-score term for GPT-OSS when `head_dim == 64`.
- Keep the existing conservative formula for Qwen, Gemma, and unknown models.
- Update routing, batching, prompt-cache, progress-reporting, and context-fit tests for the mlx-vlm path.

## Results

In testing with GPT-OSS 20B, it used 1.14 GiB less memory compared to current main after four long prompts of 16K tokens.