### PR TITLE
Add MLX disk cache control

### DIFF
--- a/mlx_engine/generate.py
+++ b/mlx_engine/generate.py
@@ -204,6 +204,7 @@ def load_model(
     quantized_kv_start: Optional[int] = None,
     prefill_step_size: Optional[int] = None,
     auto_fit_context: bool = True,
+    enable_disk_cache: bool = True,
 ) -> LoadedModelKit:
     """
     Load a language model or vision-language model from the specified path.
@@ -225,6 +226,7 @@ def load_model(
         prefill_step_size (Optional[int]): Number of tokens to process per prefill chunk.
             Defaults to PROMPT_PROCESSING_CHUNK_SIZE when None.
         auto_fit_context (bool): Whether batched models should fit context length to available memory.
+        enable_disk_cache (bool): Whether batched models should cache prompt states on disk.
 
     Returns:
         LoadedModelKit: An initialized model instance:
@@ -272,6 +274,7 @@ def load_model(
             trust_remote_code=trust_remote_code,
             seed=seed,
             auto_fit_context=auto_fit_context,
+            enable_disk_cache=enable_disk_cache,
         )
     else:
         kv_bits, kv_group_size, quantized_kv_start = get_kv_cache_quantization_params(
@@ -313,6 +316,7 @@ def load_model(
                 trust_remote_code=trust_remote_code,
                 seed=seed,
                 auto_fit_context=auto_fit_context,
+                enable_disk_cache=enable_disk_cache,
             )
         else:
             model_kit = ModelKit(

--- a/mlx_engine/model_kit/batched_vision/model_kit.py
+++ b/mlx_engine/model_kit/batched_vision/model_kit.py
@@ -128,6 +128,7 @@ class BatchedVisionModelKit:
         trust_remote_code: bool = False,
         seed: int | None = None,
         auto_fit_context: bool = True,
+        enable_disk_cache: bool = True,
     ):
         # External requests and internal generation events share one queue so
         # restore completions wake the generation thread without polling.
@@ -160,7 +161,10 @@ class BatchedVisionModelKit:
         self._uses_gemma4_bidirectional_visual_attention = (
             config_uses_bidirectional_visual_attention(self.config)
         )
-        self._prompt_cache_store = VlmPromptCacheStore(max_kv_size=max_kv_size)
+        self._prompt_cache_store = VlmPromptCacheStore(
+            max_kv_size=max_kv_size,
+            enable_disk_cache=enable_disk_cache,
+        )
         self._cache_io_thread = PromptCacheIOThread(
             cache_store=self._prompt_cache_store,
             generation_queue=self._requests,

--- a/mlx_engine/model_kit/batched_vision/prompt_cache/cache_store.py
+++ b/mlx_engine/model_kit/batched_vision/prompt_cache/cache_store.py
@@ -99,7 +99,9 @@ class VlmPromptCacheStore:
         base_dir = Path("/tmp")
         self._base_dir = base_dir
         self._max_kv_size = max_kv_size
-        self._blob_store = TemporarySafetensorBlobStore(base_dir)
+        self._blob_store: TemporarySafetensorBlobStore | None = (
+            TemporarySafetensorBlobStore(base_dir) if enable_disk_cache else None
+        )
         self._empirical_budget_set = not enable_disk_cache
         self._layout: PromptCacheLayout | None = None
         self._record_metadata_by_key: dict[str, PromptCacheRecordMetadata] = {}
@@ -236,10 +238,11 @@ class VlmPromptCacheStore:
         record_keys: list[str],
         layout: PromptCacheLayout,
     ) -> list[Any]:
+        blob_store = self._require_blob_store()
         prompt_cache: list[Any] = [None] * len(layout.layer_kinds)
         for record_key in record_keys:
             try:
-                record_prompt_cache = self._blob_store.load_record(record_key)
+                record_prompt_cache = blob_store.load_record(record_key)
             except Exception:
                 self._evict_key(record_key)
                 raise
@@ -329,19 +332,20 @@ class VlmPromptCacheStore:
         """Commit a pending save from the cache I/O thread."""
         if not self.can_store_records():
             return
+        blob_store = self._require_blob_store()
         if self._layout is None:
             self._layout = pending_save.cache_layout
 
         try:
             for record in pending_save.records:
-                if self._blob_store.exists(record.key):
+                if blob_store.exists(record.key):
                     self._record_metadata_by_key[record.key] = record.metadata
                     self._touch_cache_entry(record.key)
                     continue
 
                 # The I/O thread waits, writes, then publishes/account each record.
                 mx.eval(list(record.snapshot_arrays.values()))
-                self._blob_store.put(
+                blob_store.put(
                     record.key,
                     record.snapshot_arrays,
                     record.safetensor_metadata,
@@ -378,10 +382,14 @@ class VlmPromptCacheStore:
             chunk_sizes_by_key[chunk_key] = sum(
                 record_sizes_by_key.get(record_key, 0) for record_key in record_keys
             )
-            chunk_records_available_by_key[chunk_key] = bool(record_keys) and all(
-                record_key in record_sizes_by_key
-                and self._blob_store.exists(record_key)
-                for record_key in record_keys
+            chunk_records_available_by_key[chunk_key] = (
+                self._blob_store is not None
+                and bool(record_keys)
+                and all(
+                    record_key in record_sizes_by_key
+                    and self._blob_store.exists(record_key)
+                    for record_key in record_keys
+                )
             )
 
         return PromptCacheStoreStats(
@@ -404,7 +412,8 @@ class VlmPromptCacheStore:
         self._key_sizes.clear()
         self._lru_keys.clear()
         self._total_bytes = 0
-        self._blob_store.close()
+        if self._blob_store is not None:
+            self._blob_store.close()
 
     def _prepare_record_save(
         self,
@@ -446,7 +455,7 @@ class VlmPromptCacheStore:
         )
 
     def _touch_cache_entry(self, key: str) -> None:
-        total_size = self._blob_store.size(key)
+        total_size = self._require_blob_store().size(key)
         previous_size = self._key_sizes.get(key, 0)
         self._key_sizes[key] = total_size
         self._total_bytes += total_size - previous_size
@@ -531,8 +540,13 @@ class VlmPromptCacheStore:
         return PromptCacheRestorePlanner(
             layout=self._require_layout(),
             record_metadata_by_key=self._record_metadata_by_key,
-            record_exists=self._blob_store.exists,
+            record_exists=self._require_blob_store().exists,
         )
+
+    def _require_blob_store(self) -> TemporarySafetensorBlobStore:
+        if self._blob_store is None:
+            raise RuntimeError("prompt cache disk store is disabled")
+        return self._blob_store
 
     def _require_layout(self) -> PromptCacheLayout:
         if self._layout is None:
@@ -547,4 +561,4 @@ class VlmPromptCacheStore:
         self._cache_evictions += 1
         self._cache_evicted_bytes += evicted_bytes
 
-        self._blob_store.delete(key)
+        self._require_blob_store().delete(key)

--- a/mlx_engine/model_kit/batched_vision/prompt_cache/cache_store.py
+++ b/mlx_engine/model_kit/batched_vision/prompt_cache/cache_store.py
@@ -91,27 +91,36 @@ class VlmPromptCacheStore:
     - Touched LRU keys are committed physical records.
     """
 
-    def __init__(self, max_kv_size: int | None = None):
+    def __init__(
+        self,
+        max_kv_size: int | None = None,
+        enable_disk_cache: bool = True,
+    ):
         base_dir = Path("/tmp")
         self._base_dir = base_dir
         self._max_kv_size = max_kv_size
         self._blob_store = TemporarySafetensorBlobStore(base_dir)
-        self._empirical_budget_set = False
+        self._empirical_budget_set = not enable_disk_cache
         self._layout: PromptCacheLayout | None = None
         self._record_metadata_by_key: dict[str, PromptCacheRecordMetadata] = {}
         self._key_sizes: dict[str, int] = {}
         self._lru_keys: OrderedDict[str, None] = OrderedDict()
         self._total_bytes = 0
-        self._max_cache_store_bytes = provisional_cache_store_budget_bytes(base_dir)
+        self._max_cache_store_bytes = (
+            provisional_cache_store_budget_bytes(base_dir) if enable_disk_cache else 0
+        )
         self._restore_hit_tokens = 0
         self._restore_miss_tokens = 0
         self._cache_evictions = 0
         self._cache_evicted_bytes = 0
         self._last_cache_usage_log_time = 0.0
-        logger.info(
-            "VLM prompt cache disk store: lifetime=model_load storage=temporary "
-            "cleanup=model_unload_or_process_exit"
-        )
+        if enable_disk_cache:
+            logger.info(
+                "VLM prompt cache disk store: lifetime=model_load storage=temporary "
+                "cleanup=model_unload_or_process_exit"
+            )
+        else:
+            logger.info("VLM prompt cache disk store disabled")
 
     def ensure_max_kv_size(self, max_kv_size: int) -> None:
         """Keep the larger configured or fitted context as the budget target."""

--- a/tests/test_batched_vision_cache_store.py
+++ b/tests/test_batched_vision_cache_store.py
@@ -1,6 +1,7 @@
 import pytest
 
 import mlx.core as mx
+import mlx_engine.model_kit.batched_vision.prompt_cache.cache_store as cache_store_module
 from mlx_engine.model_kit.batched_vision.prompt_cache.cache_store import (
     VlmPromptCacheStore,
 )
@@ -93,6 +94,27 @@ def test_cache_store_keeps_larger_configured_or_fitted_context(caplog):
         )
         store.ensure_max_kv_size(262_144)
         assert store._max_kv_size == 262_144
+    finally:
+        store.close()
+
+
+def test_cache_store_can_disable_disk_cache(monkeypatch):
+    def fail_if_budget_is_calculated(_base_dir):
+        pytest.fail(
+            "disk budget should not be calculated when disk caching is disabled"
+        )
+
+    monkeypatch.setattr(
+        cache_store_module,
+        "provisional_cache_store_budget_bytes",
+        fail_if_budget_is_calculated,
+    )
+    store = VlmPromptCacheStore(enable_disk_cache=False)
+
+    try:
+        assert not store.can_store_records()
+        assert store.budget_update_from_completed_cache([]) is None
+        assert store.snapshot_stats().max_bytes == 0
     finally:
         store.close()
 

--- a/tests/test_batched_vision_cache_store.py
+++ b/tests/test_batched_vision_cache_store.py
@@ -104,10 +104,18 @@ def test_cache_store_can_disable_disk_cache(monkeypatch):
             "disk budget should not be calculated when disk caching is disabled"
         )
 
+    def fail_if_blob_store_is_created(_base_dir):
+        pytest.fail("blob store should not be created when disk caching is disabled")
+
     monkeypatch.setattr(
         cache_store_module,
         "provisional_cache_store_budget_bytes",
         fail_if_budget_is_calculated,
+    )
+    monkeypatch.setattr(
+        cache_store_module,
+        "TemporarySafetensorBlobStore",
+        fail_if_blob_store_is_created,
     )
     store = VlmPromptCacheStore(enable_disk_cache=False)
 

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -51,10 +51,12 @@ def _disable_eos_sanitization(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize("auto_fit_context", [True, False])
+@pytest.mark.parametrize("enable_disk_cache", [True, False])
 def test_batchable_text_model_uses_mlx_vlm_kit(
     monkeypatch,
     tmp_path,
     auto_fit_context,
+    enable_disk_cache,
 ):
     model_path = _write_text_config(tmp_path)
     fake_kit_class, created_kits = _install_fake_kit(
@@ -82,6 +84,7 @@ def test_batchable_text_model_uses_mlx_vlm_kit(
         trust_remote_code=True,
         seed=7,
         auto_fit_context=auto_fit_context,
+        enable_disk_cache=enable_disk_cache,
     )
 
     assert isinstance(model_kit, fake_kit_class)
@@ -95,6 +98,7 @@ def test_batchable_text_model_uses_mlx_vlm_kit(
         "trust_remote_code": True,
         "seed": 7,
         "auto_fit_context": auto_fit_context,
+        "enable_disk_cache": enable_disk_cache,
     }
 
 


### PR DESCRIPTION
Adds an `enable_disk_cache` load option and ensures disabling it avoids creating or writing to a disk-backed temporary cache.