### PR TITLE
Fix high memory usage during gemma4 image prefill

### DIFF
--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -1035,8 +1035,9 @@ class _PromptPrefill:
         if self._gemma4_image_prefill_sections is None:
             return prompt_kwargs
 
-        # Prepared image spans exactly match type-1 runs. Keep token types only
-        # for image queries so the mask patch need not scan an MLX array.
+        # Prepared image spans exactly match contiguous image soft-token runs
+        # (`mm_token_type_ids == 1`). Keep token types only for image queries so
+        # the mask patch need not scan an MLX array.
         query_start = self._processed_prefix_len
         has_image = any(
             span.start < key_len and query_start < span.end

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -24,8 +24,8 @@ from mlx_engine.model_kit.batched_vision.prompt_inputs import (
     slice_prompt_kwargs,
 )
 from mlx_engine.model_kit.patches.gemma4 import (
+    image_prefill_spans as gemma4_image_prefill_spans,
     prepare_cached_suffix_prompt_kwargs as prepare_gemma4_cached_suffix_prompt_kwargs,
-    visual_prefill_prefix_len as gemma4_visual_prefill_prefix_len,
 )
 from mlx_vlm.generate import (
     DEFAULT_COMPLETION_BATCH_SIZE,
@@ -786,7 +786,7 @@ class _PromptPrefill:
         self._all_tokens = list(all_tokens) if all_tokens is not None else []
         self._processed_prefix_len = len(self._all_tokens)
         self._prefix_cache_save_state = prefix_cache_save_state
-        self._visual_prefill_prefix_len = gemma4_visual_prefill_prefix_len(
+        self._gemma4_image_prefill_spans = gemma4_image_prefill_spans(
             model,
             prompt_kwargs,
             prefix_cache_save_state.image_spans,
@@ -854,28 +854,24 @@ class _PromptPrefill:
         if remaining_tokens <= 1:
             return 0
 
-        # Apply the Gemma4 visual-prefix rule before normal cache-boundary
-        # alignment. If a restore lands before a new image, token-type padding
-        # lets the image suffix build its mask against the restored KV prefix.
-        visual_prefix_remaining = self._visual_prefill_prefix_remaining()
-        if visual_prefix_remaining is not None:
-            if visual_prefix_remaining < remaining_tokens:
-                return visual_prefix_remaining
-            return 0
-
+        next_step = 0
         saving_prompt_cache = self._prefix_cache_save_state.callback is not None
         processed_remainder = self._processed_prefix_len % self.prefill_step_size
         if saving_prompt_cache and processed_remainder:
             # After a partial restore, land on the next normal prefill boundary.
             alignment_step = self.prefill_step_size - processed_remainder
             if alignment_step < remaining_tokens:
-                return min(alignment_step, remaining_tokens - 1)
+                next_step = min(alignment_step, remaining_tokens - 1)
 
-        if remaining_tokens > self.prefill_step_size:
-            return min(self.prefill_step_size, remaining_tokens - 1)
+        if next_step == 0 and remaining_tokens > self.prefill_step_size:
+            next_step = min(self.prefill_step_size, remaining_tokens - 1)
 
-        if saving_prompt_cache and any(
-            type(cache).__name__ == "ArraysCache" for cache in self.prompt_cache
+        if (
+            next_step == 0
+            and saving_prompt_cache
+            and any(
+                type(cache).__name__ == "ArraysCache" for cache in self.prompt_cache
+            )
         ):
             # Opaque state caches are restorable only at exact saved boundaries.
             max_reusable_prefix_len = self._processed_prefix_len + remaining_tokens - 1
@@ -883,18 +879,38 @@ class _PromptPrefill:
                 max_reusable_prefix_len // DEFAULT_PREFIX_CHUNK_SIZE
             ) * DEFAULT_PREFIX_CHUNK_SIZE
             if target_prefix_len > self._processed_prefix_len:
-                return target_prefix_len - self._processed_prefix_len
+                next_step = target_prefix_len - self._processed_prefix_len
 
-        return 0
+        return self._step_without_splitting_gemma4_image(
+            next_step,
+            remaining_tokens,
+        )
 
-    def _visual_prefill_prefix_remaining(self) -> int | None:
-        if self._visual_prefill_prefix_len is None:
-            return None
+    def _step_without_splitting_gemma4_image(
+        self,
+        proposed_step: int,
+        remaining_tokens: int,
+    ) -> int:
+        if proposed_step == 0 or self._gemma4_image_prefill_spans is None:
+            return proposed_step
+
         processed_prompt_len = self._processed_prefix_len - len(self._all_tokens)
-        remaining = self._visual_prefill_prefix_len - processed_prompt_len
-        if remaining <= 0:
-            return None
-        return remaining
+        proposed_boundary = processed_prompt_len + proposed_step
+        for image_start, image_end in self._gemma4_image_prefill_spans:
+            if not image_start < proposed_boundary < image_end:
+                continue
+            tokens_before_image = image_start - processed_prompt_len
+            if tokens_before_image > 0:
+                return tokens_before_image
+
+            image_tokens_remaining = image_end - processed_prompt_len
+            if image_tokens_remaining < remaining_tokens:
+                return image_tokens_remaining
+            # The final model call must retain at least one prompt token. If the
+            # image reaches the prompt end, let final prefill process it whole.
+            return 0
+
+        return proposed_step
 
     def _prompt_kwargs_for_next(self, n: int) -> dict:
         # Slice locally instead of relying on model-specific n_to_process hacks.
@@ -1020,7 +1036,7 @@ class _PromptPrefill:
         prompt_kwargs: dict,
         key_len: int,
     ) -> dict:
-        if self._visual_prefill_prefix_len is None:
+        if self._gemma4_image_prefill_spans is None:
             return prompt_kwargs
         return prepare_gemma4_cached_suffix_prompt_kwargs(prompt_kwargs, key_len)
 

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -884,9 +884,9 @@ class _PromptPrefill:
             if target_prefix_len > self._processed_prefix_len:
                 next_step = target_prefix_len - self._processed_prefix_len
 
-        return self._step_without_splitting_gemma4_image(next_step)
+        return self._step_without_splitting_gemma4_image_run(next_step)
 
-    def _step_without_splitting_gemma4_image(self, proposed_step: int) -> int:
+    def _step_without_splitting_gemma4_image_run(self, proposed_step: int) -> int:
         if proposed_step == 0 or self._gemma4_image_prefill_sections is None:
             return proposed_step
 

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -788,7 +788,7 @@ class _PromptPrefill:
         self._prefix_cache_save_state = prefix_cache_save_state
         self._gemma4_image_prefill_sections = gemma4_image_prefill_sections(
             model,
-            prefix_cache_save_state.image_spans,
+            prompt_kwargs,
             len(self._all_tokens),
         )
         # Restored exact hot caches may carry an existing row. Trimmed/disk
@@ -1034,21 +1034,25 @@ class _PromptPrefill:
         if self._gemma4_image_prefill_sections is None:
             return prompt_kwargs
 
-        # Prepared image spans exactly match contiguous image soft-token runs
-        # (`mm_token_type_ids == 1`). Keep token types only for image queries so
-        # the mask patch need not scan an MLX array.
-        query_start = self._processed_prefix_len
+        # Protected sections come from exact token-type runs, unlike the cache's
+        # potentially coarse image spans. Keep token types only for image queries
+        # so the mask patch need not scan an MLX array on every model call.
+        suffix_start = len(self._all_tokens)
+        query_start = self._processed_prefix_len - suffix_start
+        query_end = key_len - suffix_start
         has_image = any(
-            span.start < key_len and query_start < span.end
-            for span in self._prefix_cache_save_state.image_spans
+            section_start < query_end and query_start < section_end
+            for section_start, section_end in self._gemma4_image_prefill_sections
         )
         if has_image:
             return prepare_gemma4_cached_suffix_prompt_kwargs(prompt_kwargs, key_len)
 
         # Multimodal text slices still carry an all-zero token-type array. Drop
-        # it so None remains the no-image sentinel for the patched mask builder.
+        # both supported names so None remains the no-image sentinel for the
+        # patched mask builder.
         prepared = dict(prompt_kwargs)
         prepared.pop("mm_token_type_ids", None)
+        prepared.pop("token_type_ids", None)
         return prepared
 
 

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -916,7 +916,7 @@ class _PromptPrefill:
             n,
             mask_key_end=self._processed_prefix_len + n,
         )
-        return self._prepare_cached_suffix_prompt_kwargs(
+        return self._prepare_gemma4_prompt_kwargs(
             prompt_kwargs,
             self._processed_prefix_len + n,
         )
@@ -1022,19 +1022,32 @@ class _PromptPrefill:
             self._inputs_embeds.shape[1],
             mask_key_end=self._processed_prefix_len + self._inputs_embeds.shape[1],
         )
-        return self._prepare_cached_suffix_prompt_kwargs(
+        return self._prepare_gemma4_prompt_kwargs(
             prompt_kwargs,
             self._processed_prefix_len + self._inputs_embeds.shape[1],
         )
 
-    def _prepare_cached_suffix_prompt_kwargs(
+    def _prepare_gemma4_prompt_kwargs(
         self,
         prompt_kwargs: dict,
         key_len: int,
     ) -> dict:
         if self._gemma4_image_prefill_sections is None:
             return prompt_kwargs
-        return prepare_gemma4_cached_suffix_prompt_kwargs(prompt_kwargs, key_len)
+
+        # Prepared image spans exactly match type-1 runs. Keep token types only
+        # for image queries so the mask patch need not scan an MLX array.
+        query_start = self._processed_prefix_len
+        has_image = any(
+            span.start < key_len and query_start < span.end
+            for span in self._prefix_cache_save_state.image_spans
+        )
+        if has_image:
+            return prepare_gemma4_cached_suffix_prompt_kwargs(prompt_kwargs, key_len)
+
+        prepared = dict(prompt_kwargs)
+        prepared.pop("mm_token_type_ids", None)
+        return prepared
 
 
 class BatchGenerator:

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -1046,6 +1046,8 @@ class _PromptPrefill:
         if has_image:
             return prepare_gemma4_cached_suffix_prompt_kwargs(prompt_kwargs, key_len)
 
+        # Multimodal text slices still carry an all-zero token-type array. Drop
+        # it so None remains the no-image sentinel for the patched mask builder.
         prepared = dict(prompt_kwargs)
         prepared.pop("mm_token_type_ids", None)
         return prepared

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -898,9 +898,15 @@ class _PromptPrefill:
                 aligned_start = (
                     absolute_image_start // DEFAULT_PREFIX_CHUNK_SIZE
                 ) * DEFAULT_PREFIX_CHUNK_SIZE - suffix_start
+                while aligned_start > processed_prompt_len and any(
+                    start < aligned_start < end
+                    for start, end in self._gemma4_image_prefill_runs
+                ):
+                    aligned_start -= DEFAULT_PREFIX_CHUNK_SIZE
 
-                # Prefer the cache grid before using an exact image boundary.
-                # Never exceed the configured step unless one image is longer.
+                # Prefer the nearest globally safe cache boundary before using an
+                # exact image boundary. Never exceed the configured step unless
+                # one image is itself longer.
                 if aligned_start > processed_prompt_len:
                     safe_boundary = aligned_start
                 elif image_end - processed_prompt_len <= self.prefill_step_size:

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -788,7 +788,6 @@ class _PromptPrefill:
         self._prefix_cache_save_state = prefix_cache_save_state
         self._gemma4_image_prefill_sections = gemma4_image_prefill_sections(
             model,
-            prompt_kwargs,
             prefix_cache_save_state.image_spans,
             len(self._all_tokens),
         )

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -24,7 +24,7 @@ from mlx_engine.model_kit.batched_vision.prompt_inputs import (
     slice_prompt_kwargs,
 )
 from mlx_engine.model_kit.patches.gemma4 import (
-    image_prefill_spans as gemma4_image_prefill_spans,
+    image_prefill_sections as gemma4_image_prefill_sections,
     prepare_cached_suffix_prompt_kwargs as prepare_gemma4_cached_suffix_prompt_kwargs,
 )
 from mlx_vlm.generate import (
@@ -786,7 +786,7 @@ class _PromptPrefill:
         self._all_tokens = list(all_tokens) if all_tokens is not None else []
         self._processed_prefix_len = len(self._all_tokens)
         self._prefix_cache_save_state = prefix_cache_save_state
-        self._gemma4_image_prefill_spans = gemma4_image_prefill_spans(
+        self._gemma4_image_prefill_sections = gemma4_image_prefill_sections(
             model,
             prompt_kwargs,
             prefix_cache_save_state.image_spans,
@@ -856,6 +856,9 @@ class _PromptPrefill:
 
         next_step = 0
         saving_prompt_cache = self._prefix_cache_save_state.callback is not None
+        # Cache-producing prefill calls deliberately end on the 256-token prefix
+        # grid because opaque ArraysCache/SSM state is restorable only at an exact
+        # model-call endpoint. Image-aware adjustments must preserve that grid.
         processed_remainder = self._processed_prefix_len % self.prefill_step_size
         if saving_prompt_cache and processed_remainder:
             # After a partial restore, land on the next normal prefill boundary.
@@ -884,17 +887,24 @@ class _PromptPrefill:
         return self._step_without_splitting_gemma4_image(next_step)
 
     def _step_without_splitting_gemma4_image(self, proposed_step: int) -> int:
-        if proposed_step == 0 or self._gemma4_image_prefill_spans is None:
+        if proposed_step == 0 or self._gemma4_image_prefill_sections is None:
             return proposed_step
 
         processed_prompt_len = self._processed_prefix_len - len(self._all_tokens)
         proposed_boundary = processed_prompt_len + proposed_step
-        for image_start, image_end in self._gemma4_image_prefill_spans:
-            if image_start < proposed_boundary < image_end:
+        for section_start, section_end in self._gemma4_image_prefill_sections:
+            if section_start < proposed_boundary < section_end:
                 safe_boundary = (
-                    image_start if processed_prompt_len < image_start else image_end
+                    section_start
+                    if processed_prompt_len < section_start
+                    else section_end
                 )
-                return safe_boundary - processed_prompt_len
+                safe_step = safe_boundary - processed_prompt_len
+                # A cache-aligned section can extend past the prompt's short tail.
+                # Leave that whole suffix for the final model call.
+                if safe_step >= self._inputs_embeds.shape[1]:
+                    return 0
+                return safe_step
 
         return proposed_step
 
@@ -1022,7 +1032,7 @@ class _PromptPrefill:
         prompt_kwargs: dict,
         key_len: int,
     ) -> dict:
-        if self._gemma4_image_prefill_spans is None:
+        if self._gemma4_image_prefill_sections is None:
             return prompt_kwargs
         return prepare_gemma4_cached_suffix_prompt_kwargs(prompt_kwargs, key_len)
 

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -24,7 +24,7 @@ from mlx_engine.model_kit.batched_vision.prompt_inputs import (
     slice_prompt_kwargs,
 )
 from mlx_engine.model_kit.patches.gemma4 import (
-    image_prefill_sections as gemma4_image_prefill_sections,
+    image_prefill_runs as gemma4_image_prefill_runs,
     prepare_cached_suffix_prompt_kwargs as prepare_gemma4_cached_suffix_prompt_kwargs,
 )
 from mlx_vlm.generate import (
@@ -786,10 +786,9 @@ class _PromptPrefill:
         self._all_tokens = list(all_tokens) if all_tokens is not None else []
         self._processed_prefix_len = len(self._all_tokens)
         self._prefix_cache_save_state = prefix_cache_save_state
-        self._gemma4_image_prefill_sections = gemma4_image_prefill_sections(
+        self._gemma4_image_prefill_runs = gemma4_image_prefill_runs(
             model,
             prompt_kwargs,
-            len(self._all_tokens),
         )
         # Restored exact hot caches may carry an existing row. Trimmed/disk
         # restores pass None and let prompt prep recompute it.
@@ -855,9 +854,10 @@ class _PromptPrefill:
 
         next_step = 0
         saving_prompt_cache = self._prefix_cache_save_state.callback is not None
-        # Cache-producing prefill calls deliberately end on the 256-token prefix
+        # Cache-producing prefill calls normally end on the 256-token prefix
         # grid because opaque ArraysCache/SSM state is restorable only at an exact
-        # model-call endpoint. Image-aware adjustments must preserve that grid.
+        # model-call endpoint. Gemma 4 has only KV/rotating-KV caches, so its
+        # image-aware adjustment may use a non-aligned endpoint instead.
         processed_remainder = self._processed_prefix_len % self.prefill_step_size
         if saving_prompt_cache and processed_remainder:
             # After a partial restore, land on the next normal prefill boundary.
@@ -886,21 +886,33 @@ class _PromptPrefill:
         return self._step_without_splitting_gemma4_image_run(next_step)
 
     def _step_without_splitting_gemma4_image_run(self, proposed_step: int) -> int:
-        if proposed_step == 0 or self._gemma4_image_prefill_sections is None:
+        if proposed_step == 0 or self._gemma4_image_prefill_runs is None:
             return proposed_step
 
-        processed_prompt_len = self._processed_prefix_len - len(self._all_tokens)
+        suffix_start = len(self._all_tokens)
+        processed_prompt_len = self._processed_prefix_len - suffix_start
         proposed_boundary = processed_prompt_len + proposed_step
-        for section_start, section_end in self._gemma4_image_prefill_sections:
-            if section_start < proposed_boundary < section_end:
-                safe_boundary = (
-                    section_start
-                    if processed_prompt_len < section_start
-                    else section_end
-                )
+        for image_start, image_end in self._gemma4_image_prefill_runs:
+            if image_start < proposed_boundary < image_end:
+                absolute_image_start = suffix_start + image_start
+                aligned_start = (
+                    absolute_image_start // DEFAULT_PREFIX_CHUNK_SIZE
+                ) * DEFAULT_PREFIX_CHUNK_SIZE - suffix_start
+
+                # Prefer the cache grid before using an exact image boundary.
+                # Never exceed the configured step unless one image is longer.
+                if aligned_start > processed_prompt_len:
+                    safe_boundary = aligned_start
+                elif image_end - processed_prompt_len <= self.prefill_step_size:
+                    safe_boundary = image_end
+                elif processed_prompt_len < image_start:
+                    safe_boundary = image_start
+                else:
+                    # A single image longer than the configured step is the
+                    # smallest valid model call from its start.
+                    safe_boundary = image_end
+
                 safe_step = safe_boundary - processed_prompt_len
-                # A cache-aligned section can extend past the prompt's short tail.
-                # Leave that whole suffix for the final model call.
                 if safe_step >= self._inputs_embeds.shape[1]:
                     return 0
                 return safe_step
@@ -1031,18 +1043,18 @@ class _PromptPrefill:
         prompt_kwargs: dict,
         key_len: int,
     ) -> dict:
-        if self._gemma4_image_prefill_sections is None:
+        if self._gemma4_image_prefill_runs is None:
             return prompt_kwargs
 
-        # Protected sections come from exact token-type runs, unlike the cache's
-        # potentially coarse image spans. Keep token types only for image queries
-        # so the mask patch need not scan an MLX array on every model call.
+        # These exact token-type runs are independent of the cache's potentially
+        # coarse image spans. Keep token types only for image queries so the mask
+        # patch need not scan an MLX array on every model call.
         suffix_start = len(self._all_tokens)
         query_start = self._processed_prefix_len - suffix_start
         query_end = key_len - suffix_start
         has_image = any(
-            section_start < query_end and query_start < section_end
-            for section_start, section_end in self._gemma4_image_prefill_sections
+            image_start < query_end and query_start < image_end
+            for image_start, image_end in self._gemma4_image_prefill_runs
         )
         if has_image:
             return prepare_gemma4_cached_suffix_prompt_kwargs(prompt_kwargs, key_len)

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -881,34 +881,20 @@ class _PromptPrefill:
             if target_prefix_len > self._processed_prefix_len:
                 next_step = target_prefix_len - self._processed_prefix_len
 
-        return self._step_without_splitting_gemma4_image(
-            next_step,
-            remaining_tokens,
-        )
+        return self._step_without_splitting_gemma4_image(next_step)
 
-    def _step_without_splitting_gemma4_image(
-        self,
-        proposed_step: int,
-        remaining_tokens: int,
-    ) -> int:
+    def _step_without_splitting_gemma4_image(self, proposed_step: int) -> int:
         if proposed_step == 0 or self._gemma4_image_prefill_spans is None:
             return proposed_step
 
         processed_prompt_len = self._processed_prefix_len - len(self._all_tokens)
         proposed_boundary = processed_prompt_len + proposed_step
         for image_start, image_end in self._gemma4_image_prefill_spans:
-            if not image_start < proposed_boundary < image_end:
-                continue
-            tokens_before_image = image_start - processed_prompt_len
-            if tokens_before_image > 0:
-                return tokens_before_image
-
-            image_tokens_remaining = image_end - processed_prompt_len
-            if image_tokens_remaining < remaining_tokens:
-                return image_tokens_remaining
-            # The final model call must retain at least one prompt token. If the
-            # image reaches the prompt end, let final prefill process it whole.
-            return 0
+            if image_start < proposed_boundary < image_end:
+                safe_boundary = (
+                    image_start if processed_prompt_len < image_start else image_end
+                )
+                return safe_boundary - processed_prompt_len
 
         return proposed_step
 

--- a/mlx_engine/model_kit/batched_vision/prompt_cache/types.py
+++ b/mlx_engine/model_kit/batched_vision/prompt_cache/types.py
@@ -3,7 +3,9 @@ from typing import Any, Final, Literal, TypeAlias
 
 
 # LMCache defaults to 256-token external chunks, and MLX KV caches allocate in
-# 256-token steps. This is a cache store chunk size, not vLLM's KV page size.
+# 256-token steps. Cache-producing prefill calls deliberately end on this grid:
+# opaque ArraysCache/SSM state is reusable only at an exact model-call endpoint.
+# This is a cache store chunk size, not vLLM's KV page size.
 DEFAULT_PREFIX_CHUNK_SIZE = 256
 RecordKind: TypeAlias = Literal["kv_delta", "rotating_delta", "state_checkpoint"]
 RECORD_KIND_KV_DELTA: Final[RecordKind] = "kv_delta"

--- a/mlx_engine/model_kit/batched_vision/prompt_cache/types.py
+++ b/mlx_engine/model_kit/batched_vision/prompt_cache/types.py
@@ -3,9 +3,11 @@ from typing import Any, Final, Literal, TypeAlias
 
 
 # LMCache defaults to 256-token external chunks, and MLX KV caches allocate in
-# 256-token steps. Cache-producing prefill calls deliberately end on this grid:
+# 256-token steps. Cache-producing prefill calls normally end on this grid because
 # opaque ArraysCache/SSM state is reusable only at an exact model-call endpoint.
-# This is a cache store chunk size, not vLLM's KV page size.
+# Gemma 4 may instead end at an image-safe boundary; its sliceable KV records are
+# still stored on this grid. This is a cache store chunk size, not vLLM's KV
+# page size.
 DEFAULT_PREFIX_CHUNK_SIZE = 256
 RecordKind: TypeAlias = Literal["kv_delta", "rotating_delta", "state_checkpoint"]
 RECORD_KIND_KV_DELTA: Final[RecordKind] = "kv_delta"

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -27,7 +27,7 @@ def is_unified_model(model: Any) -> bool:
 
 
 def uses_bidirectional_visual_attention(model: Any) -> bool:
-    """Return true for Gemma4-family language models with visual bidir masks."""
+    """Return true for Gemma 4 language models with visual bidirectional masks."""
     language_model = _language_model(model)
     if not is_gemma4_model_type(getattr(language_model, "model_type", None)):
         return False
@@ -49,43 +49,58 @@ def config_uses_bidirectional_visual_attention(config: dict | Any) -> bool:
     return is_gemma4_model_type(model_type) and attention_mode == "vision"
 
 
-def visual_prefill_prefix_len(
+def image_prefill_spans(
     model: Any,
     prompt_kwargs: dict,
     image_spans: list[Any],
     cached_prefix_len: int,
-) -> int | None:
-    """Return the visual prefix Gemma4 bidir masks need in one model call.
+) -> list[tuple[int, int]] | None:
+    """Return request-relative image runs that prefill must not split.
 
-    Gemma4 derives its bidirectional visual attention overlay from token-type ids
-    visible to the current language-model call. Keep the first prefill anchored
-    at the current suffix start through the last visual token; trailing text can
-    go back to ordinary chunked prefill.
+    Gemma 4 local-attention layers are bidirectional within each image block, so
+    every contiguous image run must be visible in one model call. Token type ids
+    are authoritative when present; prepared image spans are the fallback.
     """
-    if not uses_bidirectional_visual_attention(model):
-        return None
-
     token_types = prompt_kwargs.get("mm_token_type_ids")
     if token_types is None:
         token_types = prompt_kwargs.get("token_type_ids")
-    if not isinstance(token_types, mx.array):
-        # Token types are authoritative when present. Image spans are a fallback
-        # for processor/model combinations that omit them but still carry images.
-        last_visual_end = max((span.end for span in image_spans), default=0)
-        relative_visual_end = last_visual_end - cached_prefix_len
-        return relative_visual_end if relative_visual_end > 0 else None
 
-    values = token_types.reshape(-1).tolist()
-    last_visual_idx = -1
-    for idx, value in enumerate(values):
-        if value in (1, 2):
-            last_visual_idx = idx
+    if isinstance(token_types, mx.array):
+        values = token_types.reshape(-1).tolist()
+        if is_gemma4_model_type(_model_type(model)) and 2 in values:
+            raise ValueError("Gemma 4 video input is not supported by the MLX backend")
+    else:
+        values = None
 
-    return None if last_visual_idx < 0 else last_visual_idx + 1
+    if not uses_bidirectional_visual_attention(model):
+        return None
+
+    if values is not None:
+        spans = []
+        image_start = None
+        for index, value in enumerate(values):
+            if value == 1 and image_start is None:
+                image_start = index
+            elif value != 1 and image_start is not None:
+                spans.append((image_start, index))
+                image_start = None
+        if image_start is not None:
+            spans.append((image_start, len(values)))
+        return spans
+
+    spans = []
+    for span in image_spans:
+        if span.start < cached_prefix_len < span.end:
+            raise ValueError("A restored Gemma 4 prompt cache splits an image block")
+        relative_start = span.start - cached_prefix_len
+        relative_end = span.end - cached_prefix_len
+        if relative_end > 0:
+            spans.append((max(relative_start, 0), relative_end))
+    return sorted(spans)
 
 
 def prepare_cached_suffix_prompt_kwargs(prompt_kwargs: dict, key_len: int) -> dict:
-    """Pad visual token-type ids so Gemma4 masks can line up with cached keys."""
+    """Pad visual token-type ids so Gemma 4 masks can line up with cached keys."""
     prepared = prompt_kwargs
     for name in ("mm_token_type_ids", "token_type_ids"):
         token_type_ids = prepared.get(name)
@@ -98,21 +113,26 @@ def prepare_cached_suffix_prompt_kwargs(prompt_kwargs: dict, key_len: int) -> di
 
 
 def patch_loaded_model(model: Any) -> None:
-    """Patch loaded Gemma4 bidir models for cached visual suffix masks."""
+    """Match Transformers Gemma 4 visual masks for cached, chunked prefill."""
     language_model = _language_model(model)
     if not uses_bidirectional_visual_attention(language_model):
         return
     text_model = getattr(language_model, "model", language_model)
-    if getattr(text_model, "_mlx_engine_suffix_visual_mask_patch", False):
+    if getattr(text_model, "_mlx_engine_gemma4_visual_mask_patch", False):
         return
     if not hasattr(text_model, "_apply_blockwise_bidirectional_overlay"):
         return
 
-    # Upstream builds Gemma4's visual overlay from token types over the key
-    # length. With a restored prefix, only the suffix is queried; with sliding
-    # layers, only a recent key window is visible. Compare current query rows
-    # against the key rows covered by this layer's mask.
-    def _apply_blockwise_bidirectional_overlay(self, base_mask, mm_token_type_ids):
+    # mlx-vlm requires square masks and applies the visual overlay to full
+    # attention. Transformers keeps full attention causal and applies the
+    # overlay only to sliding attention. This version also aligns cached suffix
+    # query rows with the keys visible to the current layer.
+    def _apply_blockwise_bidirectional_overlay(
+        self,
+        base_mask,
+        mm_token_type_ids,
+        window_size=None,
+    ):
         if mm_token_type_ids is None:
             return base_mask
         key_len = base_mask.shape[-1]
@@ -124,16 +144,61 @@ def patch_loaded_model(model: Any) -> None:
         block_sequence_ids = self._block_sequence_ids_for_mask(mm_token_type_ids)
         query_len = base_mask.shape[-2]
         query_block_sequence_ids = block_sequence_ids[:, -query_len:]
-        q_blocks = mx.expand_dims(query_block_sequence_ids, -1)
-        k_blocks = mx.expand_dims(block_sequence_ids, -2)
-        same_block = (q_blocks != -1) & (q_blocks == k_blocks)
+        query_blocks = mx.expand_dims(query_block_sequence_ids, -1)
+        key_blocks = mx.expand_dims(block_sequence_ids, -2)
+        same_block = (query_blocks != -1) & (query_blocks == key_blocks)
+        if window_size is not None:
+            query_positions = mx.arange(key_len - query_len, key_len)[:, None]
+            key_positions = mx.arange(key_len)[None, :]
+            same_block = same_block & (key_positions > query_positions - window_size)
         return base_mask | mx.expand_dims(same_block, 1)
 
     text_model._apply_blockwise_bidirectional_overlay = MethodType(
         _apply_blockwise_bidirectional_overlay,
         text_model,
     )
-    text_model._mlx_engine_suffix_visual_mask_patch = True
+
+    if hasattr(text_model, "_make_masks"):
+        from mlx_vlm.models.cache import create_causal_mask
+
+        original_make_masks = text_model._make_masks
+
+        def _make_masks(self, h, cache, mm_token_type_ids=None):
+            if mm_token_type_ids is None:
+                return original_make_masks(h, cache, mm_token_type_ids)
+            if int(mx.sum(mm_token_type_ids == 2).item()) > 0:
+                raise ValueError(
+                    "Gemma 4 video input is not supported by the MLX backend"
+                )
+
+            has_image_tokens = int(mx.sum(mm_token_type_ids == 1).item()) > 0
+            if not has_image_tokens or h.shape[1] <= 1:
+                return original_make_masks(h, cache, mm_token_type_ids)
+
+            masks = original_make_masks(h, cache, None)
+            patched_sliding_mask = None
+            patched_masks = []
+            for layer, base_mask in zip(self.layers, masks):
+                if layer.layer_type != "sliding_attention":
+                    patched_masks.append(base_mask)
+                    continue
+                if patched_sliding_mask is None:
+                    if isinstance(base_mask, str) and base_mask == "causal":
+                        base_mask = create_causal_mask(
+                            h.shape[1],
+                            window_size=self.window_size,
+                        )
+                    patched_sliding_mask = self._apply_blockwise_bidirectional_overlay(
+                        base_mask,
+                        mm_token_type_ids,
+                        window_size=self.window_size,
+                    )
+                patched_masks.append(patched_sliding_mask)
+            return patched_masks
+
+        text_model._make_masks = MethodType(_make_masks, text_model)
+
+    text_model._mlx_engine_gemma4_visual_mask_patch = True
 
 
 def _pad_visual_token_type_ids_to_key_len(

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -8,7 +8,6 @@ from mlx_vlm.models.cache import create_causal_mask
 
 from mlx_engine.model_kit.batched_vision.prompt_cache.types import (
     DEFAULT_PREFIX_CHUNK_SIZE,
-    PromptImageSpan,
 )
 
 
@@ -42,16 +41,23 @@ def config_uses_bidirectional_visual_attention(config: dict) -> bool:
     )
 
 
+def _get_token_type_ids(prompt_kwargs: dict) -> mx.array | None:
+    token_types = prompt_kwargs.get("mm_token_type_ids")
+    if token_types is None:
+        token_types = prompt_kwargs.get("token_type_ids")
+    return token_types
+
+
 def image_prefill_sections(
     model: Any,
-    image_spans: list[PromptImageSpan],
+    prompt_kwargs: dict,
     cached_prefix_len: int,
 ) -> list[tuple[int, int]] | None:
     """Return suffix-relative cache-aligned sections prefill must not split.
 
-    Prepared image spans and Gemma 4 token types come from the same expanded
-    image-token runs. Cache restore rejects positions inside those spans before
-    constructing the suffix, so every remaining span starts at or after it.
+    Gemma's token types are the source of truth for visual attention runs. Cache
+    image spans can conservatively cover the whole prompt when image sentinels
+    are unavailable, so they must remain separate from this prefill plan.
 
     Sections include the surrounding partial 256-token cache chunks. This keeps
     model-call endpoints on the prompt-cache grid: opaque SSM state is reusable
@@ -60,21 +66,38 @@ def image_prefill_sections(
     if not uses_bidirectional_visual_attention(model):
         return None
 
+    token_types = _get_token_type_ids(prompt_kwargs)
+    if token_types is None:
+        return []
+
+    # Materialize once while building the request's prefill plan. Each contiguous
+    # type-1 run is one image's bidirectional soft-token block and must stay in a
+    # single model call; later scheduling uses only these Python-side sections.
+    image_runs: list[tuple[int, int]] = []
+    image_start = None
+    for index, token_type in enumerate(token_types.reshape(-1).tolist()):
+        if token_type == 1:
+            if image_start is None:
+                image_start = index
+        elif image_start is not None:
+            image_runs.append((image_start, index))
+            image_start = None
+    if image_start is not None:
+        image_runs.append((image_start, token_types.shape[1]))
+
     sections: list[tuple[int, int]] = []
-    for span in image_spans:
-        # Restores never end inside an image run, so an image that starts before
-        # the restored prefix is already cached in full.
-        if span.start < cached_prefix_len:
-            continue
+    for image_start, image_end in image_runs:
+        absolute_start = cached_prefix_len + image_start
+        absolute_end = cached_prefix_len + image_end
 
         # Expand the raw image run to its surrounding 256-token cache chunks.
         # Adjusted model-call endpoints then remain valid cache checkpoints.
         section_start = max(
             cached_prefix_len,
-            (span.start // DEFAULT_PREFIX_CHUNK_SIZE) * DEFAULT_PREFIX_CHUNK_SIZE,
+            (absolute_start // DEFAULT_PREFIX_CHUNK_SIZE) * DEFAULT_PREFIX_CHUNK_SIZE,
         )
         section_end = (
-            (span.end + DEFAULT_PREFIX_CHUNK_SIZE - 1)
+            (absolute_end + DEFAULT_PREFIX_CHUNK_SIZE - 1)
             // DEFAULT_PREFIX_CHUNK_SIZE
             * DEFAULT_PREFIX_CHUNK_SIZE
         )
@@ -94,23 +117,29 @@ def image_prefill_sections(
 
 
 def prepare_cached_suffix_prompt_kwargs(prompt_kwargs: dict, key_len: int) -> dict:
-    """Pad a known image slice's token types to line up with cached keys."""
-    token_types = prompt_kwargs["mm_token_type_ids"]
-    prefix_len = key_len - token_types.shape[1]
-    if prefix_len == 0:
-        return prompt_kwargs
+    """Pad visual token types to line up with cached keys when present."""
+    prepared = prompt_kwargs
+    for name in ("mm_token_type_ids", "token_type_ids"):
+        token_types = prompt_kwargs.get(name)
+        if token_types is None:
+            continue
 
-    prepared = dict(prompt_kwargs)
-    prepared["mm_token_type_ids"] = mx.concatenate(
-        [
-            mx.zeros(
-                (token_types.shape[0], prefix_len),
-                dtype=token_types.dtype,
-            ),
-            token_types,
-        ],
-        axis=1,
-    )
+        prefix_len = key_len - token_types.shape[1]
+        if prefix_len == 0:
+            continue
+
+        if prepared is prompt_kwargs:
+            prepared = dict(prompt_kwargs)
+        prepared[name] = mx.concatenate(
+            [
+                mx.zeros(
+                    (token_types.shape[0], prefix_len),
+                    dtype=token_types.dtype,
+                ),
+                token_types,
+            ],
+            axis=1,
+        )
     return prepared
 
 

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -134,10 +134,15 @@ def patch_loaded_model(model: Any) -> None:
         # image-block overlay only to sliding attention.
         masks = original_make_masks(h, cache, None)
         sliding_mask = next(
-            mask
-            for layer, mask in zip(self.layers, masks)
-            if layer.layer_type == "sliding_attention"
+            (
+                mask
+                for layer, mask in zip(self.layers, masks)
+                if layer.layer_type == "sliding_attention"
+            ),
+            None,
         )
+        if sliding_mask is None:
+            return masks
         if isinstance(sliding_mask, str):
             sliding_mask = create_causal_mask(
                 h.shape[1],

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -41,13 +41,8 @@ def config_uses_bidirectional_visual_attention(config: dict) -> bool:
     )
 
 
-def _contains_video_tokens(token_types: mx.array | None) -> bool:
-    return token_types is not None and bool(mx.any(token_types == 2).item())
-
-
 def image_prefill_sections(
     model: Any,
-    prompt_kwargs: dict,
     image_spans: list[PromptImageSpan],
     cached_prefix_len: int,
 ) -> list[tuple[int, int]] | None:
@@ -63,10 +58,6 @@ def image_prefill_sections(
     """
     if not uses_bidirectional_visual_attention(model):
         return None
-
-    token_types = prompt_kwargs.get("mm_token_type_ids")
-    if _contains_video_tokens(token_types):
-        raise ValueError("Gemma 4 video input is not supported by the MLX backend")
 
     sections: list[tuple[int, int]] = []
     for span in image_spans:

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -106,9 +106,9 @@ def image_prefill_sections(
             section_start - cached_prefix_len,
             section_end - cached_prefix_len,
         )
-        # Nearby images can expand into overlapping or touching cache-aligned
-        # envelopes. Coalesce them into one protected prefill section.
-        if sections and relative_section[0] <= sections[-1][1]:
+        # Coalesce overlapping envelopes. Keep touching envelopes separate: their
+        # shared cache boundary lies outside both image runs and is safe to use.
+        if sections and relative_section[0] < sections[-1][1]:
             sections[-1] = (sections[-1][0], relative_section[1])
         else:
             sections.append(relative_section)

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -6,10 +6,6 @@ from typing import Any
 import mlx.core as mx
 from mlx_vlm.models.cache import create_causal_mask
 
-from mlx_engine.model_kit.batched_vision.prompt_cache.types import (
-    DEFAULT_PREFIX_CHUNK_SIZE,
-)
-
 
 def is_unified_model_type(model_type: str | None) -> bool:
     return model_type is not None and model_type.startswith("gemma4_unified")
@@ -48,20 +44,15 @@ def _get_token_type_ids(prompt_kwargs: dict) -> mx.array | None:
     return token_types
 
 
-def image_prefill_sections(
+def image_prefill_runs(
     model: Any,
     prompt_kwargs: dict,
-    cached_prefix_len: int,
 ) -> list[tuple[int, int]] | None:
-    """Return suffix-relative cache-aligned sections prefill must not split.
+    """Return suffix-relative visual runs that prefill must not split.
 
     Gemma's token types are the source of truth for visual attention runs. Cache
     image spans can conservatively cover the whole prompt when image sentinels
     are unavailable, so they must remain separate from this prefill plan.
-
-    Sections include the surrounding partial 256-token cache chunks. This keeps
-    model-call endpoints on the prompt-cache grid: opaque SSM state is reusable
-    only when its cache-chunk boundary is also an exact prefill endpoint.
     """
     if not uses_bidirectional_visual_attention(model):
         return None
@@ -71,8 +62,8 @@ def image_prefill_sections(
         return []
 
     # Materialize once while building the request's prefill plan. Each contiguous
-    # type-1 run is one image's bidirectional soft-token block and must stay in a
-    # single model call; later scheduling uses only these Python-side sections.
+    # type-1 run is one bidirectional image block and must stay in a single model
+    # call; later scheduling uses only these Python-side ranges.
     image_runs: list[tuple[int, int]] = []
     image_start = None
     for index, token_type in enumerate(token_types.reshape(-1).tolist()):
@@ -85,35 +76,7 @@ def image_prefill_sections(
     if image_start is not None:
         image_runs.append((image_start, token_types.shape[1]))
 
-    sections: list[tuple[int, int]] = []
-    for image_start, image_end in image_runs:
-        absolute_start = cached_prefix_len + image_start
-        absolute_end = cached_prefix_len + image_end
-
-        # Expand the raw image run to its surrounding 256-token cache chunks.
-        # Adjusted model-call endpoints then remain valid cache checkpoints.
-        section_start = max(
-            cached_prefix_len,
-            (absolute_start // DEFAULT_PREFIX_CHUNK_SIZE) * DEFAULT_PREFIX_CHUNK_SIZE,
-        )
-        section_end = (
-            (absolute_end + DEFAULT_PREFIX_CHUNK_SIZE - 1)
-            // DEFAULT_PREFIX_CHUNK_SIZE
-            * DEFAULT_PREFIX_CHUNK_SIZE
-        )
-        # Prompt prefill indexes the uncached suffix, not the full prompt.
-        relative_section = (
-            section_start - cached_prefix_len,
-            section_end - cached_prefix_len,
-        )
-        # Coalesce overlapping envelopes. Keep touching envelopes separate: their
-        # shared cache boundary lies outside both image runs and is safe to use.
-        if sections and relative_section[0] < sections[-1][1]:
-            sections[-1] = (sections[-1][0], relative_section[1])
-        else:
-            sections.append(relative_section)
-
-    return sections
+    return image_runs
 
 
 def prepare_cached_suffix_prompt_kwargs(prompt_kwargs: dict, key_len: int) -> dict:

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -124,6 +124,12 @@ def patch_loaded_model(model: Any) -> None:
     if getattr(text_model, "_mlx_engine_gemma4_visual_mask_patch", False):
         return
 
+    # Transformers 5.14.1 is the source of truth for Gemma 4 mask composition:
+    # https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2112-L2162
+    # mlx-vlm requires square masks and applies the visual overlay to full
+    # attention. Transformers keeps full attention causal and applies the
+    # overlay only to sliding attention. This patch also aligns cached-suffix
+    # query rows with the keys visible to each sliding-attention layer.
     original_make_masks = text_model._make_masks
 
     def _make_masks(self, h, cache, mm_token_type_ids=None):

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -5,7 +5,10 @@ from typing import Any
 
 import mlx.core as mx
 
-from mlx_engine.model_kit.batched_vision.prompt_cache.types import PromptImageSpan
+from mlx_engine.model_kit.batched_vision.prompt_cache.types import (
+    DEFAULT_PREFIX_CHUNK_SIZE,
+    PromptImageSpan,
+)
 
 
 def is_unified_model_type(model_type: str | None) -> bool:
@@ -42,17 +45,21 @@ def _contains_token_type(token_types: mx.array | None, value: int) -> bool:
     return token_types is not None and bool(mx.any(token_types == value).item())
 
 
-def image_prefill_spans(
+def image_prefill_sections(
     model: Any,
     prompt_kwargs: dict,
     image_spans: list[PromptImageSpan],
     cached_prefix_len: int,
 ) -> list[tuple[int, int]] | None:
-    """Return suffix-relative image spans that prefill must not split.
+    """Return suffix-relative cache-aligned sections prefill must not split.
 
     Prepared image spans and Gemma 4 token types come from the same expanded
     image-token runs. Cache restore rejects positions inside those spans before
     constructing the suffix, so every remaining span starts at or after it.
+
+    Sections include the surrounding partial 256-token cache chunks. This keeps
+    model-call endpoints on the prompt-cache grid: opaque SSM state is reusable
+    only when its cache-chunk boundary is also an exact prefill endpoint.
     """
     if not uses_bidirectional_visual_attention(model):
         return None
@@ -61,11 +68,30 @@ def image_prefill_spans(
     if _contains_token_type(token_types, 2):
         raise ValueError("Gemma 4 video input is not supported by the MLX backend")
 
-    return [
-        (span.start - cached_prefix_len, span.end - cached_prefix_len)
-        for span in image_spans
-        if span.start >= cached_prefix_len
-    ]
+    sections: list[tuple[int, int]] = []
+    for span in image_spans:
+        if span.start < cached_prefix_len:
+            continue
+
+        section_start = max(
+            cached_prefix_len,
+            (span.start // DEFAULT_PREFIX_CHUNK_SIZE) * DEFAULT_PREFIX_CHUNK_SIZE,
+        )
+        section_end = (
+            (span.end + DEFAULT_PREFIX_CHUNK_SIZE - 1)
+            // DEFAULT_PREFIX_CHUNK_SIZE
+            * DEFAULT_PREFIX_CHUNK_SIZE
+        )
+        relative_section = (
+            section_start - cached_prefix_len,
+            section_end - cached_prefix_len,
+        )
+        if sections and relative_section[0] <= sections[-1][1]:
+            sections[-1] = (sections[-1][0], relative_section[1])
+        else:
+            sections.append(relative_section)
+
+    return sections
 
 
 def prepare_cached_suffix_prompt_kwargs(prompt_kwargs: dict, key_len: int) -> dict:

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -4,6 +4,7 @@ from types import MethodType
 from typing import Any
 
 import mlx.core as mx
+from mlx_vlm.models.cache import create_causal_mask
 
 from mlx_engine.model_kit.batched_vision.prompt_cache.types import (
     DEFAULT_PREFIX_CHUNK_SIZE,
@@ -122,8 +123,6 @@ def patch_loaded_model(model: Any) -> None:
     text_model = language_model.model
     if getattr(text_model, "_mlx_engine_gemma4_visual_mask_patch", False):
         return
-
-    from mlx_vlm.models.cache import create_causal_mask
 
     original_make_masks = text_model._make_masks
 

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -61,9 +61,13 @@ def image_prefill_sections(
 
     sections: list[tuple[int, int]] = []
     for span in image_spans:
+        # Restores never end inside an image run, so an image that starts before
+        # the restored prefix is already cached in full.
         if span.start < cached_prefix_len:
             continue
 
+        # Expand the raw image run to its surrounding 256-token cache chunks.
+        # Adjusted model-call endpoints then remain valid cache checkpoints.
         section_start = max(
             cached_prefix_len,
             (span.start // DEFAULT_PREFIX_CHUNK_SIZE) * DEFAULT_PREFIX_CHUNK_SIZE,
@@ -73,10 +77,13 @@ def image_prefill_sections(
             // DEFAULT_PREFIX_CHUNK_SIZE
             * DEFAULT_PREFIX_CHUNK_SIZE
         )
+        # Prompt prefill indexes the uncached suffix, not the full prompt.
         relative_section = (
             section_start - cached_prefix_len,
             section_end - cached_prefix_len,
         )
+        # Nearby images can expand into overlapping or touching cache-aligned
+        # envelopes. Coalesce them into one protected prefill section.
         if sections and relative_section[0] <= sections[-1][1]:
             sections[-1] = (sections[-1][0], relative_section[1])
         else:

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -41,8 +41,8 @@ def config_uses_bidirectional_visual_attention(config: dict) -> bool:
     )
 
 
-def _contains_token_type(token_types: mx.array | None, value: int) -> bool:
-    return token_types is not None and bool(mx.any(token_types == value).item())
+def _contains_video_tokens(token_types: mx.array | None) -> bool:
+    return token_types is not None and bool(mx.any(token_types == 2).item())
 
 
 def image_prefill_sections(
@@ -65,7 +65,7 @@ def image_prefill_sections(
         return None
 
     token_types = prompt_kwargs.get("mm_token_type_ids")
-    if _contains_token_type(token_types, 2):
+    if _contains_video_tokens(token_types):
         raise ValueError("Gemma 4 video input is not supported by the MLX backend")
 
     sections: list[tuple[int, int]] = []
@@ -95,13 +95,10 @@ def image_prefill_sections(
 
 
 def prepare_cached_suffix_prompt_kwargs(prompt_kwargs: dict, key_len: int) -> dict:
-    """Pad image token types so a Gemma 4 suffix lines up with cached keys."""
-    token_types = prompt_kwargs.get("mm_token_type_ids")
-    if token_types is None:
-        return prompt_kwargs
-
+    """Pad a known image slice's token types to line up with cached keys."""
+    token_types = prompt_kwargs["mm_token_type_ids"]
     prefix_len = key_len - token_types.shape[1]
-    if prefix_len == 0 or not _contains_token_type(token_types, 1):
+    if prefix_len == 0:
         return prompt_kwargs
 
     prepared = dict(prompt_kwargs)
@@ -133,8 +130,10 @@ def patch_loaded_model(model: Any) -> None:
     original_make_masks = text_model._make_masks
 
     def _make_masks(self, h, cache, mm_token_type_ids=None):
-        if not _contains_token_type(mm_token_type_ids, 1):
-            return original_make_masks(h, cache, mm_token_type_ids)
+        # The batcher omits token types from image-free slices, so non-None is a
+        # known image slice and does not require a synchronous value scan here.
+        if mm_token_type_ids is None:
+            return original_make_masks(h, cache, None)
 
         # Transformers keeps full attention causal and adds the bidirectional
         # image-block overlay only to sliding attention.

--- a/mlx_engine/model_kit/patches/gemma4.py
+++ b/mlx_engine/model_kit/patches/gemma4.py
@@ -5,110 +5,90 @@ from typing import Any
 
 import mlx.core as mx
 
+from mlx_engine.model_kit.batched_vision.prompt_cache.types import PromptImageSpan
+
 
 def is_unified_model_type(model_type: str | None) -> bool:
-    return str(model_type or "").startswith("gemma4_unified")
+    return model_type is not None and model_type.startswith("gemma4_unified")
 
 
 def is_gemma4_model_type(model_type: str | None) -> bool:
-    return str(model_type or "").startswith("gemma4")
+    return model_type is not None and model_type.startswith("gemma4")
 
 
 def _language_model(model: Any) -> Any:
     return getattr(model, "language_model", model)
 
 
-def _model_type(model: Any) -> str | None:
-    return getattr(_language_model(model), "model_type", None)
-
-
-def is_unified_model(model: Any) -> bool:
-    return is_unified_model_type(_model_type(model))
-
-
 def uses_bidirectional_visual_attention(model: Any) -> bool:
     """Return true for Gemma 4 language models with visual bidirectional masks."""
     language_model = _language_model(model)
-    if not is_gemma4_model_type(getattr(language_model, "model_type", None)):
-        return False
-    config = getattr(language_model, "config", None)
-    return _get_config_value(config, "use_bidirectional_attention") == "vision"
+    return (
+        is_gemma4_model_type(getattr(language_model, "model_type", None))
+        and getattr(language_model.config, "use_bidirectional_attention", None)
+        == "vision"
+    )
 
 
-def _get_config_value(config: dict | Any, key: str) -> Any:
-    if isinstance(config, dict):
-        return config.get(key)
-    return getattr(config, key, None)
-
-
-def config_uses_bidirectional_visual_attention(config: dict | Any) -> bool:
+def config_uses_bidirectional_visual_attention(config: dict) -> bool:
     """Config-level version used before the loaded model exists."""
-    model_type = _get_config_value(config, "model_type")
-    text_config = _get_config_value(config, "text_config") or config
-    attention_mode = _get_config_value(text_config, "use_bidirectional_attention")
-    return is_gemma4_model_type(model_type) and attention_mode == "vision"
+    return (
+        is_gemma4_model_type(config.get("model_type"))
+        and config["text_config"].get("use_bidirectional_attention") == "vision"
+    )
+
+
+def _contains_token_type(token_types: mx.array | None, value: int) -> bool:
+    return token_types is not None and bool(mx.any(token_types == value).item())
 
 
 def image_prefill_spans(
     model: Any,
     prompt_kwargs: dict,
-    image_spans: list[Any],
+    image_spans: list[PromptImageSpan],
     cached_prefix_len: int,
 ) -> list[tuple[int, int]] | None:
-    """Return request-relative image runs that prefill must not split.
+    """Return suffix-relative image spans that prefill must not split.
 
-    Gemma 4 local-attention layers are bidirectional within each image block, so
-    every contiguous image run must be visible in one model call. Token type ids
-    are authoritative when present; prepared image spans are the fallback.
+    Prepared image spans and Gemma 4 token types come from the same expanded
+    image-token runs. Cache restore rejects positions inside those spans before
+    constructing the suffix, so every remaining span starts at or after it.
     """
-    token_types = prompt_kwargs.get("mm_token_type_ids")
-    if token_types is None:
-        token_types = prompt_kwargs.get("token_type_ids")
-
-    if isinstance(token_types, mx.array):
-        values = token_types.reshape(-1).tolist()
-        if is_gemma4_model_type(_model_type(model)) and 2 in values:
-            raise ValueError("Gemma 4 video input is not supported by the MLX backend")
-    else:
-        values = None
-
     if not uses_bidirectional_visual_attention(model):
         return None
 
-    if values is not None:
-        spans = []
-        image_start = None
-        for index, value in enumerate(values):
-            if value == 1 and image_start is None:
-                image_start = index
-            elif value != 1 and image_start is not None:
-                spans.append((image_start, index))
-                image_start = None
-        if image_start is not None:
-            spans.append((image_start, len(values)))
-        return spans
+    token_types = prompt_kwargs.get("mm_token_type_ids")
+    if _contains_token_type(token_types, 2):
+        raise ValueError("Gemma 4 video input is not supported by the MLX backend")
 
-    spans = []
-    for span in image_spans:
-        if span.start < cached_prefix_len < span.end:
-            raise ValueError("A restored Gemma 4 prompt cache splits an image block")
-        relative_start = span.start - cached_prefix_len
-        relative_end = span.end - cached_prefix_len
-        if relative_end > 0:
-            spans.append((max(relative_start, 0), relative_end))
-    return sorted(spans)
+    return [
+        (span.start - cached_prefix_len, span.end - cached_prefix_len)
+        for span in image_spans
+        if span.start >= cached_prefix_len
+    ]
 
 
 def prepare_cached_suffix_prompt_kwargs(prompt_kwargs: dict, key_len: int) -> dict:
-    """Pad visual token-type ids so Gemma 4 masks can line up with cached keys."""
-    prepared = prompt_kwargs
-    for name in ("mm_token_type_ids", "token_type_ids"):
-        token_type_ids = prepared.get(name)
-        padded = _pad_visual_token_type_ids_to_key_len(token_type_ids, key_len)
-        if padded is not token_type_ids:
-            if prepared is prompt_kwargs:
-                prepared = dict(prompt_kwargs)
-            prepared[name] = padded
+    """Pad image token types so a Gemma 4 suffix lines up with cached keys."""
+    token_types = prompt_kwargs.get("mm_token_type_ids")
+    if token_types is None:
+        return prompt_kwargs
+
+    prefix_len = key_len - token_types.shape[1]
+    if prefix_len == 0 or not _contains_token_type(token_types, 1):
+        return prompt_kwargs
+
+    prepared = dict(prompt_kwargs)
+    prepared["mm_token_type_ids"] = mx.concatenate(
+        [
+            mx.zeros(
+                (token_types.shape[0], prefix_len),
+                dtype=token_types.dtype,
+            ),
+            token_types,
+        ],
+        axis=1,
+    )
     return prepared
 
 
@@ -117,103 +97,50 @@ def patch_loaded_model(model: Any) -> None:
     language_model = _language_model(model)
     if not uses_bidirectional_visual_attention(language_model):
         return
-    text_model = getattr(language_model, "model", language_model)
+
+    text_model = language_model.model
     if getattr(text_model, "_mlx_engine_gemma4_visual_mask_patch", False):
         return
-    if not hasattr(text_model, "_apply_blockwise_bidirectional_overlay"):
-        return
 
-    # mlx-vlm requires square masks and applies the visual overlay to full
-    # attention. Transformers keeps full attention causal and applies the
-    # overlay only to sliding attention. This version also aligns cached suffix
-    # query rows with the keys visible to the current layer.
-    def _apply_blockwise_bidirectional_overlay(
-        self,
-        base_mask,
-        mm_token_type_ids,
-        window_size=None,
-    ):
-        if mm_token_type_ids is None:
-            return base_mask
-        key_len = base_mask.shape[-1]
-        if mm_token_type_ids.shape[1] < key_len:
-            return base_mask
-        if mm_token_type_ids.shape[1] > key_len:
-            mm_token_type_ids = mm_token_type_ids[:, -key_len:]
+    from mlx_vlm.models.cache import create_causal_mask
 
-        block_sequence_ids = self._block_sequence_ids_for_mask(mm_token_type_ids)
-        query_len = base_mask.shape[-2]
-        query_block_sequence_ids = block_sequence_ids[:, -query_len:]
-        query_blocks = mx.expand_dims(query_block_sequence_ids, -1)
-        key_blocks = mx.expand_dims(block_sequence_ids, -2)
+    original_make_masks = text_model._make_masks
+
+    def _make_masks(self, h, cache, mm_token_type_ids=None):
+        if not _contains_token_type(mm_token_type_ids, 1):
+            return original_make_masks(h, cache, mm_token_type_ids)
+
+        # Transformers keeps full attention causal and adds the bidirectional
+        # image-block overlay only to sliding attention.
+        masks = original_make_masks(h, cache, None)
+        sliding_mask = next(
+            mask
+            for layer, mask in zip(self.layers, masks)
+            if layer.layer_type == "sliding_attention"
+        )
+        if isinstance(sliding_mask, str):
+            sliding_mask = create_causal_mask(
+                h.shape[1],
+                window_size=self.window_size,
+            )
+
+        key_len = sliding_mask.shape[-1]
+        query_len = sliding_mask.shape[-2]
+        visible_token_types = mm_token_type_ids[:, -key_len:]
+        block_ids = self._block_sequence_ids_for_mask(visible_token_types)
+        query_blocks = mx.expand_dims(block_ids[:, -query_len:], -1)
+        key_blocks = mx.expand_dims(block_ids, -2)
         same_block = (query_blocks != -1) & (query_blocks == key_blocks)
-        if window_size is not None:
-            query_positions = mx.arange(key_len - query_len, key_len)[:, None]
-            key_positions = mx.arange(key_len)[None, :]
-            same_block = same_block & (key_positions > query_positions - window_size)
-        return base_mask | mx.expand_dims(same_block, 1)
 
-    text_model._apply_blockwise_bidirectional_overlay = MethodType(
-        _apply_blockwise_bidirectional_overlay,
-        text_model,
-    )
+        query_positions = mx.arange(key_len - query_len, key_len)[:, None]
+        key_positions = mx.arange(key_len)[None, :]
+        within_window = key_positions > query_positions - self.window_size
+        sliding_mask = sliding_mask | mx.expand_dims(same_block & within_window, 1)
 
-    if hasattr(text_model, "_make_masks"):
-        from mlx_vlm.models.cache import create_causal_mask
+        return [
+            sliding_mask if layer.layer_type == "sliding_attention" else mask
+            for layer, mask in zip(self.layers, masks)
+        ]
 
-        original_make_masks = text_model._make_masks
-
-        def _make_masks(self, h, cache, mm_token_type_ids=None):
-            if mm_token_type_ids is None:
-                return original_make_masks(h, cache, mm_token_type_ids)
-            if int(mx.sum(mm_token_type_ids == 2).item()) > 0:
-                raise ValueError(
-                    "Gemma 4 video input is not supported by the MLX backend"
-                )
-
-            has_image_tokens = int(mx.sum(mm_token_type_ids == 1).item()) > 0
-            if not has_image_tokens or h.shape[1] <= 1:
-                return original_make_masks(h, cache, mm_token_type_ids)
-
-            masks = original_make_masks(h, cache, None)
-            patched_sliding_mask = None
-            patched_masks = []
-            for layer, base_mask in zip(self.layers, masks):
-                if layer.layer_type != "sliding_attention":
-                    patched_masks.append(base_mask)
-                    continue
-                if patched_sliding_mask is None:
-                    if isinstance(base_mask, str) and base_mask == "causal":
-                        base_mask = create_causal_mask(
-                            h.shape[1],
-                            window_size=self.window_size,
-                        )
-                    patched_sliding_mask = self._apply_blockwise_bidirectional_overlay(
-                        base_mask,
-                        mm_token_type_ids,
-                        window_size=self.window_size,
-                    )
-                patched_masks.append(patched_sliding_mask)
-            return patched_masks
-
-        text_model._make_masks = MethodType(_make_masks, text_model)
-
+    text_model._make_masks = MethodType(_make_masks, text_model)
     text_model._mlx_engine_gemma4_visual_mask_patch = True
-
-
-def _pad_visual_token_type_ids_to_key_len(
-    token_type_ids: Any,
-    key_len: int,
-) -> Any:
-    if not isinstance(token_type_ids, mx.array):
-        return token_type_ids
-    if key_len <= token_type_ids.shape[1]:
-        return token_type_ids
-    if int(mx.sum((token_type_ids == 1) | (token_type_ids == 2)).item()) == 0:
-        return token_type_ids
-
-    prefix = mx.zeros(
-        (token_type_ids.shape[0], key_len - token_type_ids.shape[1]),
-        dtype=token_type_ids.dtype,
-    )
-    return mx.concatenate([prefix, token_type_ids], axis=1)

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -483,8 +483,8 @@ def test_batch_generator_slices_position_ids_and_saves_prefill_boundaries(
     ]
 
 
-def test_batch_generator_keeps_gemma4_visual_prefix_together(monkeypatch):
-    """Gemma4 visual masks need prompt start through last visual token in one call."""
+def test_batch_generator_chunks_gemma4_around_image_boundaries(monkeypatch):
+    """Ordinary Gemma 4 chunks can share a call with a whole image block."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,
@@ -519,12 +519,159 @@ def test_batch_generator_keeps_gemma4_visual_prefix_together(monkeypatch):
         generator.next()
         generator.next()
         generator.next()
+        generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [8, 4, 2]
-    assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 1, 1, 1]]
-    assert model.calls[1]["mm_token_type_ids"] == [[0, 0, 0, 0]]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 4, 2]
+    assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0]]
+    assert model.calls[1]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 1, 1, 1]]
+    assert model.calls[2]["mm_token_type_ids"] == [[0, 0, 0, 0]]
+
+
+def test_batch_generator_moves_boundary_before_gemma4_image(monkeypatch):
+    """A chunk boundary inside an image moves so the image stays whole."""
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=4,
+    )
+    prompt = list(range(12))
+    mm_token_type_ids = mx.array(
+        [[0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]],
+        dtype=mx.int32,
+    )
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[],
+        )
+
+        generator.next()
+        generator.next()
+        generator.next()
+        generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [2, 5, 4, 1]
+    assert model.calls[1]["mm_token_type_ids"] == [[0, 0, 1, 1, 1, 1, 1]]
+
+
+def test_batch_generator_keeps_multiple_gemma4_images_whole(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=4,
+    )
+    prompt = list(range(20))
+    mm_token_type_ids = mx.array(
+        [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]],
+        dtype=mx.int32,
+    )
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[],
+        )
+
+        for _ in range(6):
+            generator.next()
+    finally:
+        generator.close()
+
+    call_lengths = [len(call["input_ids"][0]) for call in model.calls]
+    assert call_lengths == [2, 4, 4, 5, 4, 1]
+    boundary = 0
+    for call_length in call_lengths[:-1]:
+        boundary += call_length
+        assert not 2 < boundary < 5
+        assert not 10 < boundary < 15
+
+
+def test_batch_generator_long_gemma4_prompt_never_uses_visual_prefix(monkeypatch):
+    """An image near 39K cannot turn prefill into a square 39K model call."""
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=2048,
+    )
+    prompt_len = 40_001
+    image_start = 38_000
+    image_end = image_start + 1_120
+    prompt = list(range(prompt_len))
+    mm_token_type_ids = mx.concatenate(
+        [
+            mx.zeros((1, image_start), dtype=mx.int32),
+            mx.ones((1, image_end - image_start), dtype=mx.int32),
+            mx.zeros((1, prompt_len - image_end), dtype=mx.int32),
+        ],
+        axis=1,
+    )
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, prompt_len, 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[],
+        )
+
+        while sum(len(call["input_ids"][0]) for call in model.calls) < prompt_len:
+            generator.next()
+    finally:
+        generator.close()
+
+    call_lengths = [len(call["input_ids"][0]) for call in model.calls]
+    assert sum(call_lengths) == prompt_len
+    assert max(call_lengths) <= 2048
+
+    boundary = 0
+    for call_length in call_lengths[:-1]:
+        boundary += call_length
+        assert not image_start < boundary < image_end
 
 
 def test_batch_generator_chunks_gemma4_text_only_normally(monkeypatch):
@@ -598,10 +745,11 @@ def test_batch_generator_does_not_split_gemma4_visual_prompt_tail(monkeypatch):
         )
 
         generator.next()
+        generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [8]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4]
 
 
 def test_batch_generator_uses_image_spans_without_gemma4_token_types(monkeypatch):
@@ -635,10 +783,11 @@ def test_batch_generator_uses_image_spans_without_gemma4_token_types(monkeypatch
 
         generator.next()
         generator.next()
+        generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [8, 2]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 2]
 
 
 def test_batch_generator_pads_gemma4_token_types_after_restore(monkeypatch):
@@ -679,6 +828,45 @@ def test_batch_generator_pads_gemma4_token_types_after_restore(monkeypatch):
     assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 0, 0, 1, 1]]
 
 
+def test_batch_generator_restores_immediately_before_gemma4_image(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    model = _gemma4_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=2,
+    )
+    prompt = list(range(6))
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={
+                "mm_token_type_ids": mx.array(
+                    [[1, 1, 1, 0, 0, 0]],
+                    dtype=mx.int32,
+                )
+            },
+            prefix_cache_chunks=[],
+            cache=[_FakeScalarCache()],
+            all_tokens=[100, 101, 102, 103, 104],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[],
+        )
+
+        generator.next()
+        generator.next()
+        generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [3, 2, 1]
+    assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 1, 1, 1]]
+
+
 def test_batch_generator_pads_gemma4_token_types_for_final_prefill(monkeypatch):
     """Final prefill also needs key-length token types when restored before image."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
@@ -712,8 +900,8 @@ def test_batch_generator_pads_gemma4_token_types_for_final_prefill(monkeypatch):
     assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 0, 1, 1]]
 
 
-def test_batch_generator_applies_visual_policy_to_bidir_gemma4(monkeypatch):
-    """Non-unified Gemma4 bidirectional-vision models use visual-prefix prefill."""
+def test_batch_generator_chunks_bidir_gemma4_around_images(monkeypatch):
+    """Non-unified Gemma 4 models use image-boundary-aware chunking."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,
@@ -747,10 +935,11 @@ def test_batch_generator_applies_visual_policy_to_bidir_gemma4(monkeypatch):
 
         generator.next()
         generator.next()
+        generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [8, 2]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 2]
 
 
 def test_batch_generator_chunks_non_bidir_gemma4_normally(monkeypatch):

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -513,7 +513,7 @@ def test_batch_generator_chunks_gemma4_around_image_boundaries(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[PromptImageSpan(start=5, end=8, image_hash="image")],
         )
 
         generator.next()
@@ -559,7 +559,7 @@ def test_batch_generator_moves_boundary_before_gemma4_image(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[PromptImageSpan(start=2, end=7, image_hash="image")],
         )
 
         generator.next()
@@ -602,7 +602,10 @@ def test_batch_generator_keeps_multiple_gemma4_images_whole(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[
+                PromptImageSpan(start=2, end=5, image_hash="first"),
+                PromptImageSpan(start=10, end=15, image_hash="second"),
+            ],
         )
 
         for _ in range(6):
@@ -656,7 +659,13 @@ def test_batch_generator_long_gemma4_prompt_never_uses_visual_prefix(monkeypatch
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[
+                PromptImageSpan(
+                    start=image_start,
+                    end=image_end,
+                    image_hash="image",
+                )
+            ],
         )
 
         while sum(len(call["input_ids"][0]) for call in model.calls) < prompt_len:
@@ -714,46 +723,8 @@ def test_batch_generator_chunks_gemma4_text_only_normally(monkeypatch):
     assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 2]
 
 
-def test_batch_generator_does_not_split_gemma4_visual_prompt_tail(monkeypatch):
-    """If the last visual token is also the last prompt token, use final prefill."""
-    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
-    monkeypatch.setattr(
-        batcher,
-        "make_prompt_cache",
-        lambda _model: [_FakeBatchCache()],
-    )
-    model = _gemma4_unified_model()
-    generator = BatchGenerator(
-        model=model,
-        stop_criteria=lambda _token: False,
-        prefill_step_size=4,
-    )
-    prompt = list(range(8))
-    mm_token_type_ids = mx.array([[0, 0, 0, 0, 0, 1, 1, 1]], dtype=mx.int32)
-
-    try:
-        generator.insert(
-            prompt,
-            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
-            sampler=_argmax_sampler,
-            logits_processors=[],
-            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
-            prefix_cache_chunks=[],
-            all_tokens=[],
-            next_prefix_cache_chunk_idx=0,
-            image_spans=[],
-        )
-
-        generator.next()
-        generator.next()
-    finally:
-        generator.close()
-
-    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4]
-
-
-def test_batch_generator_uses_image_spans_without_gemma4_token_types(monkeypatch):
-    """Image spans provide a fallback boundary if Gemma4 token types are absent."""
+def test_batch_generator_keeps_trailing_gemma4_image_whole(monkeypatch):
+    """The image run remains whole with its required trailing EOI token."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,
@@ -767,6 +738,7 @@ def test_batch_generator_uses_image_spans_without_gemma4_token_types(monkeypatch
         prefill_step_size=4,
     )
     prompt = list(range(10))
+    mm_token_type_ids = mx.array([[0, 0, 0, 0, 0, 0, 1, 1, 1, 0]], dtype=mx.int32)
 
     try:
         generator.insert(
@@ -774,11 +746,11 @@ def test_batch_generator_uses_image_spans_without_gemma4_token_types(monkeypatch
             inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
             sampler=_argmax_sampler,
             logits_processors=[],
-            prompt_kwargs={},
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=5, end=8, image_hash="image")],
+            image_spans=[PromptImageSpan(start=6, end=9, image_hash="image")],
         )
 
         generator.next()
@@ -787,7 +759,7 @@ def test_batch_generator_uses_image_spans_without_gemma4_token_types(monkeypatch
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 2]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 2, 4]
 
 
 def test_batch_generator_pads_gemma4_token_types_after_restore(monkeypatch):
@@ -817,7 +789,7 @@ def test_batch_generator_pads_gemma4_token_types_after_restore(monkeypatch):
             cache=[_FakeScalarCache()],
             all_tokens=[100, 101, 102, 103, 104],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[PromptImageSpan(start=7, end=9, image_hash="image")],
         )
 
         generator.next()
@@ -854,7 +826,7 @@ def test_batch_generator_restores_immediately_before_gemma4_image(monkeypatch):
             cache=[_FakeScalarCache()],
             all_tokens=[100, 101, 102, 103, 104],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[PromptImageSpan(start=5, end=8, image_hash="image")],
         )
 
         generator.next()
@@ -889,7 +861,7 @@ def test_batch_generator_pads_gemma4_token_types_for_final_prefill(monkeypatch):
             cache=[_FakeScalarCache()],
             all_tokens=[100, 101, 102, 103, 104],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[PromptImageSpan(start=6, end=8, image_hash="image")],
         )
 
         generator.next()
@@ -930,7 +902,7 @@ def test_batch_generator_chunks_bidir_gemma4_around_images(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[PromptImageSpan(start=5, end=8, image_hash="image")],
         )
 
         generator.next()
@@ -972,7 +944,7 @@ def test_batch_generator_chunks_non_bidir_gemma4_normally(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[],
+            image_spans=[PromptImageSpan(start=5, end=8, image_hash="image")],
         )
 
         generator.next()

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -141,6 +141,11 @@ class _FakeModel:
                     if kwargs.get("mm_token_type_ids") is None
                     else kwargs["mm_token_type_ids"].tolist()
                 ),
+                "token_type_ids": (
+                    None
+                    if kwargs.get("token_type_ids") is None
+                    else kwargs["token_type_ids"].tolist()
+                ),
             }
         )
         batch_size, seq_len = input_ids.shape
@@ -483,8 +488,12 @@ def test_batch_generator_slices_position_ids_and_saves_prefill_boundaries(
     ]
 
 
-def test_batch_generator_chunks_gemma4_around_image_boundaries(monkeypatch):
-    """Ordinary Gemma 4 chunks can share a call with a whole image block."""
+@pytest.mark.parametrize("token_type_key", ["mm_token_type_ids", "token_type_ids"])
+def test_batch_generator_uses_gemma4_token_types_when_cache_span_is_coarse(
+    monkeypatch,
+    token_type_key,
+):
+    """Cache fallback spans do not become protected attention-mask spans."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,
@@ -507,11 +516,11 @@ def test_batch_generator_chunks_gemma4_around_image_boundaries(monkeypatch):
             inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
             sampler=_argmax_sampler,
             logits_processors=[],
-            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prompt_kwargs={token_type_key: mm_token_type_ids},
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=600, end=700, image_hash="image")],
+            image_spans=[PromptImageSpan(start=0, end=len(prompt), image_hash="image")],
         )
 
         generator.next()
@@ -521,9 +530,48 @@ def test_batch_generator_chunks_gemma4_around_image_boundaries(monkeypatch):
         generator.close()
 
     assert [len(call["input_ids"][0]) for call in model.calls] == [512, 512, 276]
-    assert model.calls[0]["mm_token_type_ids"] is None
-    assert model.calls[1]["mm_token_type_ids"] == [[0] * 600 + [1] * 100 + [0] * 324]
-    assert model.calls[2]["mm_token_type_ids"] is None
+    assert model.calls[0][token_type_key] is None
+    assert model.calls[1][token_type_key] == [[0] * 600 + [1] * 100 + [0] * 324]
+    assert model.calls[2][token_type_key] is None
+
+
+def test_batch_generator_gemma4_without_token_types_chunks_normally(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=4,
+    )
+    prompt = list(range(10))
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[PromptImageSpan(start=0, end=len(prompt), image_hash="image")],
+        )
+
+        generator.next()
+        generator.next()
+        generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 2]
+    assert all(call["mm_token_type_ids"] is None for call in model.calls)
+    assert all(call["token_type_ids"] is None for call in model.calls)
 
 
 def test_batch_generator_aligns_gemma4_image_sections_to_cache_boundaries(

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -630,6 +630,49 @@ def test_batch_generator_aligns_gemma4_image_sections_to_cache_boundaries(
     assert model.calls[3]["mm_token_type_ids"] is None
 
 
+def test_batch_generator_splits_touching_gemma4_image_sections(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=256,
+    )
+    prompt = list(range(700))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 100:150] = 1
+    mm_token_type_ids[:, 300:350] = 1
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[
+                PromptImageSpan(start=100, end=150, image_hash="first"),
+                PromptImageSpan(start=300, end=350, image_hash="second"),
+            ],
+        )
+
+        generator.next()
+        generator.next()
+        generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [256, 256, 188]
+
+
 def test_batch_generator_keeps_multiple_gemma4_images_whole(monkeypatch):
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -677,6 +677,48 @@ def test_batch_generator_splits_overlapping_gemma4_cache_envelopes(monkeypatch):
         assert not 500 < boundary < 600
 
 
+def test_batch_generator_aligned_fallback_does_not_split_earlier_image(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=2_048,
+    )
+    prompt = list(range(2_500))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 1_600:1_880] = 1
+    mm_token_type_ids[:, 1_882:2_162] = 1
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[
+                PromptImageSpan(start=1_600, end=1_880, image_hash="first"),
+                PromptImageSpan(start=1_882, end=2_162, image_hash="second"),
+            ],
+        )
+
+        generator.next()
+        generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [1_536, 964]
+
+
 def test_batch_generator_keeps_image_longer_than_prefill_step_whole(monkeypatch):
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -574,10 +574,8 @@ def test_batch_generator_gemma4_without_token_types_chunks_normally(monkeypatch)
     assert all(call["token_type_ids"] is None for call in model.calls)
 
 
-def test_batch_generator_aligns_gemma4_image_sections_to_cache_boundaries(
-    monkeypatch,
-):
-    """Image adjustments preserve exact 256-token cache checkpoint endpoints."""
+def test_batch_generator_uses_image_safe_non_aligned_prefill(monkeypatch):
+    """Gemma can end at an image boundary and still backfill cache chunks."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,
@@ -621,16 +619,104 @@ def test_batch_generator_aligns_gemma4_image_sections_to_cache_boundaries(
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [256, 512, 256, 176]
-    assert snapshot_lengths == [256, 768, 1024]
-    assert all(length % 256 == 0 for length in snapshot_lengths)
+    assert [len(call["input_ids"][0]) for call in model.calls] == [256, 344, 424, 176]
+    assert snapshot_lengths == [256, 600, 1024]
     assert model.calls[0]["mm_token_type_ids"] is None
-    assert model.calls[1]["mm_token_type_ids"] == [[0] * 400 + [1] * 200 + [0] * 168]
+    assert model.calls[1]["mm_token_type_ids"] == [[0] * 400 + [1] * 200]
     assert model.calls[2]["mm_token_type_ids"] is None
     assert model.calls[3]["mm_token_type_ids"] is None
 
 
-def test_batch_generator_splits_touching_gemma4_image_sections(monkeypatch):
+def test_batch_generator_splits_overlapping_gemma4_cache_envelopes(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=256,
+    )
+    prompt = list(range(900))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 200:300] = 1
+    mm_token_type_ids[:, 500:600] = 1
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[
+                PromptImageSpan(start=200, end=300, image_hash="first"),
+                PromptImageSpan(start=500, end=600, image_hash="second"),
+            ],
+        )
+
+        for _ in range(4):
+            generator.next()
+    finally:
+        generator.close()
+
+    call_lengths = [len(call["input_ids"][0]) for call in model.calls]
+    assert call_lengths == [200, 256, 256, 188]
+    assert max(call_lengths) <= 256
+
+    boundary = 0
+    for call_length in call_lengths[:-1]:
+        boundary += call_length
+        assert not 200 < boundary < 300
+        assert not 500 < boundary < 600
+
+
+def test_batch_generator_keeps_image_longer_than_prefill_step_whole(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=256,
+    )
+    prompt = list(range(500))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 100:400] = 1
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[PromptImageSpan(start=100, end=400, image_hash="image")],
+        )
+
+        generator.next()
+        generator.next()
+        generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [100, 300, 100]
+
+
+def test_batch_generator_splits_neighboring_gemma4_image_runs(monkeypatch):
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -495,13 +495,11 @@ def test_batch_generator_chunks_gemma4_around_image_boundaries(monkeypatch):
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
-        prefill_step_size=4,
+        prefill_step_size=512,
     )
-    prompt = list(range(14))
-    mm_token_type_ids = mx.array(
-        [[0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0]],
-        dtype=mx.int32,
-    )
+    prompt = list(range(1_300))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 600:700] = 1
 
     try:
         generator.insert(
@@ -513,24 +511,24 @@ def test_batch_generator_chunks_gemma4_around_image_boundaries(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=5, end=8, image_hash="image")],
+            image_spans=[PromptImageSpan(start=600, end=700, image_hash="image")],
         )
 
-        generator.next()
         generator.next()
         generator.next()
         generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 4, 2]
-    assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0]]
-    assert model.calls[1]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 1, 1, 1]]
-    assert model.calls[2]["mm_token_type_ids"] == [[0, 0, 0, 0]]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [512, 512, 276]
+    assert model.calls[0]["mm_token_type_ids"] == [[0] * 512]
+    assert model.calls[1]["mm_token_type_ids"] == [[0] * 600 + [1] * 100 + [0] * 324]
 
 
-def test_batch_generator_moves_boundary_before_gemma4_image(monkeypatch):
-    """A chunk boundary inside an image moves so the image stays whole."""
+def test_batch_generator_aligns_gemma4_image_sections_to_cache_boundaries(
+    monkeypatch,
+):
+    """Image adjustments preserve exact 256-token cache checkpoint endpoints."""
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,
@@ -541,13 +539,19 @@ def test_batch_generator_moves_boundary_before_gemma4_image(monkeypatch):
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
-        prefill_step_size=4,
+        prefill_step_size=512,
     )
-    prompt = list(range(12))
-    mm_token_type_ids = mx.array(
-        [[0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]],
-        dtype=mx.int32,
+    prompt = list(range(1_200))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 400:600] = 1
+    prefix_cache_chunks = build_prefix_cache_chunks(
+        prompt,
+        [PromptImageSpan(start=400, end=600, image_hash="image")],
     )
+    snapshot_lengths = []
+
+    def save_snapshot(_cache, _chunks, _start_idx, _end_idx, snapshot_len):
+        snapshot_lengths.append(snapshot_len)
 
     try:
         generator.insert(
@@ -556,21 +560,22 @@ def test_batch_generator_moves_boundary_before_gemma4_image(monkeypatch):
             sampler=_argmax_sampler,
             logits_processors=[],
             prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
-            prefix_cache_chunks=[],
+            prefix_cache_chunks=prefix_cache_chunks,
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=2, end=7, image_hash="image")],
+            image_spans=[PromptImageSpan(start=400, end=600, image_hash="image")],
+            prompt_cache_save_callback=save_snapshot,
         )
 
-        generator.next()
-        generator.next()
-        generator.next()
-        generator.next()
+        for _ in range(4):
+            generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [2, 5, 4, 1]
-    assert model.calls[1]["mm_token_type_ids"] == [[0, 0, 1, 1, 1, 1, 1]]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [256, 512, 256, 176]
+    assert snapshot_lengths == [256, 768, 1024]
+    assert all(length % 256 == 0 for length in snapshot_lengths)
+    assert model.calls[1]["mm_token_type_ids"] == [[0] * 400 + [1] * 200 + [0] * 168]
 
 
 def test_batch_generator_keeps_multiple_gemma4_images_whole(monkeypatch):
@@ -584,13 +589,12 @@ def test_batch_generator_keeps_multiple_gemma4_images_whole(monkeypatch):
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
-        prefill_step_size=4,
+        prefill_step_size=512,
     )
-    prompt = list(range(20))
-    mm_token_type_ids = mx.array(
-        [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]],
-        dtype=mx.int32,
-    )
+    prompt = list(range(2_000))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 400:600] = 1
+    mm_token_type_ids[:, 1_100:1_300] = 1
 
     try:
         generator.insert(
@@ -603,23 +607,24 @@ def test_batch_generator_keeps_multiple_gemma4_images_whole(monkeypatch):
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
             image_spans=[
-                PromptImageSpan(start=2, end=5, image_hash="first"),
-                PromptImageSpan(start=10, end=15, image_hash="second"),
+                PromptImageSpan(start=400, end=600, image_hash="first"),
+                PromptImageSpan(start=1_100, end=1_300, image_hash="second"),
             ],
         )
 
-        for _ in range(6):
+        for _ in range(5):
             generator.next()
     finally:
         generator.close()
 
     call_lengths = [len(call["input_ids"][0]) for call in model.calls]
-    assert call_lengths == [2, 4, 4, 5, 4, 1]
+    assert call_lengths == [256, 512, 256, 512, 464]
     boundary = 0
     for call_length in call_lengths[:-1]:
         boundary += call_length
-        assert not 2 < boundary < 5
-        assert not 10 < boundary < 15
+        assert boundary % 256 == 0
+        assert not 400 < boundary < 600
+        assert not 1_100 < boundary < 1_300
 
 
 def test_batch_generator_long_gemma4_prompt_never_uses_visual_prefix(monkeypatch):
@@ -680,6 +685,7 @@ def test_batch_generator_long_gemma4_prompt_never_uses_visual_prefix(monkeypatch
     boundary = 0
     for call_length in call_lengths[:-1]:
         boundary += call_length
+        assert boundary % 256 == 0
         assert not image_start < boundary < image_end
 
 
@@ -735,10 +741,11 @@ def test_batch_generator_keeps_trailing_gemma4_image_whole(monkeypatch):
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
-        prefill_step_size=4,
+        prefill_step_size=512,
     )
-    prompt = list(range(10))
-    mm_token_type_ids = mx.array([[0, 0, 0, 0, 0, 0, 1, 1, 1, 0]], dtype=mx.int32)
+    prompt = list(range(1_000))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 700:900] = 1
 
     try:
         generator.insert(
@@ -750,16 +757,15 @@ def test_batch_generator_keeps_trailing_gemma4_image_whole(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=6, end=9, image_hash="image")],
+            image_spans=[PromptImageSpan(start=700, end=900, image_hash="image")],
         )
 
-        generator.next()
         generator.next()
         generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 2, 4]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [512, 488]
 
 
 def test_batch_generator_pads_gemma4_token_types_after_restore(monkeypatch):
@@ -769,9 +775,11 @@ def test_batch_generator_pads_gemma4_token_types_after_restore(monkeypatch):
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
-        prefill_step_size=4,
+        prefill_step_size=512,
     )
-    prompt = list(range(8))
+    prompt = list(range(600))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 88:188] = 1
 
     try:
         generator.insert(
@@ -779,25 +787,20 @@ def test_batch_generator_pads_gemma4_token_types_after_restore(monkeypatch):
             inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
             sampler=_argmax_sampler,
             logits_processors=[],
-            prompt_kwargs={
-                "mm_token_type_ids": mx.array(
-                    [[0, 0, 1, 1, 0, 0, 0, 0]],
-                    dtype=mx.int32,
-                )
-            },
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
             prefix_cache_chunks=[],
             cache=[_FakeScalarCache()],
-            all_tokens=[100, 101, 102, 103, 104],
+            all_tokens=list(range(512)),
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=7, end=9, image_hash="image")],
+            image_spans=[PromptImageSpan(start=600, end=700, image_hash="image")],
         )
 
         generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [4]
-    assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 0, 0, 1, 1]]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [512]
+    assert model.calls[0]["mm_token_type_ids"] == [[0] * 600 + [1] * 100 + [0] * 324]
 
 
 def test_batch_generator_restores_immediately_before_gemma4_image(monkeypatch):
@@ -806,9 +809,11 @@ def test_batch_generator_restores_immediately_before_gemma4_image(monkeypatch):
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
-        prefill_step_size=2,
+        prefill_step_size=512,
     )
-    prompt = list(range(6))
+    prompt = list(range(800))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, :188] = 1
 
     try:
         generator.insert(
@@ -816,27 +821,21 @@ def test_batch_generator_restores_immediately_before_gemma4_image(monkeypatch):
             inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
             sampler=_argmax_sampler,
             logits_processors=[],
-            prompt_kwargs={
-                "mm_token_type_ids": mx.array(
-                    [[1, 1, 1, 0, 0, 0]],
-                    dtype=mx.int32,
-                )
-            },
+            prompt_kwargs={"mm_token_type_ids": mm_token_type_ids},
             prefix_cache_chunks=[],
             cache=[_FakeScalarCache()],
-            all_tokens=[100, 101, 102, 103, 104],
+            all_tokens=list(range(512)),
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=5, end=8, image_hash="image")],
+            image_spans=[PromptImageSpan(start=512, end=700, image_hash="image")],
         )
 
-        generator.next()
         generator.next()
         generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [3, 2, 1]
-    assert model.calls[0]["mm_token_type_ids"] == [[0, 0, 0, 0, 0, 1, 1, 1]]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [512, 288]
+    assert model.calls[0]["mm_token_type_ids"] == [[0] * 512 + [1] * 188 + [0] * 324]
 
 
 def test_batch_generator_pads_gemma4_token_types_for_final_prefill(monkeypatch):
@@ -884,13 +883,11 @@ def test_batch_generator_chunks_bidir_gemma4_around_images(monkeypatch):
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
-        prefill_step_size=4,
+        prefill_step_size=512,
     )
-    prompt = list(range(10))
-    mm_token_type_ids = mx.array(
-        [[0, 0, 0, 0, 0, 1, 1, 1, 0, 0]],
-        dtype=mx.int32,
-    )
+    prompt = list(range(1_000))
+    mm_token_type_ids = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    mm_token_type_ids[:, 400:600] = 1
 
     try:
         generator.insert(
@@ -902,7 +899,7 @@ def test_batch_generator_chunks_bidir_gemma4_around_images(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=5, end=8, image_hash="image")],
+            image_spans=[PromptImageSpan(start=400, end=600, image_hash="image")],
         )
 
         generator.next()
@@ -911,7 +908,7 @@ def test_batch_generator_chunks_bidir_gemma4_around_images(monkeypatch):
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 2]
+    assert [len(call["input_ids"][0]) for call in model.calls] == [256, 512, 232]
 
 
 def test_batch_generator_chunks_non_bidir_gemma4_normally(monkeypatch):

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -521,8 +521,9 @@ def test_batch_generator_chunks_gemma4_around_image_boundaries(monkeypatch):
         generator.close()
 
     assert [len(call["input_ids"][0]) for call in model.calls] == [512, 512, 276]
-    assert model.calls[0]["mm_token_type_ids"] == [[0] * 512]
+    assert model.calls[0]["mm_token_type_ids"] is None
     assert model.calls[1]["mm_token_type_ids"] == [[0] * 600 + [1] * 100 + [0] * 324]
+    assert model.calls[2]["mm_token_type_ids"] is None
 
 
 def test_batch_generator_aligns_gemma4_image_sections_to_cache_boundaries(
@@ -575,7 +576,10 @@ def test_batch_generator_aligns_gemma4_image_sections_to_cache_boundaries(
     assert [len(call["input_ids"][0]) for call in model.calls] == [256, 512, 256, 176]
     assert snapshot_lengths == [256, 768, 1024]
     assert all(length % 256 == 0 for length in snapshot_lengths)
+    assert model.calls[0]["mm_token_type_ids"] is None
     assert model.calls[1]["mm_token_type_ids"] == [[0] * 400 + [1] * 200 + [0] * 168]
+    assert model.calls[2]["mm_token_type_ids"] is None
+    assert model.calls[3]["mm_token_type_ids"] is None
 
 
 def test_batch_generator_keeps_multiple_gemma4_images_whole(monkeypatch):
@@ -688,6 +692,8 @@ def test_batch_generator_long_gemma4_prompt_never_uses_visual_prefix(monkeypatch
         assert boundary % 256 == 0
         assert not image_start < boundary < image_end
 
+    assert sum(call["mm_token_type_ids"] is not None for call in model.calls) == 1
+
 
 def test_batch_generator_chunks_gemma4_text_only_normally(monkeypatch):
     """Gemma4 unified text-only prompts keep the configured prefill size."""
@@ -727,6 +733,7 @@ def test_batch_generator_chunks_gemma4_text_only_normally(monkeypatch):
         generator.close()
 
     assert [len(call["input_ids"][0]) for call in model.calls] == [4, 4, 2]
+    assert all(call["mm_token_type_ids"] is None for call in model.calls)
 
 
 def test_batch_generator_keeps_trailing_gemma4_image_whole(monkeypatch):
@@ -836,6 +843,7 @@ def test_batch_generator_restores_immediately_before_gemma4_image(monkeypatch):
 
     assert [len(call["input_ids"][0]) for call in model.calls] == [512, 288]
     assert model.calls[0]["mm_token_type_ids"] == [[0] * 512 + [1] * 188 + [0] * 324]
+    assert model.calls[1]["mm_token_type_ids"] is None
 
 
 def test_batch_generator_pads_gemma4_token_types_for_final_prefill(monkeypatch):

--- a/tests/test_batched_vision_cache_store.py
+++ b/tests/test_batched_vision_cache_store.py
@@ -157,6 +157,34 @@ def test_cache_store_commits_and_restores_prefix_records(cache_store):
     _assert_two_chunk_restore(loaded)
 
 
+def test_cache_store_backfills_aligned_kv_chunk_from_non_aligned_snapshot(
+    cache_store,
+):
+    prompt_input_ids = list(range(400))
+    chunks = build_prefix_cache_chunks(prompt_input_ids, [])
+
+    _save_chunk(
+        cache_store,
+        chunks[0],
+        chunks,
+        _rotating_prompt_cache(300),
+        save_state_checkpoint=False,
+    )
+
+    restore_plan = cache_store.plan_longest_prefix_restore(prompt_input_ids, [])
+    assert restore_plan is not None
+    loaded = cache_store.load_restore_plan(restore_plan)
+    kv_keys, _ = loaded.prompt_cache[0].state
+    rotating_keys, _ = loaded.prompt_cache[1].state
+    mx.eval(kv_keys, rotating_keys)
+
+    assert loaded.cached_prefix_len == 256
+    assert kv_keys.shape[2] == 256
+    assert rotating_keys.shape[2] == 256
+    assert kv_keys[0, 0, -1, 0].item() == 255
+    assert rotating_keys[0, 0, -1, 0].item() == 255
+
+
 def test_cache_store_eviction_preserves_shorter_prefix_restore(cache_store):
     prompt_input_ids = list(range(600))
     chunks = build_prefix_cache_chunks(prompt_input_ids, [])

--- a/tests/test_batched_vision_parity.py
+++ b/tests/test_batched_vision_parity.py
@@ -365,13 +365,11 @@ def test_vlm_generation_trace_matches_mlx_vlm_same_inputs(case: VlmParityCase):
         assert len(engine_logits) == max_tokens + 1
         assert len(upstream_logits) == max_tokens + 1
         if case.id == "gemma4_12b" and name == "image":
-            # Gemma4 unified image prompts intentionally split prefill at the
-            # visual-prefix boundary so later text can use normal cache chunks
-            # without splitting the bidirectional visual attention span. That
-            # gives 12B a different BF16/quantized schedule than mlx-vlm's
-            # direct one-shot reference; disabling only that split restores
-            # exact logits. Keep this case focused on emitted tokens and
-            # selected logprob stability.
+            # The engine follows Transformers: full layers stay causal, and
+            # sliding layers are bidirectional only within image blocks. It also
+            # chunks without splitting an image. mlx-vlm's one-shot reference
+            # applies the visual overlay to full layers, so keep this comparison
+            # focused on emitted tokens and selected logprob stability.
             assert engine_logprobs == pytest.approx(upstream_logprobs, abs=0.125)
             continue
 

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -71,15 +71,14 @@ def test_gemma4_cached_suffix_prompt_kwargs_pad_visual_token_types_to_key_len():
     assert prepared["unchanged"] == "value"
 
 
-def test_gemma4_cached_suffix_prompt_kwargs_keeps_text_only_token_types():
+def test_gemma4_image_prompt_kwargs_without_cached_prefix_are_unchanged():
     prompt_kwargs = {
-        "mm_token_type_ids": mx.array([[0, 0, 0, 0]], dtype=mx.int32),
+        "mm_token_type_ids": mx.array([[0, 1, 1, 0]], dtype=mx.int32),
     }
 
-    prepared = prepare_cached_suffix_prompt_kwargs(prompt_kwargs, key_len=7)
+    prepared = prepare_cached_suffix_prompt_kwargs(prompt_kwargs, key_len=4)
 
     assert prepared is prompt_kwargs
-    assert prepared["mm_token_type_ids"].tolist() == [[0, 0, 0, 0]]
 
 
 def test_gemma4_suffix_visual_mask_patch_uses_query_rows_only():

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -165,6 +165,20 @@ def test_gemma4_image_prefill_sections_merge_shared_cache_chunks():
     assert sections == [(256, 768)]
 
 
+def test_gemma4_image_prefill_sections_keep_touching_chunks_separate():
+    token_types = mx.zeros((1, 600), dtype=mx.int32)
+    token_types[:, 100:150] = 1
+    token_types[:, 300:350] = 1
+
+    sections = image_prefill_sections(
+        _gemma4_model(),
+        {"mm_token_type_ids": token_types},
+        cached_prefix_len=0,
+    )
+
+    assert sections == [(0, 256), (256, 512)]
+
+
 def test_gemma4_image_prefill_sections_support_legacy_token_types():
     token_types = mx.zeros((1, 700), dtype=mx.int32)
     token_types[:, 300:400] = 1

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -4,6 +4,7 @@ import mlx.core as mx
 import pytest
 from mlx_vlm.models.cache import create_causal_mask
 
+from mlx_engine.model_kit.batched_vision.prompt_cache.types import PromptImageSpan
 from mlx_engine.model_kit.patches.gemma4 import (
     config_uses_bidirectional_visual_attention,
     image_prefill_spans,
@@ -30,14 +31,18 @@ class _Gemma4TextModel:
         group_ids = mx.cumsum(starts.astype(mx.int32), axis=1) - 1
         return mx.where(is_vision, group_ids, mx.zeros_like(group_ids) - 1)
 
-    def _apply_blockwise_bidirectional_overlay(self, base_mask, mm_token_type_ids):
-        raise AssertionError("unpatched")
-
     def _make_masks(self, h, cache, mm_token_type_ids=None):
-        del cache, mm_token_type_ids
+        del mm_token_type_ids
         return [
-            create_causal_mask(h.shape[1]),
-            create_causal_mask(h.shape[1], window_size=self.window_size),
+            create_causal_mask(
+                h.shape[1],
+                offset=getattr(cache[0], "offset", 0),
+            ),
+            create_causal_mask(
+                h.shape[1],
+                offset=getattr(cache[1], "offset", 0),
+                window_size=self.window_size,
+            ),
         ]
 
 
@@ -80,26 +85,19 @@ def test_gemma4_cached_suffix_prompt_kwargs_keeps_text_only_token_types():
 def test_gemma4_suffix_visual_mask_patch_uses_query_rows_only():
     text_model = _Gemma4TextModel()
     patch_loaded_model(_gemma4_model(text_model))
+    cache = SimpleNamespace(offset=5)
+    token_types = mx.array([[0, 0, 0, 0, 0, 0, 0, 1, 1]], dtype=mx.int32)
 
-    base_mask = create_causal_mask(4, offset=5)
-    token_types = mx.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]], dtype=mx.int32)
-    patched = text_model._apply_blockwise_bidirectional_overlay(
-        base_mask,
+    _, patched = text_model._make_masks(
+        mx.zeros((1, 4, 4), dtype=mx.float32),
+        [cache, cache],
         token_types,
     )
+    causal_mask = create_causal_mask(4, offset=5, window_size=text_model.window_size)
 
     assert patched.shape == (1, 1, 4, 9)
     assert bool(patched[0, 0, 2, 8].item())
-    assert not bool(base_mask[2, 8].item())
-
-    short_token_types = mx.array([[0, 1]], dtype=mx.int32)
-    assert (
-        text_model._apply_blockwise_bidirectional_overlay(
-            base_mask,
-            short_token_types,
-        )
-        is base_mask
-    )
+    assert not bool(causal_mask[2, 8].item())
 
 
 def test_gemma4_mask_patch_matches_transformers_attention_topology():
@@ -124,20 +122,19 @@ def test_gemma4_mask_patch_matches_transformers_attention_topology():
     assert not bool(sliding_mask[0, 0, 1, 4].item())
 
 
-def test_gemma4_image_prefill_spans_follow_token_type_runs():
+def test_gemma4_image_prefill_spans_are_relative_to_cached_prefix():
     spans = image_prefill_spans(
         _gemma4_model(),
-        {
-            "mm_token_type_ids": mx.array(
-                [[0, 1, 1, 0, 1, 0]],
-                dtype=mx.int32,
-            )
-        },
-        [],
-        cached_prefix_len=0,
+        {},
+        [
+            PromptImageSpan(start=2, end=5, image_hash="cached"),
+            PromptImageSpan(start=10, end=13, image_hash="first"),
+            PromptImageSpan(start=20, end=25, image_hash="second"),
+        ],
+        cached_prefix_len=8,
     )
 
-    assert spans == [(1, 3), (4, 5)]
+    assert spans == [(2, 5), (12, 17)]
 
 
 def test_gemma4_image_prefill_rejects_video_tokens():
@@ -148,23 +145,6 @@ def test_gemma4_image_prefill_rejects_video_tokens():
             [],
             cached_prefix_len=0,
         )
-
-
-def test_non_gemma_image_prefill_ignores_video_token_type():
-    model = SimpleNamespace(
-        model_type="other",
-        config=SimpleNamespace(use_bidirectional_attention=None),
-    )
-
-    assert (
-        image_prefill_spans(
-            model,
-            {"mm_token_type_ids": mx.array([[0, 2, 2]], dtype=mx.int32)},
-            [],
-            cached_prefix_len=0,
-        )
-        is None
-    )
 
 
 def test_gemma4_bidirectional_visual_detection_accepts_top_and_text_config():

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 import mlx.core as mx
 from mlx_vlm.models.cache import create_causal_mask
 
-from mlx_engine.model_kit.batched_vision.prompt_cache.types import PromptImageSpan
 from mlx_engine.model_kit.patches.gemma4 import (
     config_uses_bidirectional_visual_attention,
     image_prefill_sections,
@@ -80,6 +79,24 @@ def test_gemma4_image_prompt_kwargs_without_cached_prefix_are_unchanged():
     assert prepared is prompt_kwargs
 
 
+def test_gemma4_cached_suffix_prompt_kwargs_support_legacy_token_types():
+    prompt_kwargs = {
+        "token_type_ids": mx.array([[0, 1, 1, 0]], dtype=mx.int32),
+    }
+
+    prepared = prepare_cached_suffix_prompt_kwargs(prompt_kwargs, key_len=7)
+
+    assert prepared["token_type_ids"].tolist() == [[0, 0, 0, 0, 1, 1, 0]]
+
+
+def test_gemma4_cached_suffix_prompt_kwargs_without_token_types_are_unchanged():
+    prompt_kwargs = {"unchanged": "value"}
+
+    prepared = prepare_cached_suffix_prompt_kwargs(prompt_kwargs, key_len=7)
+
+    assert prepared is prompt_kwargs
+
+
 def test_gemma4_suffix_visual_mask_patch_uses_query_rows_only():
     text_model = _Gemma4TextModel()
     patch_loaded_model(_gemma4_model(text_model))
@@ -121,13 +138,13 @@ def test_gemma4_mask_patch_matches_transformers_attention_topology():
 
 
 def test_gemma4_image_prefill_sections_are_cache_aligned_and_suffix_relative():
+    token_types = mx.zeros((1, 800), dtype=mx.int32)
+    token_types[:, 88:188] = 1
+    token_types[:, 588:688] = 1
+
     sections = image_prefill_sections(
         _gemma4_model(),
-        [
-            PromptImageSpan(start=300, end=400, image_hash="cached"),
-            PromptImageSpan(start=600, end=700, image_hash="first"),
-            PromptImageSpan(start=1_100, end=1_200, image_hash="second"),
-        ],
+        {"mm_token_type_ids": token_types},
         cached_prefix_len=512,
     )
 
@@ -135,16 +152,34 @@ def test_gemma4_image_prefill_sections_are_cache_aligned_and_suffix_relative():
 
 
 def test_gemma4_image_prefill_sections_merge_shared_cache_chunks():
+    token_types = mx.zeros((1, 700), dtype=mx.int32)
+    token_types[:, 300:400] = 1
+    token_types[:, 500:600] = 1
+
     sections = image_prefill_sections(
         _gemma4_model(),
-        [
-            PromptImageSpan(start=300, end=400, image_hash="first"),
-            PromptImageSpan(start=500, end=600, image_hash="second"),
-        ],
+        {"mm_token_type_ids": token_types},
         cached_prefix_len=0,
     )
 
     assert sections == [(256, 768)]
+
+
+def test_gemma4_image_prefill_sections_support_legacy_token_types():
+    token_types = mx.zeros((1, 700), dtype=mx.int32)
+    token_types[:, 300:400] = 1
+
+    sections = image_prefill_sections(
+        _gemma4_model(),
+        {"token_type_ids": token_types},
+        cached_prefix_len=0,
+    )
+
+    assert sections == [(256, 512)]
+
+
+def test_gemma4_image_prefill_sections_without_token_types_are_empty():
+    assert image_prefill_sections(_gemma4_model(), {}, cached_prefix_len=0) == []
 
 
 def test_gemma4_bidirectional_visual_detection_accepts_top_and_text_config():

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -1,7 +1,6 @@
 from types import SimpleNamespace
 
 import mlx.core as mx
-import pytest
 from mlx_vlm.models.cache import create_causal_mask
 
 from mlx_engine.model_kit.batched_vision.prompt_cache.types import PromptImageSpan
@@ -124,7 +123,6 @@ def test_gemma4_mask_patch_matches_transformers_attention_topology():
 def test_gemma4_image_prefill_sections_are_cache_aligned_and_suffix_relative():
     sections = image_prefill_sections(
         _gemma4_model(),
-        {},
         [
             PromptImageSpan(start=300, end=400, image_hash="cached"),
             PromptImageSpan(start=600, end=700, image_hash="first"),
@@ -139,7 +137,6 @@ def test_gemma4_image_prefill_sections_are_cache_aligned_and_suffix_relative():
 def test_gemma4_image_prefill_sections_merge_shared_cache_chunks():
     sections = image_prefill_sections(
         _gemma4_model(),
-        {},
         [
             PromptImageSpan(start=300, end=400, image_hash="first"),
             PromptImageSpan(start=500, end=600, image_hash="second"),
@@ -148,16 +145,6 @@ def test_gemma4_image_prefill_sections_merge_shared_cache_chunks():
     )
 
     assert sections == [(256, 768)]
-
-
-def test_gemma4_image_prefill_rejects_video_tokens():
-    with pytest.raises(ValueError, match="video input is not supported"):
-        image_prefill_sections(
-            _gemma4_model(),
-            {"mm_token_type_ids": mx.array([[0, 2, 2]], dtype=mx.int32)},
-            [],
-            cached_prefix_len=0,
-        )
 
 
 def test_gemma4_bidirectional_visual_detection_accepts_top_and_text_config():

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -1,10 +1,12 @@
 from types import SimpleNamespace
 
 import mlx.core as mx
-from mlx_lm.models.base import create_causal_mask
+import pytest
+from mlx_vlm.models.cache import create_causal_mask
 
 from mlx_engine.model_kit.patches.gemma4 import (
     config_uses_bidirectional_visual_attention,
+    image_prefill_spans,
     patch_loaded_model,
     prepare_cached_suffix_prompt_kwargs,
     uses_bidirectional_visual_attention,
@@ -12,6 +14,12 @@ from mlx_engine.model_kit.patches.gemma4 import (
 
 
 class _Gemma4TextModel:
+    window_size = 2
+    layers = [
+        SimpleNamespace(layer_type="full_attention"),
+        SimpleNamespace(layer_type="sliding_attention"),
+    ]
+
     def _block_sequence_ids_for_mask(self, mm_token_type_ids):
         is_vision = (mm_token_type_ids == 1) | (mm_token_type_ids == 2)
         prev = mx.concatenate(
@@ -25,18 +33,36 @@ class _Gemma4TextModel:
     def _apply_blockwise_bidirectional_overlay(self, base_mask, mm_token_type_ids):
         raise AssertionError("unpatched")
 
+    def _make_masks(self, h, cache, mm_token_type_ids=None):
+        del cache, mm_token_type_ids
+        return [
+            create_causal_mask(h.shape[1]),
+            create_causal_mask(h.shape[1], window_size=self.window_size),
+        ]
+
+
+def _gemma4_model(text_model=None):
+    if text_model is None:
+        text_model = _Gemma4TextModel()
+    language_model = SimpleNamespace(
+        model_type="gemma4_text",
+        config=SimpleNamespace(use_bidirectional_attention="vision"),
+        model=text_model,
+    )
+    return SimpleNamespace(language_model=language_model)
+
 
 def test_gemma4_cached_suffix_prompt_kwargs_pad_visual_token_types_to_key_len():
     """Restored Gemma4 visual suffix masks need token types for cached keys."""
     prompt_kwargs = {
-        "mm_token_type_ids": mx.array([[0, 1, 0, 2]], dtype=mx.int32),
+        "mm_token_type_ids": mx.array([[0, 1, 0, 1]], dtype=mx.int32),
         "unchanged": "value",
     }
 
     prepared = prepare_cached_suffix_prompt_kwargs(prompt_kwargs, key_len=7)
 
     assert prepared is not prompt_kwargs
-    assert prepared["mm_token_type_ids"].tolist() == [[0, 0, 0, 0, 1, 0, 2]]
+    assert prepared["mm_token_type_ids"].tolist() == [[0, 0, 0, 0, 1, 0, 1]]
     assert prepared["unchanged"] == "value"
 
 
@@ -53,14 +79,7 @@ def test_gemma4_cached_suffix_prompt_kwargs_keeps_text_only_token_types():
 
 def test_gemma4_suffix_visual_mask_patch_uses_query_rows_only():
     text_model = _Gemma4TextModel()
-    language_model = SimpleNamespace(
-        model_type="gemma4_text",
-        config=SimpleNamespace(use_bidirectional_attention="vision"),
-        model=text_model,
-    )
-    model = SimpleNamespace(language_model=language_model)
-
-    patch_loaded_model(model)
+    patch_loaded_model(_gemma4_model(text_model))
 
     base_mask = create_causal_mask(4, offset=5)
     token_types = mx.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]], dtype=mx.int32)
@@ -80,6 +99,71 @@ def test_gemma4_suffix_visual_mask_patch_uses_query_rows_only():
             short_token_types,
         )
         is base_mask
+    )
+
+
+def test_gemma4_mask_patch_matches_transformers_attention_topology():
+    text_model = _Gemma4TextModel()
+    patch_loaded_model(_gemma4_model(text_model))
+    token_types = mx.array([[0, 1, 1, 1, 3]], dtype=mx.int32)
+
+    full_mask, sliding_mask = text_model._make_masks(
+        mx.zeros((1, 5, 4), dtype=mx.float32),
+        [None, None],
+        token_types,
+    )
+
+    # Full attention is causal even within an image block.
+    assert not bool(full_mask[1, 2].item())
+    assert bool(full_mask[3, 1].item())
+
+    # Sliding attention is causal OR same-image-block, then windowed.
+    assert bool(sliding_mask[0, 0, 1, 2].item())
+    assert bool(sliding_mask[0, 0, 1, 3].item())
+    assert not bool(sliding_mask[0, 0, 3, 1].item())
+    assert not bool(sliding_mask[0, 0, 1, 4].item())
+
+
+def test_gemma4_image_prefill_spans_follow_token_type_runs():
+    spans = image_prefill_spans(
+        _gemma4_model(),
+        {
+            "mm_token_type_ids": mx.array(
+                [[0, 1, 1, 0, 1, 0]],
+                dtype=mx.int32,
+            )
+        },
+        [],
+        cached_prefix_len=0,
+    )
+
+    assert spans == [(1, 3), (4, 5)]
+
+
+def test_gemma4_image_prefill_rejects_video_tokens():
+    with pytest.raises(ValueError, match="video input is not supported"):
+        image_prefill_spans(
+            _gemma4_model(),
+            {"mm_token_type_ids": mx.array([[0, 2, 2]], dtype=mx.int32)},
+            [],
+            cached_prefix_len=0,
+        )
+
+
+def test_non_gemma_image_prefill_ignores_video_token_type():
+    model = SimpleNamespace(
+        model_type="other",
+        config=SimpleNamespace(use_bidirectional_attention=None),
+    )
+
+    assert (
+        image_prefill_spans(
+            model,
+            {"mm_token_type_ids": mx.array([[0, 2, 2]], dtype=mx.int32)},
+            [],
+            cached_prefix_len=0,
+        )
+        is None
     )
 
 

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -7,7 +7,7 @@ from mlx_vlm.models.cache import create_causal_mask
 from mlx_engine.model_kit.batched_vision.prompt_cache.types import PromptImageSpan
 from mlx_engine.model_kit.patches.gemma4 import (
     config_uses_bidirectional_visual_attention,
-    image_prefill_spans,
+    image_prefill_sections,
     patch_loaded_model,
     prepare_cached_suffix_prompt_kwargs,
     uses_bidirectional_visual_attention,
@@ -122,24 +122,38 @@ def test_gemma4_mask_patch_matches_transformers_attention_topology():
     assert not bool(sliding_mask[0, 0, 1, 4].item())
 
 
-def test_gemma4_image_prefill_spans_are_relative_to_cached_prefix():
-    spans = image_prefill_spans(
+def test_gemma4_image_prefill_sections_are_cache_aligned_and_suffix_relative():
+    sections = image_prefill_sections(
         _gemma4_model(),
         {},
         [
-            PromptImageSpan(start=2, end=5, image_hash="cached"),
-            PromptImageSpan(start=10, end=13, image_hash="first"),
-            PromptImageSpan(start=20, end=25, image_hash="second"),
+            PromptImageSpan(start=300, end=400, image_hash="cached"),
+            PromptImageSpan(start=600, end=700, image_hash="first"),
+            PromptImageSpan(start=1_100, end=1_200, image_hash="second"),
         ],
-        cached_prefix_len=8,
+        cached_prefix_len=512,
     )
 
-    assert spans == [(2, 5), (12, 17)]
+    assert sections == [(0, 256), (512, 768)]
+
+
+def test_gemma4_image_prefill_sections_merge_shared_cache_chunks():
+    sections = image_prefill_sections(
+        _gemma4_model(),
+        {},
+        [
+            PromptImageSpan(start=300, end=400, image_hash="first"),
+            PromptImageSpan(start=500, end=600, image_hash="second"),
+        ],
+        cached_prefix_len=0,
+    )
+
+    assert sections == [(256, 768)]
 
 
 def test_gemma4_image_prefill_rejects_video_tokens():
     with pytest.raises(ValueError, match="video input is not supported"):
-        image_prefill_spans(
+        image_prefill_sections(
             _gemma4_model(),
             {"mm_token_type_ids": mx.array([[0, 2, 2]], dtype=mx.int32)},
             [],

--- a/tests/test_patched_gemma4.py
+++ b/tests/test_patched_gemma4.py
@@ -5,7 +5,7 @@ from mlx_vlm.models.cache import create_causal_mask
 
 from mlx_engine.model_kit.patches.gemma4 import (
     config_uses_bidirectional_visual_attention,
-    image_prefill_sections,
+    image_prefill_runs,
     patch_loaded_model,
     prepare_cached_suffix_prompt_kwargs,
     uses_bidirectional_visual_attention,
@@ -137,63 +137,75 @@ def test_gemma4_mask_patch_matches_transformers_attention_topology():
     assert not bool(sliding_mask[0, 0, 1, 4].item())
 
 
-def test_gemma4_image_prefill_sections_are_cache_aligned_and_suffix_relative():
+def test_gemma4_mask_patch_keeps_separate_image_runs_causal():
+    text_model = _Gemma4TextModel()
+    patch_loaded_model(_gemma4_model(text_model))
+    token_types = mx.array([[1, 1, 0, 1, 1]], dtype=mx.int32)
+
+    _, sliding_mask = text_model._make_masks(
+        mx.zeros((1, 5, 4), dtype=mx.float32),
+        [None, None],
+        token_types,
+    )
+
+    assert bool(sliding_mask[0, 0, 0, 1].item())
+    assert not bool(sliding_mask[0, 0, 1, 3].item())
+    assert bool(sliding_mask[0, 0, 3, 4].item())
+
+
+def test_gemma4_image_prefill_runs_are_suffix_relative():
     token_types = mx.zeros((1, 800), dtype=mx.int32)
     token_types[:, 88:188] = 1
     token_types[:, 588:688] = 1
 
-    sections = image_prefill_sections(
+    runs = image_prefill_runs(
         _gemma4_model(),
         {"mm_token_type_ids": token_types},
-        cached_prefix_len=512,
     )
 
-    assert sections == [(0, 256), (512, 768)]
+    assert runs == [(88, 188), (588, 688)]
 
 
-def test_gemma4_image_prefill_sections_merge_shared_cache_chunks():
+def test_gemma4_image_prefill_runs_keep_images_separate():
     token_types = mx.zeros((1, 700), dtype=mx.int32)
     token_types[:, 300:400] = 1
     token_types[:, 500:600] = 1
 
-    sections = image_prefill_sections(
+    runs = image_prefill_runs(
         _gemma4_model(),
         {"mm_token_type_ids": token_types},
-        cached_prefix_len=0,
     )
 
-    assert sections == [(256, 768)]
+    assert runs == [(300, 400), (500, 600)]
 
 
-def test_gemma4_image_prefill_sections_keep_touching_chunks_separate():
+def test_gemma4_image_prefill_runs_do_not_merge_neighboring_chunks():
     token_types = mx.zeros((1, 600), dtype=mx.int32)
     token_types[:, 100:150] = 1
     token_types[:, 300:350] = 1
 
-    sections = image_prefill_sections(
+    runs = image_prefill_runs(
         _gemma4_model(),
         {"mm_token_type_ids": token_types},
-        cached_prefix_len=0,
     )
 
-    assert sections == [(0, 256), (256, 512)]
+    assert runs == [(100, 150), (300, 350)]
 
 
-def test_gemma4_image_prefill_sections_support_legacy_token_types():
+def test_gemma4_image_prefill_runs_support_legacy_token_types():
     token_types = mx.zeros((1, 700), dtype=mx.int32)
     token_types[:, 300:400] = 1
 
-    sections = image_prefill_sections(
+    runs = image_prefill_runs(
         _gemma4_model(),
         {"token_type_ids": token_types},
-        cached_prefix_len=0,
     )
 
-    assert sections == [(256, 512)]
+    assert runs == [(300, 400)]
 
 
-def test_gemma4_image_prefill_sections_without_token_types_are_empty():
-    assert image_prefill_sections(_gemma4_model(), {}, cached_prefix_len=0) == []
+def test_gemma4_image_prefill_runs_without_token_types_are_empty():
+    assert image_prefill_runs(_gemma4_model(), {}) == []
 
 
 def test_gemma4_bidirectional_visual_detection_accepts_top_and_text_config():


### PR DESCRIPTION
## Summary

Fixes an OOM when Gemma 4 processes long prompts containing images. The change restores bounded chunked prefill while keeping each bidirectional image block in one model call.

It also matches the Gemma 4 attention-mask behavior in [Transformers 5.14.1](https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2112-L2162).

## Problem

A Gemma 4 26B-A4B MLX user reached about 43K tokens with images from HTML and PDF files. MLX then attempted to allocate a 48.7 GB Metal buffer, above the machine's 30.2 GB buffer limit.

AutoFit estimated memory using the configured 2,048-token prefill size. The existing Gemma 4 workaround could instead process everything from the uncached prompt start through the last image in one model call. On a long prompt, this produced a much larger square attention allocation than AutoFit expected.

## Root cause

Gemma 4 needs bidirectional sliding attention only within each contiguous image soft-token run. Separate images are separate attention blocks. Full-attention layers remain causal.

The previous implementation satisfied this by keeping the entire visual prefix together, which was more restrictive than the model requires. It also used prompt-cache image spans as attention spans, but those spans may conservatively cover the entire prompt when image sentinels are unavailable.

## Design

The loaded Gemma 4 model is patched to use Transformers-compatible masks:

- Full attention stays causal.
- Sliding attention is causal or bidirectional within the same image block, constrained by the sliding window.
- Cached suffix queries are aligned with the visible key rows.

Exact image runs are derived once from `mm_token_type_ids == 1`. The legacy `token_type_ids` name is also supported. Cache image spans remain responsible only for cache identity and invalidation.

The scheduler accepts normal prefill boundaries unless they split an image run. It prefers the nearest globally safe 256-token cache boundary. If no such boundary exists, it uses an exact image boundary. This prevents nearby images from becoming one unbounded prefill call.

Gemma 4 has only KV and rotating-KV caches, so an occasional non-aligned model-call endpoint is safe. Disk cache records remain 256-token aligned. Completed chunks are sliced from the live snapshot, while a partial tail waits until the next cache boundary.

A call is now bounded by the configured prefill size or the largest individual image run. Published Gemma 4 processors use at most 280 image soft tokens, below the default 2,048-token prefill size.


## Performance

Prefill performance improves after this change. Measured on M2 Mac Studio.

| Scenario | Metric | Before (`35a325f`) | After (`6c2ed7e`) | Change |
|---|---:|---:|---:|---:|
| 8K text | Prefill | 8.279 s | 8.286 s | +0.08% |
| 8K text | Prefill throughput | 989.5 tok/s | 988.7 tok/s | −0.08% |
| 8K text | Decode | 73.62 tok/s | 73.31 tok/s | −0.43% |
| 8K text | Peak MLX memory | 17.269 GiB | 17.269 GiB | unchanged |
| 8K + image | Prefill | 9.364 s | 8.377 s | **−10.54%** |
| 8K + image | Prefill throughput | 874.8 tok/s | 977.9 tok/s | **+11.78%** |
| 8K + image | TTFT | 9.399 s | 8.412 s | **−10.50%** |
| 8K + image | Decode | 73.28 tok/s | 73.56 tok/s | +0.37% |
| 8K + image | Peak MLX memory | 19.079 GiB | 17.278 GiB | **−1.801 GiB / −9.44%** |


## Code review

<img width="739" height="404" alt="Screenshot 2026-08-13 at 4 53 22 PM" src="https://github.com/user-attachments/assets/96d937d7-edbf-4a3a-8cdb-66e46e29d5bd" />
