### PR TITLE
Increase autofitted context length by dynamically adjusting prefill step size

### DIFF
--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -863,9 +863,9 @@ class _PromptPrefill:
 
         segment_capacity = max(0, segment_end - self._processed_prefix_len)
         next_chunk_size = min(
-            step_size,
-            segment_capacity,
-            remaining_tokens - 1,
+            step_size,  # Normal maximum chunk size.
+            segment_capacity,  # Tokens until the step-size policy changes.
+            remaining_tokens - 1,  # Preserve a final model call for logits.
         )
         next_step = 0
         saving_prompt_cache = self._prefix_cache_save_state.callback is not None

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -900,6 +900,10 @@ class _PromptPrefill:
             if target_prefix_len > self._processed_prefix_len:
                 next_step = target_prefix_len - self._processed_prefix_len
 
+        # Segment ends change the preferred step; they are not valid split points
+        # inside Gemma 4's bidirectional image attention. The current image
+        # processor caps a run at 280 soft tokens, so even the worst 1,024 -> 512
+        # crossing is bounded at 535 tokens (255 before the image plus 280).
         return self._step_without_splitting_gemma4_image_run(
             next_step,
             maximum_step=step_size,

--- a/mlx_engine/model_kit/batched_vision/batch_generator.py
+++ b/mlx_engine/model_kit/batched_vision/batch_generator.py
@@ -19,6 +19,7 @@ from mlx_engine.model_kit.batched_vision.prompt_cache.types import (
     PromptImageSpan,
     PromptPrefixChunk,
 )
+from mlx_engine.model_kit.batched_vision.prefill_plan import PrefillPlan
 from mlx_engine.model_kit.batched_vision.prompt_inputs import (
     drop_prompt_kwargs_prefix,
     slice_prompt_kwargs,
@@ -79,6 +80,7 @@ class _PendingSequence:
     sampler: Callable[[mx.array], mx.array]
     logits_processors: list[LogitsProcessor]
     inputs_embeds: mx.array
+    prefill_plan: PrefillPlan | None
     cache: Optional[list[Any]]
     all_tokens: list[int]
     rope_deltas: Any | None
@@ -766,6 +768,7 @@ class _PromptPrefill:
         inputs_embeds: mx.array,
         prompt_kwargs: dict,
         prefix_cache_save_state: _PrefixCacheSaveState,
+        prefill_plan: PrefillPlan | None = None,
         prefill_step_size: Optional[int] = DEFAULT_PREFILL_STEP_SIZE,
         cache: Optional[list[Any]] = None,
         all_tokens: Optional[list[int]] = None,
@@ -777,6 +780,7 @@ class _PromptPrefill:
         self.top_logprobs = top_logprobs
         self.sampler = sampler
         self.logits_processors = logits_processors
+        self.prefill_plan = prefill_plan
         self.prefill_step_size = prefill_step_size
 
         self._input_ids = _left_pad_prompts([input_ids], max_length=len(input_ids))
@@ -839,12 +843,7 @@ class _PromptPrefill:
         return n
 
     def _next_prompt_step_size(self) -> int:
-        """Return the next chunked prefill size.
-
-        When disk checkpointing is active, a restored prefix can start between
-        normal prefill boundaries, so the first step may be short to land back
-        on the regular step grid.
-        """
+        """Return the next chunk from the request's precomputed schedule."""
         if self.prefill_step_size is None:
             return 0
 
@@ -852,21 +851,39 @@ class _PromptPrefill:
         if remaining_tokens <= 1:
             return 0
 
+        step_size = self.prefill_step_size
+        segment_start = 0
+        segment_end = self._processed_prefix_len + remaining_tokens
+        if self.prefill_plan is not None:
+            segment_start, segment = self.prefill_plan.segment_and_start_for_context(
+                self._processed_prefix_len
+            )
+            step_size = segment.step_size
+            segment_end = segment.end_context_length
+
+        segment_capacity = max(0, segment_end - self._processed_prefix_len)
+        next_chunk_size = min(
+            step_size,
+            segment_capacity,
+            remaining_tokens - 1,
+        )
         next_step = 0
         saving_prompt_cache = self._prefix_cache_save_state.callback is not None
-        # Cache-producing prefill calls normally end on the 256-token prefix
-        # grid because opaque ArraysCache/SSM state is restorable only at an exact
+        # Cache-producing prefill calls normally end on the active segment's grid
+        # because opaque ArraysCache/SSM state is restorable only at an exact
         # model-call endpoint. Gemma 4 has only KV/rotating-KV caches, so its
         # image-aware adjustment may use a non-aligned endpoint instead.
-        processed_remainder = self._processed_prefix_len % self.prefill_step_size
-        if saving_prompt_cache and processed_remainder:
-            # After a partial restore, land on the next normal prefill boundary.
-            alignment_step = self.prefill_step_size - processed_remainder
-            if alignment_step < remaining_tokens:
-                next_step = min(alignment_step, remaining_tokens - 1)
+        processed_remainder = (self._processed_prefix_len - segment_start) % step_size
+        if saving_prompt_cache and processed_remainder and next_chunk_size > 0:
+            # After a partial restore, land on the next active segment boundary.
+            alignment_step = step_size - processed_remainder
+            if alignment_step <= next_chunk_size and alignment_step < remaining_tokens:
+                next_step = alignment_step
 
-        if next_step == 0 and remaining_tokens > self.prefill_step_size:
-            next_step = min(self.prefill_step_size, remaining_tokens - 1)
+        final_context_length = self._processed_prefix_len + remaining_tokens
+        crosses_segment = final_context_length > segment_end
+        if next_step == 0 and (remaining_tokens > step_size or crosses_segment):
+            next_step = next_chunk_size
 
         if (
             next_step == 0
@@ -883,9 +900,17 @@ class _PromptPrefill:
             if target_prefix_len > self._processed_prefix_len:
                 next_step = target_prefix_len - self._processed_prefix_len
 
-        return self._step_without_splitting_gemma4_image_run(next_step)
+        return self._step_without_splitting_gemma4_image_run(
+            next_step,
+            maximum_step=step_size,
+        )
 
-    def _step_without_splitting_gemma4_image_run(self, proposed_step: int) -> int:
+    def _step_without_splitting_gemma4_image_run(
+        self,
+        proposed_step: int,
+        *,
+        maximum_step: int,
+    ) -> int:
         if proposed_step == 0 or self._gemma4_image_prefill_runs is None:
             return proposed_step
 
@@ -909,7 +934,7 @@ class _PromptPrefill:
                 # one image is itself longer.
                 if aligned_start > processed_prompt_len:
                     safe_boundary = aligned_start
-                elif image_end - processed_prompt_len <= self.prefill_step_size:
+                elif image_end - processed_prompt_len <= maximum_step:
                     safe_boundary = image_end
                 elif processed_prompt_len < image_start:
                     safe_boundary = image_start
@@ -1132,6 +1157,7 @@ class BatchGenerator:
         *,
         inputs_embeds: mx.array,
         sampler: Callable[[mx.array], mx.array],
+        prefill_plan: PrefillPlan | None = None,
         logits_processors: list[LogitsProcessor],
         prompt_kwargs: dict,
         prefix_cache_chunks: list[PromptPrefixChunk],
@@ -1158,6 +1184,7 @@ class BatchGenerator:
                 # Stateful processors are request-owned; callers must not share them.
                 logits_processors=list(logits_processors),
                 inputs_embeds=inputs_embeds,
+                prefill_plan=prefill_plan,
                 cache=cache,
                 all_tokens=list(all_tokens),
                 rope_deltas=rope_deltas,
@@ -1238,6 +1265,7 @@ class BatchGenerator:
                 inputs_embeds=sequence.inputs_embeds,
                 prompt_kwargs=sequence.prompt_kwargs,
                 prefix_cache_save_state=sequence.prefix_cache_save_state,
+                prefill_plan=sequence.prefill_plan,
                 prefill_step_size=self.prefill_step_size,
                 cache=sequence.cache,
                 all_tokens=sequence.all_tokens,

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -1,27 +1,25 @@
-"""Fit a model's context length to the available unified memory.
+"""Fit context and precompute memory-aware prompt-prefill schedules.
 
-A model's native context limit does not account for its loaded weights or the
-memory needed to read a long prompt. Guessing by allocating progressively larger
-prompts is unsafe because a Metal out-of-memory error can terminate the process.
-Instead, a one-token probe reveals the loaded model's real cache shapes and
-dtypes, then uses the formula below. The score term is validated for unfused
-Gemma 4 and Qwen 3.5 attention and fused 64-dimensional GPT-OSS attention. Other
-measurable cache layouts use the conservative unfused fit as a best effort.
+A one-token probe measures the loaded model's real cache shapes and dtypes. For
+a prepared prompt of ``P`` tokens, a post-chunk cache length ``K``, and prefill
+step ``S``, the peak estimate is:
 
-    fixed = loaded baseline + rotating cache + recurrent state
-    bytes/token = full KV + retained prompt inputs + attention scores
-    context = (recommended working set - reserve - fixed) / bytes/token
+    baseline + fixed SSM + rotating_constant + rotating_per_step * S
+    + prompt_input_bytes_per_token * P
+    + full_kv_bytes_per_token * K
+    + attention_bytes_per_context_per_step * S * K
+    + runtime reserve
 
-Long-prefill experiments on dense and MoE Qwen and Gemma models showed that
-unfused attention materialized scores matching
-`query heads * prefill chunk * activation dtype size`. GPT-OSS uses MLX's fused
-attention for its 64-dimensional heads, so it has no context-linear score term.
-The largest measured peak not explained by the formula was 2.41 GiB,
-motivating the 3 GiB reserve floor.
+The fitted maximum is solved once at load. At request admission, the same
+coefficients are solved once for cache-length boundaries and compiled into an
+immutable schedule: use the configured step (normally 2,048) while it fits,
+then 1,024, and use 512 only near the fitted maximum. Prompt callbacks only
+look up those boundaries; they do not rerun the memory formula.
 
-For example, Qwen 3.6 35B-A3B on a 27 GiB working set has about 19.06 GiB of
-fixed memory and uses 88 KiB per token. After the 3 GiB reserve, the formula
-fits 58,846 tokens, which rounds to a 58,880-token cache boundary.
+The fixed 3 GiB reserve covers the largest measured residual between this
+formula and actual prefill peaks. Measurements showed that residual follows
+model execution rather than installed RAM, so the reserve does not grow on
+larger-memory Macs and is not reduced to force a larger minimum context.
 """
 
 import gc
@@ -32,6 +30,11 @@ from typing import Any
 import mlx.core as mx
 from mlx_vlm.models.cache import make_prompt_cache
 
+from mlx_engine.model_kit.batched_vision.prefill_plan import (
+    PrefillPlan,
+    PrefillSegment,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,6 +43,10 @@ GIB = 1024**3
 MIN_FITTED_CONTEXT_TOKENS = 4_096
 # Round the largest 2.41 GiB unexplained experimental peak up to 3 GiB.
 MIN_RUNTIME_RESERVE_BYTES = 3 * GIB
+PREFILL_STEP_CANDIDATES = (2_048, 1_024, 512)
+# Bionic compacts at 15/16. Starting the smallest chunks no earlier than 85%
+# of the reported maximum limits them to about 9.3% of the pre-compaction range.
+SMALLEST_STEP_START_CONTEXT_PERCENT = 85
 
 _FAMILY_GEMMA4 = "gemma4"
 _FAMILY_GPT_OSS = "gpt_oss"
@@ -63,9 +70,26 @@ class CacheFitProfile:
     query_attention_heads: int
     activation_dtype_bytes: int
     prefill_step_size: int
-    rotating_peak_bytes: int
+    rotating_constant_bytes: int
+    rotating_bytes_per_prefill_token: int
     fixed_ssm_bytes: int
     max_context_length: int
+
+    @property
+    def rotating_peak_bytes(self) -> int:
+        return self.rotating_peak_bytes_for_step(self.prefill_step_size)
+
+    def rotating_peak_bytes_for_step(self, prefill_step_size: int) -> int:
+        return (
+            self.rotating_constant_bytes
+            + self.rotating_bytes_per_prefill_token * prefill_step_size
+        )
+
+    @property
+    def attention_bytes_per_context_per_prefill_token(self) -> int:
+        if not self.materializes_attention_scores:
+            return 0
+        return self.query_attention_heads * self.activation_dtype_bytes
 
 
 @dataclass(frozen=True)
@@ -73,6 +97,70 @@ class ContextFitResult:
     context_length: int
     runtime_reserve_bytes: int
     safe_ceiling_bytes: int
+    profile: CacheFitProfile | None = None
+    baseline_bytes: int = 0
+    working_set_bytes: int = 0
+    prefill_step_sizes: tuple[int, ...] = ()
+    step_context_limits: tuple[tuple[int, int], ...] = ()
+
+    def make_request_prefill_plan(
+        self,
+        *,
+        prompt_context_length: int,
+    ) -> PrefillPlan | None:
+        """Build one segmented schedule from the prepared prompt length.
+
+        The full prompt inputs can be resident before its KV cache is complete,
+        so request planning keeps prompt length and post-chunk cache length as
+        separate terms. No memory calculation is needed while chunks execute.
+        """
+        if self.profile is None or not self.prefill_step_sizes:
+            return None
+        if prompt_context_length <= 0:
+            raise ValueError("Prompt context length must be positive")
+        if prompt_context_length > self.context_length:
+            raise ValueError(
+                f"Prepared prompt has {prompt_context_length:,} tokens, exceeding "
+                f"the fitted {self.context_length:,}-token context"
+            )
+
+        segments: list[PrefillSegment] = []
+        previous_end = 0
+        for step_size in self.prefill_step_sizes:
+            context_limit = _request_cache_limit_for_step(
+                self.profile,
+                step_size=step_size,
+                prompt_context_length=prompt_context_length,
+                safe_ceiling_bytes=self.safe_ceiling_bytes,
+                baseline_bytes=self.baseline_bytes,
+            )
+            segment_end = min(prompt_context_length, context_limit)
+            segment_end = max(previous_end, segment_end)
+            if segment_end > previous_end:
+                segments.append(
+                    PrefillSegment(
+                        end_context_length=segment_end,
+                        step_size=step_size,
+                    )
+                )
+                previous_end = segment_end
+            if previous_end >= prompt_context_length:
+                break
+
+        if previous_end < prompt_context_length:
+            # The reported maximum is constrained by the smallest candidate, so
+            # this is only reachable through allocation-boundary rounding.
+            segments.append(
+                PrefillSegment(
+                    end_context_length=prompt_context_length,
+                    step_size=self.prefill_step_sizes[-1],
+                )
+            )
+
+        return PrefillPlan(
+            prompt_context_length=prompt_context_length,
+            segments=tuple(segments),
+        )
 
 
 def fit_batched_vlm_context(
@@ -80,13 +168,34 @@ def fit_batched_vlm_context(
     model: Any,
     prefill_step_size: int,
 ) -> int | None:
-    """Return a fitted token limit, or `None` to leave the limit unchanged.
+    """Return the fitted token limit, preserving the existing integer API."""
+    result = _fit_batched_vlm_context(
+        model=model,
+        prefill_step_size=prefill_step_size,
+        dynamic_prefill=False,
+    )
+    return None if result is None else result.context_length
 
-    A one-token probe measures the model's cache, retained prompt inputs, and
-    activation layout. Gemma 4 and Qwen 3.5 use the validated unfused fit;
-    64-dimensional GPT-OSS uses its validated fused fit. Other families use the
-    conservative unfused fit when their memory layout can be measured.
-    """
+
+def fit_batched_vlm_context_result(
+    *,
+    model: Any,
+    prefill_step_size: int,
+) -> ContextFitResult | None:
+    """Probe a model and return its context plus request-planning coefficients."""
+    return _fit_batched_vlm_context(
+        model=model,
+        prefill_step_size=prefill_step_size,
+        dynamic_prefill=True,
+    )
+
+
+def _fit_batched_vlm_context(
+    *,
+    model: Any,
+    prefill_step_size: int,
+    dynamic_prefill: bool,
+) -> ContextFitResult | None:
     max_context_length = None
     validated_family = False
     try:
@@ -142,9 +251,6 @@ def fit_batched_vlm_context(
                 query_head_dim = _config_value(source, "head_dim")
                 if query_head_dim is not None:
                     break
-            # MLX 0.32 uses fused long-prefill SDPA for GPT-OSS's official
-            # 64-dimensional attention layout. Unexpected variants retain the
-            # conservative score-matrix estimate.
             materializes_attention_scores = query_head_dim != 64
             if not materializes_attention_scores:
                 validated_family = True
@@ -181,7 +287,6 @@ def fit_batched_vlm_context(
                 materializes_attention_scores=materializes_attention_scores,
             )
         finally:
-            # Release the temporary probe arrays before measuring the loaded model.
             mx.synchronize()
             gc.collect()
             mx.clear_cache()
@@ -190,16 +295,21 @@ def fit_batched_vlm_context(
         if profile is None:
             return None
 
-        # Active arrays and allocator cache both occupy unified memory. Together
-        # they are the starting cost before the prompt grows.
         baseline_bytes = mx.get_active_memory() + mx.get_cache_memory()
-        # Apple's recommended working set is the process budget, not total RAM.
         working_set_bytes = mx.device_info()["max_recommended_working_set_size"]
-        result = calculate_context_fit(
-            profile,
-            working_set_bytes=working_set_bytes,
-            baseline_bytes=baseline_bytes,
-        )
+        if dynamic_prefill:
+            result = calculate_dynamic_context_fit(
+                profile,
+                working_set_bytes=working_set_bytes,
+                baseline_bytes=baseline_bytes,
+                maximum_prefill_step_size=prefill_step_size,
+            )
+        else:
+            result = calculate_context_fit(
+                profile,
+                working_set_bytes=working_set_bytes,
+                baseline_bytes=baseline_bytes,
+            )
         if not validated_family and result.context_length <= MIN_FITTED_CONTEXT_TOKENS:
             logger.info(
                 "Best-effort context fit for model family %s was only %s tokens; "
@@ -209,51 +319,181 @@ def fit_batched_vlm_context(
             )
             return None
 
-        attention_scores_bytes_per_token = _attention_scores_bytes_per_token(profile)
-        peak_bytes_per_token = (
-            profile.full_kv_bytes_per_token
-            + profile.prompt_input_bytes_per_token
-            + attention_scores_bytes_per_token
-        )
-        estimated_memory_bytes = (
-            baseline_bytes
-            + profile.rotating_peak_bytes
-            + profile.fixed_ssm_bytes
-            + peak_bytes_per_token * result.context_length
-        )
         logger.info(
             "Model context auto-fit: family=%s max=%s fitted=%s "
-            "working_set=%.2fGiB reserve=%.2fGiB safe_ceiling=%.2fGiB "
-            "baseline=%.2fGiB full_kv=%dB/token prompt_inputs=%dB/token "
-            "attention=%dB/token rotating_peak=%.2fGiB fixed_ssm=%.2fGiB "
-            "estimated_peak=%.2fGiB",
+            "working_set=%.2fGiB reserve=%.2fGiB baseline=%.2fGiB "
+            "full_kv=%dB/token prompt_inputs=%dB/token "
+            "attention_coefficient=%dB/context/step rotating_constant=%.2fGiB "
+            "rotating_per_step=%dB steps=%s",
             profile.family,
             f"{max_context_length:,}",
             f"{result.context_length:,}",
             working_set_bytes / GIB,
             result.runtime_reserve_bytes / GIB,
-            result.safe_ceiling_bytes / GIB,
             baseline_bytes / GIB,
             profile.full_kv_bytes_per_token,
             profile.prompt_input_bytes_per_token,
-            attention_scores_bytes_per_token,
-            profile.rotating_peak_bytes / GIB,
-            profile.fixed_ssm_bytes / GIB,
-            estimated_memory_bytes / GIB,
+            profile.attention_bytes_per_context_per_prefill_token,
+            profile.rotating_constant_bytes / GIB,
+            profile.rotating_bytes_per_prefill_token,
+            ",".join(f"{step}:{limit:,}" for step, limit in result.step_context_limits),
         )
-        return result.context_length
+        return result
     except Exception:
         logger.exception("Model context auto-fit failed; leaving context unchanged")
         return None
 
 
-def _attention_scores_bytes_per_token(profile: CacheFitProfile) -> int:
-    if not profile.materializes_attention_scores:
-        return 0
-    return (
-        profile.query_attention_heads
-        * profile.prefill_step_size
-        * profile.activation_dtype_bytes
+def _candidate_prefill_steps(maximum_prefill_step_size: int) -> tuple[int, ...]:
+    if maximum_prefill_step_size <= 0:
+        raise ValueError("Prefill step size must be positive")
+    candidates = [maximum_prefill_step_size]
+    candidates.extend(
+        step for step in PREFILL_STEP_CANDIDATES if step < maximum_prefill_step_size
+    )
+    return tuple(dict.fromkeys(candidates))
+
+
+def _attention_scores_bytes_per_token(
+    profile: CacheFitProfile,
+    prefill_step_size: int | None = None,
+) -> int:
+    if prefill_step_size is None:
+        prefill_step_size = profile.prefill_step_size
+    return profile.attention_bytes_per_context_per_prefill_token * prefill_step_size
+
+
+def _context_fit_for_step(
+    profile: CacheFitProfile,
+    *,
+    step_size: int,
+    safe_ceiling_bytes: int,
+    baseline_bytes: int,
+) -> int:
+    fixed_memory_bytes = (
+        baseline_bytes
+        + profile.fixed_ssm_bytes
+        + profile.rotating_peak_bytes_for_step(step_size)
+    )
+    peak_bytes_per_token = (
+        profile.full_kv_bytes_per_token
+        + profile.prompt_input_bytes_per_token
+        + _attention_scores_bytes_per_token(profile, step_size)
+    )
+    available_prompt_bytes = max(0, safe_ceiling_bytes - fixed_memory_bytes)
+    tokens_that_fit = available_prompt_bytes // peak_bytes_per_token
+    allocation_step = profile.allocation_step
+    context_length = (
+        (tokens_that_fit + allocation_step - 1) // allocation_step * allocation_step
+    )
+    return min(profile.max_context_length, context_length)
+
+
+def _request_cache_limit_for_step(
+    profile: CacheFitProfile,
+    *,
+    step_size: int,
+    prompt_context_length: int,
+    safe_ceiling_bytes: int,
+    baseline_bytes: int,
+) -> int:
+    fixed_and_prompt_bytes = (
+        baseline_bytes
+        + profile.fixed_ssm_bytes
+        + profile.rotating_peak_bytes_for_step(step_size)
+        + profile.prompt_input_bytes_per_token * prompt_context_length
+    )
+    bytes_per_cached_token = (
+        profile.full_kv_bytes_per_token
+        + _attention_scores_bytes_per_token(profile, step_size)
+    )
+    available_cache_bytes = max(0, safe_ceiling_bytes - fixed_and_prompt_bytes)
+    tokens_that_fit = available_cache_bytes // bytes_per_cached_token
+    return tokens_that_fit // profile.allocation_step * profile.allocation_step
+
+
+def _tail_limited_context(
+    profile: CacheFitProfile,
+    *,
+    step_size: int,
+    safe_ceiling_bytes: int,
+    baseline_bytes: int,
+) -> int:
+    """Cap context so ``step_size`` stays safe through the fast-step region."""
+    fixed_memory_bytes = (
+        baseline_bytes
+        + profile.fixed_ssm_bytes
+        + profile.rotating_peak_bytes_for_step(step_size)
+    )
+    available_bytes = max(0, safe_ceiling_bytes - fixed_memory_bytes)
+    cached_bytes_per_token = (
+        profile.full_kv_bytes_per_token
+        + _attention_scores_bytes_per_token(profile, step_size)
+    )
+    denominator = (
+        profile.prompt_input_bytes_per_token * 100
+        + cached_bytes_per_token * SMALLEST_STEP_START_CONTEXT_PERCENT
+    )
+    tokens_that_fit = available_bytes * 100 // denominator
+    return tokens_that_fit // profile.allocation_step * profile.allocation_step
+
+
+def calculate_dynamic_context_fit(
+    profile: CacheFitProfile,
+    *,
+    working_set_bytes: int,
+    baseline_bytes: int,
+    maximum_prefill_step_size: int,
+) -> ContextFitResult:
+    """Fit context using a decreasing per-request prefill schedule."""
+    # The measured overhead is tied to model execution, not installed RAM.
+    runtime_reserve_bytes = MIN_RUNTIME_RESERVE_BYTES
+    safe_ceiling_bytes = working_set_bytes - runtime_reserve_bytes
+    prefill_step_sizes = _candidate_prefill_steps(maximum_prefill_step_size)
+    step_context_limits = tuple(
+        (
+            step_size,
+            _context_fit_for_step(
+                profile,
+                step_size=step_size,
+                safe_ceiling_bytes=safe_ceiling_bytes,
+                baseline_bytes=baseline_bytes,
+            ),
+        )
+        for step_size in prefill_step_sizes
+    )
+
+    context_length = step_context_limits[-1][1]
+    if len(prefill_step_sizes) >= 2 and prefill_step_sizes[-1] == 512:
+        # Keep the slowest candidate in the final 15% regardless of the
+        # caller's configured maximum (for example, 1,536 or 1,024).
+        context_length = min(
+            context_length,
+            _tail_limited_context(
+                profile,
+                step_size=prefill_step_sizes[-2],
+                safe_ceiling_bytes=safe_ceiling_bytes,
+                baseline_bytes=baseline_bytes,
+            ),
+        )
+    if context_length < MIN_FITTED_CONTEXT_TOKENS:
+        logger.warning(
+            "Model context auto-fit calculated %s tokens; using the %s token minimum",
+            f"{context_length:,}",
+            f"{MIN_FITTED_CONTEXT_TOKENS:,}",
+        )
+        context_length = MIN_FITTED_CONTEXT_TOKENS
+    context_length = min(profile.max_context_length, context_length)
+
+    return ContextFitResult(
+        context_length=context_length,
+        runtime_reserve_bytes=runtime_reserve_bytes,
+        safe_ceiling_bytes=safe_ceiling_bytes,
+        profile=profile,
+        baseline_bytes=baseline_bytes,
+        working_set_bytes=working_set_bytes,
+        prefill_step_sizes=prefill_step_sizes,
+        step_context_limits=step_context_limits,
     )
 
 
@@ -263,45 +503,14 @@ def calculate_context_fit(
     working_set_bytes: int,
     baseline_bytes: int,
 ) -> ContextFitResult:
-    """Calculate the context limit from the model's measured memory costs.
-
-    The fit subtracts the runtime reserve and fixed memory from the recommended
-    working set. It divides what remains by the per-token peak for KV, retained
-    prompt inputs, and any materialized attention scores. The result contains the
-    chosen token limit and the reserve and safe ceiling used to calculate it.
-    """
-    # The modeled terms undercounted measured prefill peaks by at most 2.41 GiB.
-    # Leave 3 GiB for that variation, or 5% on very large working sets.
-    runtime_reserve_bytes = max(MIN_RUNTIME_RESERVE_BYTES, working_set_bytes // 20)
+    """Calculate the legacy fixed-step context limit."""
+    runtime_reserve_bytes = MIN_RUNTIME_RESERVE_BYTES
     safe_ceiling_bytes = working_set_bytes - runtime_reserve_bytes
-    # These costs do not grow with the ordinary full-context KV cache.
-    fixed_memory_bytes = (
-        baseline_bytes + profile.rotating_peak_bytes + profile.fixed_ssm_bytes
-    )
-
-    # Unfused long-prefill attention materializes one score value per query head
-    # and prefill token for every context token. Validated fused paths omit this
-    # context-linear allocation; their fixed-size workspace remains in the reserve.
-    attention_scores_bytes_per_token = _attention_scores_bytes_per_token(profile)
-    peak_bytes_per_token = (
-        profile.full_kv_bytes_per_token
-        + profile.prompt_input_bytes_per_token
-        + attention_scores_bytes_per_token
-    )
-
-    # First find how many bytes remain for the prompt after paying the model's
-    # fixed costs. If those costs already exceed the ceiling, zero bytes remain.
-    available_prompt_bytes = max(0, safe_ceiling_bytes - fixed_memory_bytes)
-
-    # Dividing the remaining bytes by one token's peak cost gives the number of
-    # prompt tokens that fit in memory.
-    tokens_that_fit = available_prompt_bytes // peak_bytes_per_token
-
-    # MLX allocates KV in token blocks. Round to the measured block boundary;
-    # the reserve absorbs the less-than-one-block difference.
-    allocation_step = profile.allocation_step
-    context_length = (
-        (tokens_that_fit + allocation_step - 1) // allocation_step * allocation_step
+    context_length = _context_fit_for_step(
+        profile,
+        step_size=profile.prefill_step_size,
+        safe_ceiling_bytes=safe_ceiling_bytes,
+        baseline_bytes=baseline_bytes,
     )
     if context_length < MIN_FITTED_CONTEXT_TOKENS:
         logger.warning(
@@ -310,13 +519,16 @@ def calculate_context_fit(
             f"{MIN_FITTED_CONTEXT_TOKENS:,}",
         )
         context_length = MIN_FITTED_CONTEXT_TOKENS
-    # Available memory never permits extending the model beyond its native limit.
     context_length = min(profile.max_context_length, context_length)
-
     return ContextFitResult(
         context_length=context_length,
         runtime_reserve_bytes=runtime_reserve_bytes,
         safe_ceiling_bytes=safe_ceiling_bytes,
+        profile=profile,
+        baseline_bytes=baseline_bytes,
+        working_set_bytes=working_set_bytes,
+        prefill_step_sizes=(profile.prefill_step_size,),
+        step_context_limits=((profile.prefill_step_size, context_length),),
     )
 
 
@@ -331,7 +543,6 @@ def _probe_cache_fit_profile(
     materializes_attention_scores: bool = True,
 ) -> CacheFitProfile | None:
     prompt_cache = make_prompt_cache(language_model)
-    # One token is enough to allocate every cache in its real shape and dtype.
     input_ids = mx.zeros((1, 1), dtype=mx.int32)
     embedding_kwargs = {
         key: value
@@ -339,12 +550,10 @@ def _probe_cache_fit_profile(
         if value is not None
     }
     inputs_embeds = embedding_kwargs.pop("inputs_embeds")
-    # Gemma 4 keeps per-layer inputs alive for the full prompt too.
     prompt_input_bytes_per_token = inputs_embeds.nbytes
     per_layer_inputs = embedding_kwargs.get("per_layer_inputs")
     if per_layer_inputs is not None:
         prompt_input_bytes_per_token += per_layer_inputs.nbytes
-    # Attention uses the same activation dtype as the token embeddings.
     activation_dtype_bytes = inputs_embeds.itemsize
 
     language_model(
@@ -356,12 +565,10 @@ def _probe_cache_fit_profile(
     mx.eval([cache.state for cache in prompt_cache])
     mx.synchronize()
 
-    # Full KV grows with context. Rotating KV and Qwen SSM state are fixed costs.
     full_kv_bytes_per_token = 0
-    rotating_peak_bytes = 0
+    rotating_constant_bytes = 0
+    rotating_bytes_per_prefill_token = 0
     fixed_ssm_bytes = 0
-    # KV caches grow in token blocks. Every layer must use the same block size so
-    # one rounded context length describes the whole model.
     cache_allocation_steps = set()
 
     for cache in prompt_cache:
@@ -375,8 +582,6 @@ def _probe_cache_fit_profile(
             return None
 
         if cache_type == "KVCache":
-            # nbytes includes both keys and values. Divide by the allocated token
-            # width to get the cost of one token.
             full_kv_bytes_per_token += cache.nbytes // cache.keys.shape[2]
             cache_allocation_steps.add(cache.step)
         elif cache_type == "RotatingKVCache":
@@ -387,16 +592,11 @@ def _probe_cache_fit_profile(
                     cache.keep,
                 )
                 return None
-            # One layer can briefly hold its window plus the new prefill chunk,
-            # with one overlapping token: max_size + prefill_step_size - 1.
-            rotating_peak_bytes += (
-                cache.nbytes
-                // cache.keys.shape[2]
-                * (cache.max_size + prefill_step_size - 1)
-            )
+            rotating_bytes_per_token = cache.nbytes // cache.keys.shape[2]
+            rotating_constant_bytes += rotating_bytes_per_token * (cache.max_size - 1)
+            rotating_bytes_per_prefill_token += rotating_bytes_per_token
             cache_allocation_steps.add(cache.step)
         else:
-            # ArraysCache holds fixed-size convolution or recurrent state.
             if any(state is None for state in cache.cache):
                 logger.error(
                     "ArraysCache probe for %s left state uninitialized; "
@@ -429,7 +629,8 @@ def _probe_cache_fit_profile(
         query_attention_heads=query_attention_heads,
         activation_dtype_bytes=activation_dtype_bytes,
         prefill_step_size=prefill_step_size,
-        rotating_peak_bytes=rotating_peak_bytes,
+        rotating_constant_bytes=rotating_constant_bytes,
+        rotating_bytes_per_prefill_token=rotating_bytes_per_prefill_token,
         fixed_ssm_bytes=fixed_ssm_bytes,
         max_context_length=max_context_length,
     )

--- a/mlx_engine/model_kit/batched_vision/context_fit.py
+++ b/mlx_engine/model_kit/batched_vision/context_fit.py
@@ -13,8 +13,8 @@ step ``S``, the peak estimate is:
 The fitted maximum is solved once at load. At request admission, the same
 coefficients are solved once for cache-length boundaries and compiled into an
 immutable schedule: use the configured step (normally 2,048) while it fits,
-then 1,024, and use 512 only near the fitted maximum. Prompt callbacks only
-look up those boundaries; they do not rerun the memory formula.
+then 1,024 and 512 only when their lower peak memory is required. Prompt
+callbacks only look up those boundaries; they do not rerun the memory formula.
 
 The fixed 3 GiB reserve covers the largest measured residual between this
 formula and actual prefill peaks. Measurements showed that residual follows
@@ -44,9 +44,6 @@ MIN_FITTED_CONTEXT_TOKENS = 4_096
 # Round the largest 2.41 GiB unexplained experimental peak up to 3 GiB.
 MIN_RUNTIME_RESERVE_BYTES = 3 * GIB
 PREFILL_STEP_CANDIDATES = (2_048, 1_024, 512)
-# Bionic compacts at 15/16. Starting the smallest chunks no earlier than 85%
-# of the reported maximum limits them to about 9.3% of the pre-compaction range.
-SMALLEST_STEP_START_CONTEXT_PERCENT = 85
 
 _FAMILY_GEMMA4 = "gemma4"
 _FAMILY_GPT_OSS = "gpt_oss"
@@ -148,14 +145,22 @@ class ContextFitResult:
                 break
 
         if previous_end < prompt_context_length:
-            # The reported maximum is constrained by the smallest candidate, so
-            # this is only reachable through allocation-boundary rounding.
-            segments.append(
-                PrefillSegment(
+            # The fitted limit rounds to a cache-allocation boundary, while the
+            # request boundary rounds down. Extend the final candidate through
+            # that sub-block difference without creating a duplicate segment.
+            final_step_size = self.prefill_step_sizes[-1]
+            if segments and segments[-1].step_size == final_step_size:
+                segments[-1] = PrefillSegment(
                     end_context_length=prompt_context_length,
-                    step_size=self.prefill_step_sizes[-1],
+                    step_size=final_step_size,
                 )
-            )
+            else:
+                segments.append(
+                    PrefillSegment(
+                        end_context_length=prompt_context_length,
+                        step_size=final_step_size,
+                    )
+                )
 
         return PrefillPlan(
             prompt_context_length=prompt_context_length,
@@ -412,32 +417,6 @@ def _request_cache_limit_for_step(
     return tokens_that_fit // profile.allocation_step * profile.allocation_step
 
 
-def _tail_limited_context(
-    profile: CacheFitProfile,
-    *,
-    step_size: int,
-    safe_ceiling_bytes: int,
-    baseline_bytes: int,
-) -> int:
-    """Cap context so ``step_size`` stays safe through the fast-step region."""
-    fixed_memory_bytes = (
-        baseline_bytes
-        + profile.fixed_ssm_bytes
-        + profile.rotating_peak_bytes_for_step(step_size)
-    )
-    available_bytes = max(0, safe_ceiling_bytes - fixed_memory_bytes)
-    cached_bytes_per_token = (
-        profile.full_kv_bytes_per_token
-        + _attention_scores_bytes_per_token(profile, step_size)
-    )
-    denominator = (
-        profile.prompt_input_bytes_per_token * 100
-        + cached_bytes_per_token * SMALLEST_STEP_START_CONTEXT_PERCENT
-    )
-    tokens_that_fit = available_bytes * 100 // denominator
-    return tokens_that_fit // profile.allocation_step * profile.allocation_step
-
-
 def calculate_dynamic_context_fit(
     profile: CacheFitProfile,
     *,
@@ -463,19 +442,9 @@ def calculate_dynamic_context_fit(
         for step_size in prefill_step_sizes
     )
 
+    # The smallest candidate defines the maximum memory-safe context. Request
+    # plans still use every larger candidate up to its exact safe boundary.
     context_length = step_context_limits[-1][1]
-    if len(prefill_step_sizes) >= 2 and prefill_step_sizes[-1] == 512:
-        # Keep the slowest candidate in the final 15% regardless of the
-        # caller's configured maximum (for example, 1,536 or 1,024).
-        context_length = min(
-            context_length,
-            _tail_limited_context(
-                profile,
-                step_size=prefill_step_sizes[-2],
-                safe_ceiling_bytes=safe_ceiling_bytes,
-                baseline_bytes=baseline_bytes,
-            ),
-        )
     if context_length < MIN_FITTED_CONTEXT_TOKENS:
         logger.warning(
             "Model context auto-fit calculated %s tokens; using the %s token minimum",

--- a/mlx_engine/model_kit/batched_vision/model_kit.py
+++ b/mlx_engine/model_kit/batched_vision/model_kit.py
@@ -22,7 +22,10 @@ from mlx_engine.model_kit.batched_model_kit_types import (
 from mlx_engine.model_kit.batched_vision.batch_generator import (
     BatchGenerator as LocalVlmBatchGenerator,
 )
-from mlx_engine.model_kit.batched_vision.context_fit import fit_batched_vlm_context
+from mlx_engine.model_kit.batched_vision.context_fit import (
+    ContextFitResult,
+    fit_batched_vlm_context_result,
+)
 from mlx_engine.model_kit.batched_vision.prompt_cache.coordinator import (
     VlmPromptCacheCoordinator,
 )
@@ -140,6 +143,7 @@ class BatchedVisionModelKit:
         self.prefill_step_size = prefill_step_size
         self._model_path = model_path
         self._effective_context_length: int | None = None
+        self._context_fit_result: ContextFitResult | None = None
         if max_seq_nums is None:
             max_seq_nums = DEFAULT_MAX_SEQ_NUMS
         elif max_seq_nums < 1:
@@ -236,6 +240,7 @@ class BatchedVisionModelKit:
 
         if not self._auto_fit_context:
             logger.info("Context auto-fit disabled; leaving context unchanged")
+            self._context_fit_result = None
             self._effective_context_length = None
         elif _requires_global_no_chunked_prefill(
             self.model,
@@ -243,11 +248,17 @@ class BatchedVisionModelKit:
             self._uses_gemma4_bidirectional_visual_attention,
         ):
             logger.info("Model requires unchunked prefill; leaving context unchanged")
+            self._context_fit_result = None
             self._effective_context_length = None
         else:
-            self._effective_context_length = fit_batched_vlm_context(
+            self._context_fit_result = fit_batched_vlm_context_result(
                 model=self.model,
                 prefill_step_size=self.prefill_step_size,
+            )
+            self._effective_context_length = (
+                None
+                if self._context_fit_result is None
+                else self._context_fit_result.context_length
             )
             if self._effective_context_length is not None:
                 self._prompt_cache_store.ensure_max_kv_size(
@@ -454,6 +465,20 @@ class BatchedVisionModelKit:
         restored = prepared_insert.restored
         full_prompt_input_ids = prepared_prompt.prompt_input_ids
         prompt_token_count = len(full_prompt_input_ids)
+        try:
+            prefill_plan = (
+                None
+                if self._context_fit_result is None
+                else self._context_fit_result.make_request_prefill_plan(
+                    prompt_context_length=prompt_token_count,
+                )
+            )
+        except ValueError as error:
+            # Multimodal preparation can expand beyond the text-token limit.
+            # Reject only this request instead of failing the generation thread.
+            request.rqueue.put(error)
+            return
+
         if restored is not None and _restore_splits_gemma4_image_span(
             model_type=self.model_type,
             cached_prefix_len=restored.cached_prefix_len,
@@ -526,9 +551,21 @@ class BatchedVisionModelKit:
                 prefill_tokens_processed=0,
             )
         )
+        if prefill_plan is not None:
+            logger.info(
+                "Request prefill plan: prompt=%s cached=%s segments=%s",
+                f"{prompt_token_count:,}",
+                f"{cached_prefix_len:,}",
+                ",".join(
+                    f"{segment.step_size}:{segment.end_context_length:,}"
+                    for segment in prefill_plan.segments
+                ),
+            )
+
         uid = batch_generator.insert(
             prompt_input_ids,
             inputs_embeds=inputs_embeds,
+            prefill_plan=prefill_plan,
             max_tokens=request.max_tokens,
             top_logprobs=request.top_logprobs,
             sampler=request.sampler,

--- a/mlx_engine/model_kit/batched_vision/prefill_plan.py
+++ b/mlx_engine/model_kit/batched_vision/prefill_plan.py
@@ -1,0 +1,36 @@
+"""Immutable per-request chunk schedule for memory-aware prompt prefill."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PrefillSegment:
+    """Use ``step_size`` until the cache reaches ``end_context_length``."""
+
+    end_context_length: int
+    step_size: int
+
+
+@dataclass(frozen=True)
+class PrefillPlan:
+    """A precomputed segmented schedule for one prepared prompt."""
+
+    prompt_context_length: int
+    segments: tuple[PrefillSegment, ...]
+
+    def segment_and_start_for_context(
+        self,
+        context_length: int,
+    ) -> tuple[int, PrefillSegment]:
+        if not self.segments:
+            raise ValueError("Prefill plan has no segments")
+        segment_start = 0
+        for segment in self.segments:
+            if context_length < segment.end_context_length:
+                return segment_start, segment
+            segment_start = segment.end_context_length
+        last_segment = self.segments[-1]
+        previous_end = (
+            self.segments[-2].end_context_length if len(self.segments) > 1 else 0
+        )
+        return previous_end, last_segment

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -1503,3 +1503,50 @@ def test_segmented_plan_preserves_state_cache_checkpoints_after_restore(monkeypa
         (2, 3, 768),
         (3, 4, 1_024),
     ]
+
+
+def test_dynamic_prefill_plan_uses_active_step_around_gemma4_image(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _gemma4_unified_model()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=4,
+    )
+    prompt = list(range(12))
+    token_types = mx.zeros((1, len(prompt)), dtype=mx.int32)
+    token_types[:, 5:7] = 1
+    plan = PrefillPlan(
+        prompt_context_length=len(prompt),
+        segments=(
+            PrefillSegment(end_context_length=4, step_size=4),
+            PrefillSegment(end_context_length=len(prompt), step_size=2),
+        ),
+    )
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            prefill_plan=plan,
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={"mm_token_type_ids": token_types},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[PromptImageSpan(start=5, end=7, image_hash="image")],
+        )
+        for _ in range(6):
+            generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 1, 2, 2, 2, 1]
+    assert model.calls[1]["mm_token_type_ids"] is None
+    assert model.calls[2]["mm_token_type_ids"] == [[0] * 5 + [1] * 2]

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -16,6 +16,10 @@ from mlx_engine.model_kit.batched_vision.batch_generator import (
     GenerationBatch,
     _PrefixCacheSaveState,
 )
+from mlx_engine.model_kit.batched_vision.prefill_plan import (
+    PrefillPlan,
+    PrefillSegment,
+)
 from mlx_engine.model_kit.batched_vision.prompt_cache.chunks import (
     build_prefix_cache_chunks,
 )
@@ -1296,3 +1300,206 @@ def test_batch_generator_state_cache_lands_on_reusable_tail_boundary(monkeypatch
         (start_chunk_idx, end_chunk_idx, snapshot_len)
         for _, _, start_chunk_idx, end_chunk_idx, snapshot_len in snapshots
     ] == [(0, 7, 1792)]
+
+
+def test_batch_generator_uses_precomputed_segmented_prefill_plan(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _FakeModel()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=2_048,
+    )
+    prompt = list(range(15))
+    plan = PrefillPlan(
+        prompt_context_length=len(prompt),
+        segments=(
+            PrefillSegment(end_context_length=8, step_size=4),
+            PrefillSegment(end_context_length=12, step_size=2),
+            PrefillSegment(end_context_length=15, step_size=1),
+        ),
+    )
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            prefill_plan=plan,
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={},
+            prefix_cache_chunks=[],
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[],
+        )
+        for _ in range(7):
+            generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [
+        4,
+        4,
+        2,
+        2,
+        1,
+        1,
+        1,
+    ]
+
+
+def test_cache_saves_do_not_inject_small_chunks_after_plan_transition(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        batcher,
+        "make_prompt_cache",
+        lambda _model: [_FakeBatchCache()],
+    )
+    model = _FakeModel()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=1_024,
+    )
+    prompt = list(range(2_305))
+    plan = PrefillPlan(
+        prompt_context_length=len(prompt),
+        segments=(
+            PrefillSegment(end_context_length=768, step_size=1_024),
+            PrefillSegment(end_context_length=len(prompt), step_size=512),
+        ),
+    )
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            prefill_plan=plan,
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={},
+            prefix_cache_chunks=build_prefix_cache_chunks(prompt, []),
+            all_tokens=[],
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[],
+            prompt_cache_save_callback=lambda *_args: None,
+        )
+        for _ in range(5):
+            generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [
+        768,
+        512,
+        512,
+        512,
+        1,
+    ]
+
+
+def test_batch_generator_starts_restored_request_in_later_plan_segment(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    model = _FakeModel()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=2_048,
+    )
+    prompt = list(range(5))
+    plan = PrefillPlan(
+        prompt_context_length=15,
+        segments=(
+            PrefillSegment(end_context_length=8, step_size=4),
+            PrefillSegment(end_context_length=12, step_size=2),
+            PrefillSegment(end_context_length=15, step_size=1),
+        ),
+    )
+
+    try:
+        generator.insert(
+            prompt,
+            inputs_embeds=mx.zeros((1, len(prompt), 2), dtype=mx.float32),
+            prefill_plan=plan,
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={},
+            prefix_cache_chunks=[],
+            cache=[_FakeScalarCache()],
+            all_tokens=list(range(10)),
+            next_prefix_cache_chunk_idx=0,
+            image_spans=[],
+        )
+        for _ in range(4):
+            generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [2, 1, 1, 1]
+
+
+def test_segmented_plan_preserves_state_cache_checkpoints_after_restore(monkeypatch):
+    monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
+    model = _FakeModel()
+    generator = BatchGenerator(
+        model=model,
+        stop_criteria=lambda _token: False,
+        prefill_step_size=512,
+    )
+    full_prompt = list(range(1_025))
+    restored_prefix = full_prompt[:256]
+    prompt_suffix = full_prompt[256:]
+    plan = PrefillPlan(
+        prompt_context_length=len(full_prompt),
+        segments=(
+            PrefillSegment(end_context_length=512, step_size=512),
+            PrefillSegment(end_context_length=768, step_size=256),
+            PrefillSegment(end_context_length=1_025, step_size=128),
+        ),
+    )
+    snapshots = []
+
+    try:
+        generator.insert(
+            prompt_suffix,
+            inputs_embeds=mx.zeros(
+                (1, len(prompt_suffix), 2),
+                dtype=mx.float32,
+            ),
+            prefill_plan=plan,
+            sampler=_argmax_sampler,
+            logits_processors=[],
+            prompt_kwargs={},
+            prefix_cache_chunks=build_prefix_cache_chunks(full_prompt, []),
+            cache=[ArraysCache()],
+            all_tokens=restored_prefix,
+            next_prefix_cache_chunk_idx=1,
+            image_spans=[],
+            prompt_cache_save_callback=lambda *args: snapshots.append(args),
+        )
+        for _ in range(5):
+            generator.next()
+    finally:
+        generator.close()
+
+    assert [len(call["input_ids"][0]) for call in model.calls] == [
+        256,
+        256,
+        128,
+        128,
+        1,
+    ]
+    assert [
+        (start_chunk_idx, end_chunk_idx, snapshot_len)
+        for _, _, start_chunk_idx, end_chunk_idx, snapshot_len in snapshots
+    ] == [
+        (1, 2, 512),
+        (2, 3, 768),
+        (3, 4, 1_024),
+    ]

--- a/tests/test_batched_vision_batch_generator.py
+++ b/tests/test_batched_vision_batch_generator.py
@@ -1505,7 +1505,9 @@ def test_segmented_plan_preserves_state_cache_checkpoints_after_restore(monkeypa
     ]
 
 
-def test_dynamic_prefill_plan_uses_active_step_around_gemma4_image(monkeypatch):
+def test_dynamic_prefill_plan_keeps_gemma4_image_whole_across_transition(
+    monkeypatch,
+):
     monkeypatch.setattr(batcher, "wired_limit", lambda _model: contextlib.nullcontext())
     monkeypatch.setattr(
         batcher,
@@ -1516,16 +1518,18 @@ def test_dynamic_prefill_plan_uses_active_step_around_gemma4_image(monkeypatch):
     generator = BatchGenerator(
         model=model,
         stop_criteria=lambda _token: False,
-        prefill_step_size=4,
+        prefill_step_size=1_024,
     )
-    prompt = list(range(12))
+    prompt = list(range(2_049))
+    image_start = 1_023
+    image_end = image_start + 280
     token_types = mx.zeros((1, len(prompt)), dtype=mx.int32)
-    token_types[:, 5:7] = 1
+    token_types[:, image_start:image_end] = 1
     plan = PrefillPlan(
         prompt_context_length=len(prompt),
         segments=(
-            PrefillSegment(end_context_length=4, step_size=4),
-            PrefillSegment(end_context_length=len(prompt), step_size=2),
+            PrefillSegment(end_context_length=1_024, step_size=1_024),
+            PrefillSegment(end_context_length=len(prompt), step_size=512),
         ),
     )
 
@@ -1540,13 +1544,24 @@ def test_dynamic_prefill_plan_uses_active_step_around_gemma4_image(monkeypatch):
             prefix_cache_chunks=[],
             all_tokens=[],
             next_prefix_cache_chunk_idx=0,
-            image_spans=[PromptImageSpan(start=5, end=7, image_hash="image")],
+            image_spans=[
+                PromptImageSpan(
+                    start=image_start,
+                    end=image_end,
+                    image_hash="image",
+                )
+            ],
         )
-        for _ in range(6):
+        for _ in range(4):
             generator.next()
     finally:
         generator.close()
 
-    assert [len(call["input_ids"][0]) for call in model.calls] == [4, 1, 2, 2, 2, 1]
-    assert model.calls[1]["mm_token_type_ids"] is None
-    assert model.calls[2]["mm_token_type_ids"] == [[0] * 5 + [1] * 2]
+    # The 535-token call is the worst supported crossing: up to 255 tokens from
+    # the cache grid followed by one complete 280-soft-token image run.
+    assert [len(call["input_ids"][0]) for call in model.calls] == [768, 535, 512, 234]
+    assert model.calls[0]["mm_token_type_ids"] is None
+    assert model.calls[1]["mm_token_type_ids"] == [
+        [0] * image_start + [1] * (image_end - image_start)
+    ]
+    assert model.calls[2]["mm_token_type_ids"] is None

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -84,8 +84,12 @@ def _profile(
     activation_dtype_bytes=2,
     prefill_step_size=2_048,
     rotating_peak_bytes=0,
+    rotating_constant_bytes=None,
+    rotating_bytes_per_prefill_token=0,
     fixed_ssm_bytes=0,
 ):
+    if rotating_constant_bytes is None:
+        rotating_constant_bytes = rotating_peak_bytes
     return CacheFitProfile(
         family=family,
         allocation_step=256,
@@ -95,7 +99,8 @@ def _profile(
         query_attention_heads=query_attention_heads,
         activation_dtype_bytes=activation_dtype_bytes,
         prefill_step_size=prefill_step_size,
-        rotating_peak_bytes=rotating_peak_bytes,
+        rotating_constant_bytes=rotating_constant_bytes,
+        rotating_bytes_per_prefill_token=rotating_bytes_per_prefill_token,
         fixed_ssm_bytes=fixed_ssm_bytes,
         max_context_length=max_context_length,
     )
@@ -157,6 +162,8 @@ def test_probe_uses_rotating_prefill_peak(monkeypatch):
     profile = _probe_profile(monkeypatch, [kv_cache, rotating_cache])
 
     rotating_bytes_per_token = rotating_cache.nbytes // rotating_cache.keys.shape[2]
+    assert profile.rotating_constant_bytes == rotating_bytes_per_token * (1_024 - 1)
+    assert profile.rotating_bytes_per_prefill_token == rotating_bytes_per_token
     assert profile.rotating_peak_bytes == rotating_bytes_per_token * (1_024 + 2_048 - 1)
 
 
@@ -293,7 +300,7 @@ def test_fit_raises_a_small_result_to_minimum(caplog):
     assert "using the 4,096 token minimum" in caplog.text
 
 
-def test_runtime_reserve_uses_five_percent_or_three_gib():
+def test_runtime_reserve_is_three_gib_on_all_working_sets():
     percentage_result = calculate_context_fit(
         _profile(max_context_length=4_096),
         working_set_bytes=80 * GIB,
@@ -305,8 +312,8 @@ def test_runtime_reserve_uses_five_percent_or_three_gib():
         baseline_bytes=0,
     )
 
-    assert percentage_result.runtime_reserve_bytes == 4 * GIB
-    assert percentage_result.safe_ceiling_bytes == 76 * GIB
+    assert percentage_result.runtime_reserve_bytes == 3 * GIB
+    assert percentage_result.safe_ceiling_bytes == 77 * GIB
     assert minimum_result.runtime_reserve_bytes == 3 * GIB
     assert minimum_result.safe_ceiling_bytes == 13 * GIB
 
@@ -449,6 +456,144 @@ def test_fit_scales_across_memory_tiers(working_set_gib, expected_context):
     )
 
     assert result.context_length == expected_context
+
+
+def test_dynamic_fit_keeps_reserve_when_large_model_exceeds_safe_ceiling():
+    profile = _profile(
+        family="qwen3_5",
+        max_context_length=262_144,
+        full_kv_bytes_per_token=65_536,
+        prompt_input_bytes_per_token=10_240,
+        query_attention_heads=24,
+        fixed_ssm_bytes=153_944_064,
+    )
+
+    result = context_fit.calculate_dynamic_context_fit(
+        profile,
+        # Actual M5 recommended working set and loaded-model baseline.
+        working_set_bytes=19_069_665_280,
+        baseline_bytes=16_055_717_354,
+        maximum_prefill_step_size=2_048,
+    )
+    plan = result.make_request_prefill_plan(prompt_context_length=4_096)
+
+    assert result.runtime_reserve_bytes == 3 * GIB
+    assert result.step_context_limits == ((2_048, 0), (1_024, 0), (512, 0))
+    assert result.context_length == 4_096
+    assert [
+        (segment.step_size, segment.end_context_length) for segment in plan.segments
+    ] == [(512, 4_096)]
+
+
+def test_dynamic_fit_builds_request_specific_prefill_segments():
+    profile = _profile(
+        max_context_length=262_144,
+        full_kv_bytes_per_token=20_480,
+        prompt_input_bytes_per_token=5_632,
+        query_attention_heads=16,
+        rotating_constant_bytes=209_510_400,
+        rotating_bytes_per_prefill_token=204_800,
+    )
+
+    result = context_fit.calculate_dynamic_context_fit(
+        profile,
+        working_set_bytes=27 * GIB,
+        baseline_bytes=15_611_655_610,
+        maximum_prefill_step_size=2_048,
+    )
+    plan = result.make_request_prefill_plan(prompt_context_length=result.context_length)
+
+    assert result.step_context_limits == (
+        (2_048, 104_192),
+        (1_024, 165_632),
+        (512, 231_680),
+    )
+    assert result.context_length == 191_232
+    assert [
+        (segment.step_size, segment.end_context_length) for segment in plan.segments
+    ] == [
+        (2_048, 98_048),
+        (1_024, 162_560),
+        (512, 191_232),
+    ]
+    compaction_context = result.context_length * 15 // 16
+    tokens_at_step_512 = compaction_context - plan.segments[-2].end_context_length
+    assert tokens_at_step_512 / compaction_context < 0.10
+
+
+def test_dynamic_fit_keeps_short_request_at_largest_step():
+    profile = _profile(
+        max_context_length=262_144,
+        full_kv_bytes_per_token=20_480,
+        prompt_input_bytes_per_token=5_632,
+        query_attention_heads=16,
+        rotating_constant_bytes=209_510_400,
+        rotating_bytes_per_prefill_token=204_800,
+    )
+    result = context_fit.calculate_dynamic_context_fit(
+        profile,
+        working_set_bytes=27 * GIB,
+        baseline_bytes=15_611_655_610,
+        maximum_prefill_step_size=2_048,
+    )
+
+    plan = result.make_request_prefill_plan(prompt_context_length=50_000)
+
+    assert [
+        (segment.step_size, segment.end_context_length) for segment in plan.segments
+    ] == [(2_048, 50_000)]
+
+
+def test_dynamic_fit_rejects_prompt_above_reported_context():
+    profile = _profile(max_context_length=100_000)
+    result = context_fit.calculate_dynamic_context_fit(
+        profile,
+        working_set_bytes=10 * GIB,
+        baseline_bytes=0,
+        maximum_prefill_step_size=2_048,
+    )
+
+    with pytest.raises(ValueError, match="exceeding the fitted"):
+        result.make_request_prefill_plan(
+            prompt_context_length=result.context_length + 1
+        )
+
+
+def test_dynamic_fit_respects_custom_maximum_prefill_step():
+    result = context_fit.calculate_dynamic_context_fit(
+        _profile(max_context_length=100_000),
+        working_set_bytes=10 * GIB,
+        baseline_bytes=0,
+        maximum_prefill_step_size=1_024,
+    )
+
+    assert result.prefill_step_sizes == (1_024, 512)
+    assert [step for step, _limit in result.step_context_limits] == [1_024, 512]
+
+
+def test_dynamic_fit_tail_policy_uses_custom_predecessor_step():
+    result = context_fit.calculate_dynamic_context_fit(
+        _profile(
+            max_context_length=262_144,
+            full_kv_bytes_per_token=20_480,
+            prompt_input_bytes_per_token=5_632,
+            query_attention_heads=16,
+            rotating_constant_bytes=128 * MIB,
+            rotating_bytes_per_prefill_token=64 * KIB,
+        ),
+        working_set_bytes=10 * GIB,
+        baseline_bytes=5 * GIB,
+        maximum_prefill_step_size=1_000,
+    )
+    plan = result.make_request_prefill_plan(prompt_context_length=result.context_length)
+
+    assert result.prefill_step_sizes == (1_000, 512)
+    assert plan.segments[-1].step_size == 512
+    smallest_step_start = plan.segments[-2].end_context_length
+    assert smallest_step_start * 100 >= (
+        result.context_length * context_fit.SMALLEST_STEP_START_CONTEXT_PERCENT
+        - result.profile.allocation_step * 100
+    )
 
 
 def test_one_token_probe_uses_token_zero_and_reports_fit(monkeypatch):

--- a/tests/test_batched_vision_context_fit.py
+++ b/tests/test_batched_vision_context_fit.py
@@ -508,17 +508,14 @@ def test_dynamic_fit_builds_request_specific_prefill_segments():
         (1_024, 165_632),
         (512, 231_680),
     )
-    assert result.context_length == 191_232
+    assert result.context_length == 231_680
     assert [
         (segment.step_size, segment.end_context_length) for segment in plan.segments
     ] == [
-        (2_048, 98_048),
-        (1_024, 162_560),
-        (512, 191_232),
+        (2_048, 95_488),
+        (1_024, 158_208),
+        (512, 231_680),
     ]
-    compaction_context = result.context_length * 15 // 16
-    tokens_at_step_512 = compaction_context - plan.segments[-2].end_context_length
-    assert tokens_at_step_512 / compaction_context < 0.10
 
 
 def test_dynamic_fit_keeps_short_request_at_largest_step():
@@ -569,31 +566,6 @@ def test_dynamic_fit_respects_custom_maximum_prefill_step():
 
     assert result.prefill_step_sizes == (1_024, 512)
     assert [step for step, _limit in result.step_context_limits] == [1_024, 512]
-
-
-def test_dynamic_fit_tail_policy_uses_custom_predecessor_step():
-    result = context_fit.calculate_dynamic_context_fit(
-        _profile(
-            max_context_length=262_144,
-            full_kv_bytes_per_token=20_480,
-            prompt_input_bytes_per_token=5_632,
-            query_attention_heads=16,
-            rotating_constant_bytes=128 * MIB,
-            rotating_bytes_per_prefill_token=64 * KIB,
-        ),
-        working_set_bytes=10 * GIB,
-        baseline_bytes=5 * GIB,
-        maximum_prefill_step_size=1_000,
-    )
-    plan = result.make_request_prefill_plan(prompt_context_length=result.context_length)
-
-    assert result.prefill_step_sizes == (1_000, 512)
-    assert plan.segments[-1].step_size == 512
-    smallest_step_start = plan.segments[-2].end_context_length
-    assert smallest_step_start * 100 >= (
-        result.context_length * context_fit.SMALLEST_STEP_START_CONTEXT_PERCENT
-        - result.profile.allocation_step * 100
-    )
 
 
 def test_one_token_probe_uses_token_zero_and_reports_fit(monkeypatch):

--- a/tests/test_batched_vision_model_kit.py
+++ b/tests/test_batched_vision_model_kit.py
@@ -164,6 +164,7 @@ def test_insert_reports_full_prepared_prompt_length(monkeypatch):
     kit.model = SimpleNamespace(no_chunked_prefill=False)
     kit.model_type = "other_vlm"
     kit._uses_gemma4_bidirectional_visual_attention = False
+    kit._context_fit_result = None
     kit._vision_feature_memoizer = None
     kit._prompt_cache_coordinator = SimpleNamespace(
         save_prompt_cache_snapshot=lambda *_args, **_kwargs: None

--- a/tests/test_batched_vision_model_kit.py
+++ b/tests/test_batched_vision_model_kit.py
@@ -9,6 +9,10 @@ from mlx_engine.model_kit.batched_vision.model_kit import (
     _restore_splits_gemma4_image_span,
 )
 import mlx_engine.model_kit.batched_vision.model_kit as model_kit_module
+from mlx_engine.model_kit.batched_vision.prefill_plan import (
+    PrefillPlan,
+    PrefillSegment,
+)
 from mlx_engine.model_kit.batched_vision.prompt_cache.types import (
     PromptImageSpan,
 )
@@ -94,7 +98,7 @@ def test_load_model_forces_no_trust_remote_code(monkeypatch, tmp_path):
     monkeypatch.setattr(model_kit_module.mx, "clear_cache", lambda: None)
     monkeypatch.setattr(
         model_kit_module,
-        "fit_batched_vlm_context",
+        "fit_batched_vlm_context_result",
         lambda **_kwargs: None,
     )
 
@@ -270,11 +274,11 @@ def test_load_model_stores_context_fit_before_startup(monkeypatch, tmp_path):
 
     def fake_fit_context(**kwargs):
         calls["fit"] = kwargs
-        return fitted_context_length
+        return SimpleNamespace(context_length=fitted_context_length)
 
     monkeypatch.setattr(
         model_kit_module,
-        "fit_batched_vlm_context",
+        "fit_batched_vlm_context_result",
         fake_fit_context,
     )
     kit = object.__new__(BatchedVisionModelKit)
@@ -317,7 +321,7 @@ def test_load_model_skips_context_fit_when_disabled(monkeypatch, tmp_path, caplo
 
     monkeypatch.setattr(
         model_kit_module,
-        "fit_batched_vlm_context",
+        "fit_batched_vlm_context_result",
         unexpected_fit,
     )
     caplog.set_level("INFO")
@@ -334,6 +338,101 @@ def test_load_model_skips_context_fit_when_disabled(monkeypatch, tmp_path, caplo
 
     assert kit.effective_context_length is None
     assert "auto-fit disabled" in caplog.text
+
+
+def test_request_admission_builds_and_passes_prefill_plan_once(monkeypatch):
+    prompt_tokens = [10, 11, 12, 13, 14, 15]
+    plan = PrefillPlan(
+        prompt_context_length=len(prompt_tokens),
+        segments=(
+            PrefillSegment(
+                end_context_length=len(prompt_tokens),
+                step_size=2_048,
+            ),
+        ),
+    )
+    planner_calls = []
+    inserted = {}
+
+    class FakeBatchGenerator:
+        def insert(self, prompt, **kwargs):
+            inserted["prompt"] = prompt
+            inserted.update(kwargs)
+            return 7
+
+    monkeypatch.setattr(
+        model_kit_module,
+        "build_prompt_kwargs",
+        lambda *_args, **_kwargs: {"inputs_embeds": "embeddings"},
+    )
+
+    kit = object.__new__(BatchedVisionModelKit)
+    kit._shutdown = SimpleNamespace(is_set=lambda: True)
+    kit.model = SimpleNamespace(no_chunked_prefill=False)
+    kit.model_type = "qwen3_5"
+    kit._uses_gemma4_bidirectional_visual_attention = False
+    kit._context_fit_result = SimpleNamespace(
+        make_request_prefill_plan=lambda **kwargs: (
+            planner_calls.append(kwargs) or plan
+        )
+    )
+    kit._prompt_cache_store = SimpleNamespace(can_store_records=lambda: False)
+    kit._prompt_cache_coordinator = SimpleNamespace()
+    kit._vision_feature_memoizer = SimpleNamespace()
+    kit._new_detokenizer = lambda: SimpleNamespace()
+
+    response_queue = Queue()
+    request = SimpleNamespace(
+        rqueue=response_queue,
+        max_tokens=16,
+        top_logprobs=0,
+        sampler=object(),
+        logits_processors=[],
+        request_id="request",
+    )
+    prepared_insert = SimpleNamespace(
+        request=request,
+        prepared_prompt=SimpleNamespace(
+            prompt_input_ids=prompt_tokens,
+            image_spans=[],
+        ),
+        restored=None,
+    )
+    active = {}
+
+    kit._insert_prepared_request(FakeBatchGenerator(), prepared_insert, active)
+
+    assert planner_calls == [{"prompt_context_length": len(prompt_tokens)}]
+    assert inserted["prompt"] == prompt_tokens
+    assert inserted["inputs_embeds"] == "embeddings"
+    assert inserted["prefill_plan"] is plan
+    assert active[7].request_id == "request"
+
+
+def test_request_admission_rejects_oversized_prepared_prompt_without_insert():
+    error = ValueError("prepared prompt exceeds fitted context")
+    response_queue = Queue()
+    kit = object.__new__(BatchedVisionModelKit)
+    kit._shutdown = SimpleNamespace(is_set=lambda: True)
+    kit._context_fit_result = SimpleNamespace(
+        make_request_prefill_plan=lambda **_kwargs: (_ for _ in ()).throw(error)
+    )
+    prepared_insert = SimpleNamespace(
+        request=SimpleNamespace(rqueue=response_queue),
+        prepared_prompt=SimpleNamespace(
+            prompt_input_ids=list(range(10)),
+            image_spans=[],
+        ),
+        restored=None,
+    )
+
+    kit._insert_prepared_request(
+        SimpleNamespace(insert=lambda *_args, **_kwargs: pytest.fail("insert called")),
+        prepared_insert,
+        {},
+    )
+
+    assert response_queue.get_nowait() is error
 
 
 def test_load_model_skips_context_fit_for_unchunked_prefill(
@@ -358,7 +457,7 @@ def test_load_model_skips_context_fit_for_unchunked_prefill(
 
     monkeypatch.setattr(
         model_kit_module,
-        "fit_batched_vlm_context",
+        "fit_batched_vlm_context_result",
         unexpected_fit,
     )
     caplog.set_level("INFO")


### PR DESCRIPTION
## Summary

mlx-engine uses a prefill step size of 2048 by default. When the model is prefilling, it allocates the memory buffers necessary for processing 2048 tokens in parallel. When the context size is high enough, this allocation could occupy the remainder of the recommended working set size. The autofit calculation is currently based on ensuring that the allocation during this prefill step does not exceed the recommendation.

We can squeeze more context from the autofit by reducing the prefill step size. However, reducing the step size means that fewer operations will happen in parallel. For machines where memory room is not a concern, we would want a high prefill step size (like 2048) in order to minimize prompt processing time.

So, as we approach the limit of the recommended memory usage, start decreasing the prefill step size. This means that we can still do prompt processing without exceeding the recommended memory limit, effectively increasing the context length. The step size plan is pre-computed when the request arrives, so that we're not calculating the appropriate step size after every prefill step.

## Impact

- **M5 laptop:** 24 GB RAM, 17.76 GiB working set
- **M3 Max:** 36 GB RAM, 27 GiB working set

Values below are **old fixed-2048 → new dynamic maximum**.

| Model | M5 laptop, 24 GB | M3 Max, 36 GB |
|---|---:|---:|
| Qwen 35B-A3B MoE 4-bit | 4K → 4K | **59K → 130K** |
| Qwen 27B dense 4-bit | 4K → 4K | **55K → 95K** |
| Gemma 4 26B-A4B MoE 4-bit | 4K → 4K | **104K → 232K** |
| Gemma 4 12B dense 4-bit | **43K → 108K** | **154K → 262K** |
| Gemma 4 12B dense 8-bit | **24K → 65K** | **135K → 262K** |

## Performance

Overall we can substantially increase context length while minimizing performance penalty, and in some cases improving performance. Below is a table of step size regime change to performance impact

| Machine | 2048 → 1024 | 1024 → 512 |
|---|---:|---:|
| M5 laptop | Approximately **6–17% faster** | Approximately **1–9% faster** |
| M3 Max | Approximately neutral to **3% faster** | Model-dependent: **2% slower to 13% faster** |
| M2 Ultra | Approximately **±1%** | Approximately **2–7% slower** |

When using smaller step sizes near the working memory limits, the performance is a wash. Less memory pressure trades off with high parallelism, both of which affect throughput.

## Code review

<img width="735" height="634" alt="Screenshot 2026-08-19 at 12 45 45 PM" src="https://github.com/user-attachments/assets/5be8b7b9-8383-4e43-84f8-3953387a48f3" />

This is not a regression. The autofit is our best estimate at load time. Also, with the bionic implementation, the parallel tasks (explore agents) will be shorter context than the parent task.